### PR TITLE
E2-S1: implement WORKFLOW.md front matter loader

### DIFF
--- a/dotnet/src/Symphony.Abstractions/Workflows/MissingWorkflowFileException.cs
+++ b/dotnet/src/Symphony.Abstractions/Workflows/MissingWorkflowFileException.cs
@@ -1,0 +1,14 @@
+namespace Symphony.Abstractions.Workflows;
+
+public sealed class MissingWorkflowFileException : WorkflowLoadException
+{
+    public const string ErrorCode = "missing_workflow_file";
+
+    public MissingWorkflowFileException(string workflowPath)
+        : base(
+            ErrorCode,
+            workflowPath,
+            $"Workflow file '{workflowPath}' was not found. Provide a valid WORKFLOW.md path or add WORKFLOW.md to the working directory.")
+    {
+    }
+}

--- a/dotnet/src/Symphony.Abstractions/Workflows/WorkflowFrontMatterNotMapException.cs
+++ b/dotnet/src/Symphony.Abstractions/Workflows/WorkflowFrontMatterNotMapException.cs
@@ -1,0 +1,14 @@
+namespace Symphony.Abstractions.Workflows;
+
+public sealed class WorkflowFrontMatterNotMapException : WorkflowLoadException
+{
+    public const string ErrorCode = "workflow_front_matter_not_a_map";
+
+    public WorkflowFrontMatterNotMapException(string workflowPath)
+        : base(
+            ErrorCode,
+            workflowPath,
+            $"Workflow file '{workflowPath}' has YAML front matter that does not decode to a map/object. Use top-level keys such as 'tracker' or 'workspace'.")
+    {
+    }
+}

--- a/dotnet/src/Symphony.Abstractions/Workflows/WorkflowLoadException.cs
+++ b/dotnet/src/Symphony.Abstractions/Workflows/WorkflowLoadException.cs
@@ -1,0 +1,15 @@
+namespace Symphony.Abstractions.Workflows;
+
+public abstract class WorkflowLoadException : Exception
+{
+    protected WorkflowLoadException(string code, string workflowPath, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Code = code;
+        WorkflowPath = workflowPath;
+    }
+
+    public string Code { get; }
+
+    public string WorkflowPath { get; }
+}

