### PR TITLE
E4-S2: implement process runner for CLI invocation standard

### DIFF
--- a/dotnet/src/Symphony.Infrastructure/Class1.cs
+++ b/dotnet/src/Symphony.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Symphony.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Symphony.Abstractions.Processes;
+using Symphony.Infrastructure.Processes;
 
 namespace Symphony.Infrastructure.DependencyInjection;
 
@@ -9,6 +11,7 @@ public static class InfrastructureServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<InfrastructureServiceMarker>();
+        services.AddSingleton<IProcessRunner, ProcessRunner>();
 
         return services;
     }

--- a/dotnet/src/Symphony.Infrastructure/Processes/ProcessRunner.cs
+++ b/dotnet/src/Symphony.Infrastructure/Processes/ProcessRunner.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Processes;
+
+namespace Symphony.Infrastructure.Processes;
+
+public sealed class ProcessRunner(ILogger<ProcessRunner> logger) : IProcessRunner
+{
+    public async Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (request.Timeout is not null)
+        {
+            linkedCancellationTokenSource.CancelAfter(request.Timeout.Value);
+        }
+
+        var effectiveCancellationToken = linkedCancellationTokenSource.Token;
+        var startInfo = CreateStartInfo(request);
+        using var process = new Process { StartInfo = startInfo };
+
+        var startedAt = DateTimeOffset.UtcNow;
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException($"Failed to start process '{request.FileName}'.");
+        }
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(effectiveCancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(effectiveCancellationToken);
+
+        using var cancellationRegistration = effectiveCancellationToken.Register(() => TryKill(process));
+
+        try
+        {
+            if (request.StandardInput is not null)
+            {
+                await process.StandardInput.WriteAsync(request.StandardInput.AsMemory(), effectiveCancellationToken).ConfigureAwait(false);
+                process.StandardInput.Close();
+            }
+
+            await process.WaitForExitAsync(effectiveCancellationToken).ConfigureAwait(false);
+
+            var standardOutput = await standardOutputTask.ConfigureAwait(false);
+            var standardError = await standardErrorTask.ConfigureAwait(false);
+            var finishedAt = DateTimeOffset.UtcNow;
+            var result = new ProcessRunResult(process.ExitCode, standardOutput, standardError, startedAt, finishedAt);
+
+            if (result.ExitCode != 0)
+            {
+                logger.LogWarning(
+                    "Process '{FileName}' exited with code {ExitCode}. Standard error: {StandardError}",
+                    request.FileName,
+                    result.ExitCode,
+                    result.StandardError);
+            }
+
+            return result;
+        }
+        catch (OperationCanceledException) when (effectiveCancellationToken.IsCancellationRequested)
+        {
+            TryKill(process);
+
+            try
+            {
+                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            throw;
+        }
+    }
+
+    private static ProcessStartInfo CreateStartInfo(ProcessRunRequest request)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = request.FileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = request.StandardInput is not null,
+            WorkingDirectory = request.WorkingDirectory
+        };
+
+        foreach (var argument in request.Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        foreach (var environmentVariable in request.EnvironmentVariables)
+        {
+            startInfo.Environment[environmentVariable.Key] = environmentVariable.Value ?? string.Empty;
+        }
+
+        return startInfo;
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
+using Symphony.Abstractions.Processes;
 using Symphony.Infrastructure.DependencyInjection;
+using Symphony.Infrastructure.Processes;
 
 namespace Symphony.Infrastructure.Tests;
 
@@ -9,11 +11,13 @@ public class InfrastructureServiceCollectionExtensionsTests
     public void AddSymphonyInfrastructure_registers_infrastructure_marker()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
 
         services.AddSymphonyInfrastructure();
 
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<InfrastructureServiceMarker>());
+        Assert.IsType<ProcessRunner>(serviceProvider.GetRequiredService<IProcessRunner>());
     }
 }

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Processes/ProcessRunnerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Processes/ProcessRunnerTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Abstractions.Processes;
+using Symphony.Infrastructure.Processes;
+
+namespace Symphony.Infrastructure.Tests.Processes;
+
+public sealed class ProcessRunnerTests
+{
+    private readonly ProcessRunner _runner = new(NullLogger<ProcessRunner>.Instance);
+
+    [Fact]
+    public async Task RunAsync_uses_requested_working_directory()
+    {
+        var workingDirectory = CreateTemporaryDirectory();
+        var request = CreateShellRequest(
+            OperatingSystem.IsWindows() ? "cd" : "pwd",
+            workingDirectory);
+
+        var result = await _runner.RunAsync(request);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(Path.GetFullPath(workingDirectory), result.StandardOutput.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsync_captures_stdout_stderr_exit_code_and_duration()
+    {
+        var request = CreateShellRequest(
+            OperatingSystem.IsWindows()
+                ? "echo stdout message & echo stderr message 1>&2 & exit /b 3"
+                : "printf 'stdout message\\n'; printf 'stderr message\\n' 1>&2; exit 3",
+            CreateTemporaryDirectory());
+
+        var result = await _runner.RunAsync(request);
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Contains("stdout message", result.StandardOutput, StringComparison.Ordinal);
+        Assert.Contains("stderr message", result.StandardError, StringComparison.Ordinal);
+        Assert.True(result.Duration >= TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task RunAsync_writes_standard_input_when_requested()
+    {
+        var request = CreatePipeRequest("agent payload", CreateTemporaryDirectory());
+
+        var result = await _runner.RunAsync(request);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("agent payload", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunAsync_applies_environment_variables()
+    {
+        var request = OperatingSystem.IsWindows()
+            ? new ProcessRunRequest(
+                "cmd",
+                ["/c", "echo %SYMPHONY_RUNNER_TEST%"],
+                CreateTemporaryDirectory(),
+                environmentVariables: new Dictionary<string, string?> { ["SYMPHONY_RUNNER_TEST"] = "from-env" })
+            : new ProcessRunRequest(
+                "/bin/sh",
+                ["-c", "printf '%s' \"$SYMPHONY_RUNNER_TEST\""],
+                CreateTemporaryDirectory(),
+                environmentVariables: new Dictionary<string, string?> { ["SYMPHONY_RUNNER_TEST"] = "from-env" });
+
+        var result = await _runner.RunAsync(request);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("from-env", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunAsync_terminates_process_when_cancellation_requested()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var request = CreateShellRequest(
+            OperatingSystem.IsWindows()
+                ? "ping 127.0.0.1 -n 30 > nul"
+                : "sleep 30",
+            CreateTemporaryDirectory());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _runner.RunAsync(request, cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task RunAsync_terminates_process_when_timeout_expires()
+    {
+        var request = OperatingSystem.IsWindows()
+            ? new ProcessRunRequest("cmd", ["/c", "ping 127.0.0.1 -n 30 > nul"], CreateTemporaryDirectory(), timeout: TimeSpan.FromMilliseconds(200))
+            : new ProcessRunRequest("/bin/sh", ["-c", "sleep 30"], CreateTemporaryDirectory(), timeout: TimeSpan.FromMilliseconds(200));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _runner.RunAsync(request));
+    }
+
+    private static ProcessRunRequest CreateShellRequest(string script, string workingDirectory)
+    {
+        return OperatingSystem.IsWindows()
+            ? new ProcessRunRequest("cmd", ["/c", script], workingDirectory)
+            : new ProcessRunRequest("/bin/sh", ["-c", script], workingDirectory);
+    }
+
+    private static ProcessRunRequest CreatePipeRequest(string input, string workingDirectory)
+    {
+        return OperatingSystem.IsWindows()
+            ? new ProcessRunRequest("cmd", ["/c", "more"], workingDirectory, standardInput: input)
+            : new ProcessRunRequest("/bin/sh", ["-c", "cat"], workingDirectory, standardInput: input);
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"symphony-process-runner-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
Closes #20

#### Context

Implement story E4-S2 from the plan and SPEC.md so the execution layer can launch repo-scoped subprocesses safely.

#### TL;DR

*Add a spec-aligned process runner with subprocess capture, stdin/env support, and cancellation handling.*

#### Summary

- Add `ProcessRunner` using explicit working directories and argument-list invocation.
- Capture stdout, stderr, exit code, and run timing for subprocess execution.
- Cover stdin, environment, cancellation, timeout, and DI wiring with infrastructure tests.

#### Alternatives

- Keep subprocess execution as a later concern in E4-S3, but that would block the agent runner on a missing execution primitive.
- Launch shell commands directly from the future agent runner, but that would couple session orchestration to process lifecycle details.

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release` (equivalent gates run separately with `--no-restore`)
- [x] `dotnet build .\dotnet\Symphony.sln -c Release --no-restore -m:1 -v minimal`
- [x] `dotnet test .\dotnet\Symphony.sln -c Release --no-build --no-restore -m:1 -v minimal`
- [x] `dotnet format .\dotnet\Symphony.sln --verify-no-changes --no-restore`