--- a/dotnet/src/Symphony.Abstractions/Workflows/WorkflowParseException.cs
+++ b/dotnet/src/Symphony.Abstractions/Workflows/WorkflowParseException.cs
@@ -1,0 +1,11 @@
+namespace Symphony.Abstractions.Workflows;
+
+public sealed class WorkflowParseException : WorkflowLoadException
+{
+    public const string ErrorCode = "workflow_parse_error";
+
+    public WorkflowParseException(string workflowPath, string message, Exception? innerException = null)
+        : base(ErrorCode, workflowPath, message, innerException)
+    {
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Class1.cs
+++ b/dotnet/src/Symphony.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Symphony.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Symphony.Abstractions.Workflows;
+using Symphony.Infrastructure.Workflows;
 
 namespace Symphony.Infrastructure.DependencyInjection;
 
@@ -9,6 +11,8 @@ public static class InfrastructureServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<InfrastructureServiceMarker>();
+        services.AddSingleton<IWorkflowLoader, YamlWorkflowLoader>();
+        services.AddHostedService<WorkflowStartupValidationHostedService>();
 
         return services;
     }

--- a/dotnet/src/Symphony.Infrastructure/Symphony.Infrastructure.csproj
+++ b/dotnet/src/Symphony.Infrastructure/Symphony.Infrastructure.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <ProjectReference Include="..\Symphony.Application\Symphony.Application.csproj" />
     <ProjectReference Include="..\Symphony.Abstractions\Symphony.Abstractions.csproj" />
     <ProjectReference Include="..\Symphony.Domain\Symphony.Domain.csproj" />

--- a/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowStartupValidationHostedService.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowStartupValidationHostedService.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Workflows;
+
+namespace Symphony.Infrastructure.Workflows;
+
+public sealed class WorkflowStartupValidationHostedService : IHostedService
+{
+    private readonly ILogger<WorkflowStartupValidationHostedService> _logger;
+    private readonly IWorkflowLoader _workflowLoader;
+
+    public WorkflowStartupValidationHostedService(
+        IWorkflowLoader workflowLoader,
+        ILogger<WorkflowStartupValidationHostedService> logger)
+    {
+        _workflowLoader = workflowLoader;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var workflowPath = Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md");
+
+        try
+        {
+            await _workflowLoader.LoadAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (WorkflowLoadException exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to load workflow file '{WorkflowPath}' ({ErrorCode}). Fix WORKFLOW.md before starting Symphony.",
+                exception.WorkflowPath,
+                exception.Code);
+
+            throw new InvalidOperationException(
+                $"Failed to load workflow file '{exception.WorkflowPath}' ({exception.Code}). {exception.Message}",
+                exception);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Workflows/YamlWorkflowLoader.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workflows/YamlWorkflowLoader.cs
@@ -1,0 +1,139 @@
+using System.Collections;
+using System.Globalization;
+using Symphony.Abstractions.Workflows;
+using Symphony.Domain.Workflows;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace Symphony.Infrastructure.Workflows;
+
+public sealed class YamlWorkflowLoader : IWorkflowLoader
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder().Build();
+
+    public async Task<WorkflowDefinition> LoadAsync(string workflowPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowPath);
+
+        if (!File.Exists(workflowPath))
+        {
+            throw new MissingWorkflowFileException(workflowPath);
+        }
+
+        var content = await File.ReadAllTextAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+        content = RemoveUtf8Bom(content);
+
+        if (!StartsWithFrontMatter(content))
+        {
+            return new WorkflowDefinition(
+                config: new Dictionary<string, object?>(),
+                promptTemplate: content);
+        }
+
+        var (frontMatter, promptBody) = SplitFrontMatter(content, workflowPath);
+        var config = ParseFrontMatter(frontMatter, workflowPath);
+
+        return new WorkflowDefinition(config, promptBody);
+    }
+
+    private static IReadOnlyDictionary<string, object?> ParseFrontMatter(string frontMatter, string workflowPath)
+    {
+        object? yamlObject;
+
+        try
+        {
+            yamlObject = Deserializer.Deserialize<object?>(frontMatter);
+        }
+        catch (YamlException exception)
+        {
+            throw new WorkflowParseException(
+                workflowPath,
+                $"Workflow file '{workflowPath}' contains invalid YAML front matter: {exception.Message}",
+                exception);
+        }
+
+        if (yamlObject is not IDictionary dictionary)
+        {
+            throw new WorkflowFrontMatterNotMapException(workflowPath);
+        }
+
+        return NormalizeDictionary(dictionary, workflowPath);
+    }
+
+    private static IReadOnlyDictionary<string, object?> NormalizeDictionary(IDictionary dictionary, string workflowPath)
+    {
+        var normalized = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            var key = entry.Key?.ToString();
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new WorkflowParseException(
+                    workflowPath,
+                    $"Workflow file '{workflowPath}' contains a YAML mapping entry with an empty key.");
+            }
+
+            normalized[key] = NormalizeValue(entry.Value, workflowPath);
+        }
+
+        return normalized;
+    }
+
+    private static object? NormalizeValue(object? value, string workflowPath)
+    {
+        return value switch
+        {
+            null => null,
+            IDictionary dictionary => NormalizeDictionary(dictionary, workflowPath),
+            IList list => list.Cast<object?>().Select(item => NormalizeValue(item, workflowPath)).ToArray(),
+            sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal or bool
+                => value,
+            DateTime dateTime => dateTime,
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static (string FrontMatter, string PromptBody) SplitFrontMatter(string content, string workflowPath)
+    {
+        using var reader = new StringReader(content);
+        _ = reader.ReadLine();
+
+        var frontMatterLines = new List<string>();
+
+        while (true)
+        {
+            var line = reader.ReadLine();
+            if (line is null)
+            {
+                throw new WorkflowParseException(
+                    workflowPath,
+                    $"Workflow file '{workflowPath}' starts with YAML front matter but is missing the closing '---' delimiter.");
+            }
+
+            if (line == "---")
+            {
+                break;
+            }
+
+            frontMatterLines.Add(line);
+        }
+
+        return (string.Join(Environment.NewLine, frontMatterLines), reader.ReadToEnd());
+    }
+
+    private static bool StartsWithFrontMatter(string content)
+    {
+        return content.StartsWith("---\r\n", StringComparison.Ordinal)
+            || content.StartsWith("---\n", StringComparison.Ordinal)
+            || string.Equals(content, "---", StringComparison.Ordinal);
+    }
+
+    private static string RemoveUtf8Bom(string content)
+    {
+        return content.Length > 0 && content[0] == '\uFEFF'
+            ? content[1..]
+            : content;
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -1,19 +1,28 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Symphony.Abstractions.Workflows;
 using Symphony.Infrastructure.DependencyInjection;
+using Symphony.Infrastructure.Workflows;
 
 namespace Symphony.Infrastructure.Tests;
 
 public class InfrastructureServiceCollectionExtensionsTests
 {
     [Fact]
-    public void AddSymphonyInfrastructure_registers_infrastructure_marker()
+    public void AddSymphonyInfrastructure_registers_infrastructure_services()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
 
         services.AddSymphonyInfrastructure();
 
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<InfrastructureServiceMarker>());
+        Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
+
+        var hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
+
+        Assert.Contains(hostedServices, service => service is WorkflowStartupValidationHostedService);
     }
 }

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Infrastructure.Tests.Workflows;
+
+public sealed class WorkflowStartupValidationHostedServiceTests
+{
+    private static readonly SemaphoreSlim CurrentDirectoryGate = new(1, 1);
+
+    [Fact]
+    public async Task StartAsync_invalid_workflow_logs_actionable_error_and_throws()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"symphony-startup-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(tempDirectory, "WORKFLOW.md"),
+            """
+            ---
+            tracker:
+              kind: [github
+            ---
+            Prompt
+            """);
+
+        var loggerProvider = new TestLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+        var service = new WorkflowStartupValidationHostedService(
+            new YamlWorkflowLoader(),
+            loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
+
+        await CurrentDirectoryGate.WaitAsync();
+
+        try
+        {
+            var previousDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDirectory);
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.StartAsync(CancellationToken.None));
+
+                Assert.Contains("workflow_parse_error", exception.Message);
+                Assert.Contains("WORKFLOW.md", exception.Message);
+                Assert.Contains(
+                    loggerProvider.Messages,
+                    message => message.Contains("Fix WORKFLOW.md before starting Symphony.", StringComparison.Ordinal));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousDirectory);
+            }
+        }
+        finally
+        {
+            CurrentDirectoryGate.Release();
+        }
+    }
+
+    private sealed class TestLoggerProvider : ILoggerProvider
+    {
+        public List<string> Messages { get; } = [];
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new TestLogger(Messages);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestLogger(List<string> messages) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/YamlWorkflowLoaderTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/YamlWorkflowLoaderTests.cs
@@ -1,0 +1,106 @@
+using Symphony.Abstractions.Workflows;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Infrastructure.Tests.Workflows;
+
+public sealed class YamlWorkflowLoaderTests
+{
+    private readonly YamlWorkflowLoader _loader = new();
+
+    [Fact]
+    public async Task LoadAsync_parses_front_matter_and_trims_prompt_body()
+    {
+        var workflowPath = await CreateWorkflowFileAsync(
+            """
+            ---
+            tracker:
+              kind: github
+              repository: AGiorgetti/my-symphony
+            polling:
+              interval_ms: 5000
+            ---
+
+            You are working on issue {{ issue.identifier }}.
+            """);
+
+        var definition = await _loader.LoadAsync(workflowPath);
+
+        var tracker = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(definition.Config["tracker"]);
+        Assert.Equal("github", tracker["kind"]);
+        Assert.Equal("AGiorgetti/my-symphony", tracker["repository"]);
+
+        var polling = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(definition.Config["polling"]);
+        Assert.Equal(5000, Convert.ToInt32(polling["interval_ms"]));
+        Assert.Equal("You are working on issue {{ issue.identifier }}.", definition.PromptTemplate);
+    }
+
+    [Fact]
+    public async Task LoadAsync_without_front_matter_uses_empty_config()
+    {
+        var workflowPath = await CreateWorkflowFileAsync(
+            """
+
+            Plain workflow body
+
+            """);
+
+        var definition = await _loader.LoadAsync(workflowPath);
+
+        Assert.Empty(definition.Config);
+        Assert.Equal("Plain workflow body", definition.PromptTemplate);
+    }
+
+    [Fact]
+    public async Task LoadAsync_missing_file_throws_typed_error()
+    {
+        var workflowPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.md");
+
+        var exception = await Assert.ThrowsAsync<MissingWorkflowFileException>(() => _loader.LoadAsync(workflowPath));
+
+        Assert.Equal(MissingWorkflowFileException.ErrorCode, exception.Code);
+    }
+
+    [Fact]
+    public async Task LoadAsync_invalid_yaml_throws_parse_error()
+    {
+        var workflowPath = await CreateWorkflowFileAsync(
+            """
+            ---
+            tracker:
+              kind: [github
+            ---
+            Prompt
+            """);
+
+        var exception = await Assert.ThrowsAsync<WorkflowParseException>(() => _loader.LoadAsync(workflowPath));
+
+        Assert.Equal(WorkflowParseException.ErrorCode, exception.Code);
+    }
+
+    [Fact]
+    public async Task LoadAsync_non_map_front_matter_throws_specific_error()
+    {
+        var workflowPath = await CreateWorkflowFileAsync(
+            """
+            ---
+            - tracker
+            - github
+            ---
+            Prompt
+            """);
+
+        var exception = await Assert.ThrowsAsync<WorkflowFrontMatterNotMapException>(() => _loader.LoadAsync(workflowPath));
+
+        Assert.Equal(WorkflowFrontMatterNotMapException.ErrorCode, exception.Code);
+    }
+
+    private static async Task<string> CreateWorkflowFileAsync(string content)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"symphony-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        var workflowPath = Path.Combine(directory, "WORKFLOW.md");
+        await File.WriteAllTextAsync(workflowPath, content);
+        return workflowPath;
+    }
+}


### PR DESCRIPTION
Closes #12

#### Context

Implement E2-S1 by adding the raw `WORKFLOW.md` loader, typed workflow load errors, and startup validation that fails boot when the workflow file is missing or invalid.

#### TL;DR

*Add a YamlDotNet-backed workflow loader and fail startup on invalid `WORKFLOW.md`.*

#### Summary

- add abstraction-level workflow load exceptions for missing files, YAML parse failures, and non-map front matter
- add `YamlWorkflowLoader` plus startup validation hosted service in infrastructure and register them in DI
- add infrastructure tests covering front matter parsing, no-front-matter behavior, typed errors, and actionable startup logging

#### Alternatives

- postpone startup validation until typed options exist, but that would leave the host booting without the workflow contract required by the spec
- parse YAML directly in the host, but that would couple file I/O and parsing behavior to the composition root instead of the infrastructure boundary

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release` (executed as equivalent restore/build/test/format steps on `Symphony.sln`)
- [x] Additional targeted checks
  - `dotnet restore Symphony.sln -v minimal`
  - `dotnet build Symphony.sln -c Release --no-restore -m:1 -v minimal`
  - `dotnet test Symphony.sln -c Release --no-build --no-restore -m:1 -v minimal`
  - `dotnet format Symphony.sln --verify-no-changes --no-restore`