### PR TITLE
E2-S2: implement typed workflow options and validation

### DIFF
--- a/dotnet/src/Symphony.Application/Class1.cs
+++ b/dotnet/src/Symphony.Application/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Symphony.Application;
-
-public class Class1
-{
-
-}

--- a/dotnet/src/Symphony.Application/Configuration/IWorkflowOptionsResolver.cs
+++ b/dotnet/src/Symphony.Application/Configuration/IWorkflowOptionsResolver.cs
@@ -1,0 +1,8 @@
+using Symphony.Domain.Workflows;
+
+namespace Symphony.Application.Configuration;
+
+public interface IWorkflowOptionsResolver
+{
+    WorkflowServiceOptions Resolve(WorkflowDefinition workflowDefinition);
+}

--- a/dotnet/src/Symphony.Application/Configuration/WorkflowConfigurationException.cs
+++ b/dotnet/src/Symphony.Application/Configuration/WorkflowConfigurationException.cs
@@ -1,0 +1,18 @@
+namespace Symphony.Application.Configuration;
+
+public sealed class WorkflowConfigurationException : Exception
+{
+    public WorkflowConfigurationException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public WorkflowConfigurationException(string code, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Code = code;
+    }
+
+    public string Code { get; }
+}

--- a/dotnet/src/Symphony.Application/Configuration/WorkflowServiceOptions.cs
+++ b/dotnet/src/Symphony.Application/Configuration/WorkflowServiceOptions.cs
@@ -1,0 +1,46 @@
+namespace Symphony.Application.Configuration;
+
+public sealed record WorkflowServiceOptions(
+    WorkflowTrackerOptions Tracker,
+    WorkflowPollingOptions Polling,
+    WorkflowWorkspaceOptions Workspace,
+    WorkflowHookOptions Hooks,
+    WorkflowAgentOptions Agent,
+    WorkflowCodexOptions Codex);
+
+public sealed record WorkflowTrackerOptions(
+    string Kind,
+    string Endpoint,
+    string ApiKey,
+    string? ProjectSlug,
+    string? Repository,
+    string? Organization,
+    string? Project,
+    IReadOnlyList<string> ActiveStates,
+    IReadOnlyList<string> TerminalStates);
+
+public sealed record WorkflowPollingOptions(int IntervalMs);
+
+public sealed record WorkflowWorkspaceOptions(string Root);
+
+public sealed record WorkflowHookOptions(
+    string? AfterCreate,
+    string? BeforeRun,
+    string? AfterRun,
+    string? BeforeRemove,
+    int TimeoutMs);
+
+public sealed record WorkflowAgentOptions(
+    int MaxConcurrentAgents,
+    int MaxTurns,
+    int MaxRetryBackoffMs,
+    IReadOnlyDictionary<string, int> MaxConcurrentAgentsByState);
+
+public sealed record WorkflowCodexOptions(
+    string Command,
+    string? ApprovalPolicy,
+    string? ThreadSandbox,
+    string? TurnSandboxPolicy,
+    int TurnTimeoutMs,
+    int ReadTimeoutMs,
+    int StallTimeoutMs);

--- a/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsResolver.cs
+++ b/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsResolver.cs
@@ -1,0 +1,481 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using Symphony.Abstractions.Trackers;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Workflows;
+
+namespace Symphony.Infrastructure.Configuration;
+
+public sealed class WorkflowOptionsResolver : IWorkflowOptionsResolver
+{
+    private const int DefaultPollingIntervalMs = 30_000;
+    private const int DefaultHooksTimeoutMs = 60_000;
+    private const int DefaultMaxConcurrentAgents = 10;
+    private const int DefaultMaxTurns = 20;
+    private const int DefaultMaxRetryBackoffMs = 300_000;
+    private const int DefaultTurnTimeoutMs = 3_600_000;
+    private const int DefaultReadTimeoutMs = 5_000;
+    private const int DefaultStallTimeoutMs = 300_000;
+    private const string DefaultCodexCommand = "codex app-server";
+    private static readonly IReadOnlyDictionary<string, object?> EmptySection = new ReadOnlyDictionary<string, object?>(
+        new Dictionary<string, object?>(StringComparer.Ordinal));
+    private static readonly string[] DefaultActiveStates = ["Todo", "In Progress"];
+    private static readonly string[] DefaultTerminalStates = ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"];
+
+    public WorkflowServiceOptions Resolve(WorkflowDefinition workflowDefinition)
+    {
+        ArgumentNullException.ThrowIfNull(workflowDefinition);
+
+        var trackerSection = GetSection(workflowDefinition.Config, "tracker");
+        var pollingSection = GetSection(workflowDefinition.Config, "polling");
+        var workspaceSection = GetSection(workflowDefinition.Config, "workspace");
+        var hooksSection = GetSection(workflowDefinition.Config, "hooks");
+        var agentSection = GetSection(workflowDefinition.Config, "agent");
+        var codexSection = GetSection(workflowDefinition.Config, "codex");
+
+        return new WorkflowServiceOptions(
+            ResolveTrackerOptions(trackerSection),
+            new WorkflowPollingOptions(
+                GetPositiveIntOrDefault(pollingSection, "interval_ms", DefaultPollingIntervalMs, "polling.interval_ms")),
+            new WorkflowWorkspaceOptions(
+                ResolveWorkspaceRoot(workspaceSection)),
+            new WorkflowHookOptions(
+                GetOptionalString(hooksSection, "after_create", "hooks.after_create"),
+                GetOptionalString(hooksSection, "before_run", "hooks.before_run"),
+                GetOptionalString(hooksSection, "after_run", "hooks.after_run"),
+                GetOptionalString(hooksSection, "before_remove", "hooks.before_remove"),
+                GetHookTimeout(hooksSection)),
+            new WorkflowAgentOptions(
+                GetPositiveIntOrDefault(agentSection, "max_concurrent_agents", DefaultMaxConcurrentAgents, "agent.max_concurrent_agents"),
+                GetPositiveIntOrDefault(agentSection, "max_turns", DefaultMaxTurns, "agent.max_turns"),
+                GetPositiveIntOrDefault(agentSection, "max_retry_backoff_ms", DefaultMaxRetryBackoffMs, "agent.max_retry_backoff_ms"),
+                GetStateCapMap(agentSection, "max_concurrent_agents_by_state", "agent.max_concurrent_agents_by_state")),
+            ResolveCodexOptions(codexSection));
+    }
+
+    private static WorkflowTrackerOptions ResolveTrackerOptions(IReadOnlyDictionary<string, object?> trackerSection)
+    {
+        var configuredKind = GetOptionalString(trackerSection, "kind", "tracker.kind");
+        if (!TrackerAdapterKinds.TryNormalize(configuredKind, out var trackerKind))
+        {
+            throw new WorkflowConfigurationException(
+                "unsupported_tracker_kind",
+                $"tracker.kind must be one of: {string.Join(", ", TrackerAdapterKinds.All)}.");
+        }
+
+        var endpoint = GetOptionalString(trackerSection, "endpoint", "tracker.endpoint")
+            ?? trackerKind switch
+            {
+                TrackerAdapterKinds.GitHub => "https://api.github.com",
+                TrackerAdapterKinds.AzureDevOps => "https://dev.azure.com",
+                TrackerAdapterKinds.Linear => "https://api.linear.app/graphql",
+                _ => throw new UnreachableException()
+            };
+
+        var apiKey = ResolveRequiredApiKey(trackerSection);
+        var projectSlug = GetOptionalString(trackerSection, "project_slug", "tracker.project_slug");
+        var repository = GetOptionalString(trackerSection, "repository", "tracker.repository");
+        var organization = GetOptionalString(trackerSection, "organization", "tracker.organization");
+        var project = GetOptionalString(trackerSection, "project", "tracker.project");
+        var activeStates = GetStringListOrDefault(trackerSection, "active_states", DefaultActiveStates, "tracker.active_states");
+        var terminalStates = GetStringListOrDefault(trackerSection, "terminal_states", DefaultTerminalStates, "tracker.terminal_states");
+
+        ValidateTrackerFields(trackerKind, repository, projectSlug, organization, project, activeStates, terminalStates);
+
+        return new WorkflowTrackerOptions(
+            trackerKind,
+            endpoint,
+            apiKey,
+            projectSlug,
+            repository,
+            organization,
+            project,
+            activeStates,
+            terminalStates);
+    }
+
+    private static WorkflowCodexOptions ResolveCodexOptions(IReadOnlyDictionary<string, object?> codexSection)
+    {
+        if (codexSection.TryGetValue("command", out var rawCommandValue)
+            && rawCommandValue is string rawCommand
+            && string.IsNullOrWhiteSpace(rawCommand))
+        {
+            throw InvalidConfiguration("codex.command must not be empty.");
+        }
+
+        var command = GetOptionalString(codexSection, "command", "codex.command") ?? DefaultCodexCommand;
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            throw InvalidConfiguration("codex.command must not be empty.");
+        }
+
+        return new WorkflowCodexOptions(
+            command,
+            GetOptionalString(codexSection, "approval_policy", "codex.approval_policy"),
+            GetOptionalString(codexSection, "thread_sandbox", "codex.thread_sandbox"),
+            GetOptionalString(codexSection, "turn_sandbox_policy", "codex.turn_sandbox_policy"),
+            GetPositiveIntOrDefault(codexSection, "turn_timeout_ms", DefaultTurnTimeoutMs, "codex.turn_timeout_ms"),
+            GetPositiveIntOrDefault(codexSection, "read_timeout_ms", DefaultReadTimeoutMs, "codex.read_timeout_ms"),
+            GetIntOrDefault(codexSection, "stall_timeout_ms", DefaultStallTimeoutMs, "codex.stall_timeout_ms"));
+    }
+
+    private static void ValidateTrackerFields(
+        string trackerKind,
+        string? repository,
+        string? projectSlug,
+        string? organization,
+        string? project,
+        IReadOnlyList<string> activeStates,
+        IReadOnlyList<string> terminalStates)
+    {
+        switch (trackerKind)
+        {
+            case TrackerAdapterKinds.GitHub:
+                if (repository is null)
+                {
+                    throw new WorkflowConfigurationException(
+                        "missing_tracker_repository",
+                        "tracker.repository is required when tracker.kind is github.");
+                }
+
+                if (!IsRepositoryName(repository))
+                {
+                    throw InvalidConfiguration("tracker.repository must use the format '<owner>/<repo>'.");
+                }
+
+                break;
+            case TrackerAdapterKinds.Linear:
+                if (projectSlug is null)
+                {
+                    throw new WorkflowConfigurationException(
+                        "missing_tracker_project_slug",
+                        "tracker.project_slug is required when tracker.kind is linear.");
+                }
+
+                break;
+            case TrackerAdapterKinds.AzureDevOps:
+                if (organization is null)
+                {
+                    throw new WorkflowConfigurationException(
+                        "missing_tracker_organization",
+                        "tracker.organization is required when tracker.kind is azure_devops.");
+                }
+
+                if (project is null)
+                {
+                    throw new WorkflowConfigurationException(
+                        "missing_tracker_project",
+                        "tracker.project is required when tracker.kind is azure_devops.");
+                }
+
+                break;
+        }
+
+        var activeStateSet = new HashSet<string>(activeStates.Select(static state => state.ToLowerInvariant()), StringComparer.Ordinal);
+        activeStateSet.IntersectWith(terminalStates.Select(static state => state.ToLowerInvariant()));
+        if (activeStateSet.Count > 0)
+        {
+            throw InvalidConfiguration("tracker.active_states and tracker.terminal_states cannot overlap.");
+        }
+    }
+
+    private static string ResolveRequiredApiKey(IReadOnlyDictionary<string, object?> trackerSection)
+    {
+        var rawApiKey = GetOptionalString(trackerSection, "api_key", "tracker.api_key");
+        var apiKey = rawApiKey is not null && rawApiKey.StartsWith('$')
+            ? ResolveEnvironmentToken(rawApiKey)
+            : rawApiKey;
+
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new WorkflowConfigurationException(
+                "missing_tracker_api_key",
+                "tracker.api_key must be configured directly or via a non-empty $ENV_VAR reference.");
+        }
+
+        return apiKey;
+    }
+
+    private static string ResolveWorkspaceRoot(IReadOnlyDictionary<string, object?> workspaceSection)
+    {
+        var rawRoot = GetOptionalString(workspaceSection, "root", "workspace.root");
+        if (rawRoot is null)
+        {
+            return Path.GetFullPath(Path.Combine(Path.GetTempPath(), "symphony_workspaces"));
+        }
+
+        var resolvedRoot = ResolveEnvironmentToken(rawRoot);
+        if (resolvedRoot is null)
+        {
+            throw InvalidConfiguration("workspace.root resolved to an empty path.");
+        }
+
+        resolvedRoot = ExpandHomeDirectory(resolvedRoot);
+
+        if (ContainsDirectorySeparator(resolvedRoot) || Path.IsPathRooted(resolvedRoot))
+        {
+            return Path.GetFullPath(resolvedRoot);
+        }
+
+        return resolvedRoot;
+    }
+
+    private static IReadOnlyDictionary<string, int> GetStateCapMap(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        string fieldName)
+    {
+        if (!section.TryGetValue(key, out var value) || value is null)
+        {
+            return new ReadOnlyDictionary<string, int>(new Dictionary<string, int>(StringComparer.Ordinal));
+        }
+
+        var childSection = value switch
+        {
+            IReadOnlyDictionary<string, object?> readOnlyDictionary => readOnlyDictionary,
+            IDictionary<string, object?> dictionary => new ReadOnlyDictionary<string, object?>(dictionary),
+            _ => throw InvalidConfiguration($"{fieldName} must be an object.")
+        };
+
+        var normalized = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var (state, rawValue) in childSection)
+        {
+            var normalizedState = state.Trim().ToLowerInvariant();
+            if (normalizedState.Length == 0 || !TryGetInt(rawValue, out var parsedValue) || parsedValue <= 0)
+            {
+                continue;
+            }
+
+            normalized[normalizedState] = parsedValue;
+        }
+
+        return new ReadOnlyDictionary<string, int>(normalized);
+    }
+
+    private static IReadOnlyList<string> GetStringListOrDefault(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        IReadOnlyList<string> defaultValue,
+        string fieldName)
+    {
+        if (!section.TryGetValue(key, out var value) || value is null)
+        {
+            return defaultValue.ToArray();
+        }
+
+        if (value is string)
+        {
+            throw InvalidConfiguration($"{fieldName} must be a list of strings.");
+        }
+
+        if (value is not IEnumerable<object?> enumerable)
+        {
+            throw InvalidConfiguration($"{fieldName} must be a list of strings.");
+        }
+
+        return enumerable.Select(item => GetRequiredStringValue(item, fieldName)).ToArray();
+    }
+
+    private static int GetHookTimeout(IReadOnlyDictionary<string, object?> section)
+    {
+        var timeout = GetOptionalInt(section, "timeout_ms", "hooks.timeout_ms");
+        if (timeout is null || timeout <= 0)
+        {
+            return DefaultHooksTimeoutMs;
+        }
+
+        return timeout.Value;
+    }
+
+    private static int GetPositiveIntOrDefault(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        int defaultValue,
+        string fieldName)
+    {
+        var value = GetOptionalInt(section, key, fieldName);
+        if (value is null)
+        {
+            return defaultValue;
+        }
+
+        if (value <= 0)
+        {
+            throw InvalidConfiguration($"{fieldName} must be greater than zero.");
+        }
+
+        return value.Value;
+    }
+
+    private static int GetIntOrDefault(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        int defaultValue,
+        string fieldName)
+    {
+        return GetOptionalInt(section, key, fieldName) ?? defaultValue;
+    }
+
+    private static int? GetOptionalInt(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        string fieldName)
+    {
+        if (!section.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        if (!TryGetInt(value, out var parsedValue))
+        {
+            throw InvalidConfiguration($"{fieldName} must be an integer.");
+        }
+
+        return parsedValue;
+    }
+
+    private static bool TryGetInt(object? value, out int parsedValue)
+    {
+        switch (value)
+        {
+            case sbyte sbyteValue:
+                parsedValue = sbyteValue;
+                return true;
+            case byte byteValue:
+                parsedValue = byteValue;
+                return true;
+            case short shortValue:
+                parsedValue = shortValue;
+                return true;
+            case ushort ushortValue:
+                parsedValue = ushortValue;
+                return true;
+            case int intValue:
+                parsedValue = intValue;
+                return true;
+            case uint uintValue when uintValue <= int.MaxValue:
+                parsedValue = (int)uintValue;
+                return true;
+            case long longValue when longValue is >= int.MinValue and <= int.MaxValue:
+                parsedValue = (int)longValue;
+                return true;
+            case ulong ulongValue when ulongValue <= int.MaxValue:
+                parsedValue = (int)ulongValue;
+                return true;
+            case string stringValue when int.TryParse(stringValue.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var stringInt):
+                parsedValue = stringInt;
+                return true;
+            default:
+                parsedValue = default;
+                return false;
+        }
+    }
+
+    private static string? GetOptionalString(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        string fieldName)
+    {
+        if (!section.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        if (value is not string stringValue)
+        {
+            throw InvalidConfiguration($"{fieldName} must be a string.");
+        }
+
+        var trimmed = stringValue.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static string GetRequiredStringValue(object? value, string fieldName)
+    {
+        if (value is not string stringValue)
+        {
+            throw InvalidConfiguration($"{fieldName} must contain only strings.");
+        }
+
+        var trimmed = stringValue.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw InvalidConfiguration($"{fieldName} must not contain empty values.");
+        }
+
+        return trimmed;
+    }
+
+    private static IReadOnlyDictionary<string, object?> GetSection(
+        IReadOnlyDictionary<string, object?> root,
+        string key)
+    {
+        if (!root.TryGetValue(key, out var value) || value is null)
+        {
+            return EmptySection;
+        }
+
+        return value switch
+        {
+            IReadOnlyDictionary<string, object?> readOnlyDictionary => readOnlyDictionary,
+            IDictionary<string, object?> dictionary => new ReadOnlyDictionary<string, object?>(dictionary),
+            _ => throw InvalidConfiguration($"{key} must be an object.")
+        };
+    }
+
+    private static string? ResolveEnvironmentToken(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (!value.StartsWith('$'))
+        {
+            return value;
+        }
+
+        var variableName = value[1..].Trim();
+        if (variableName.Length == 0)
+        {
+            return null;
+        }
+
+        var resolved = Environment.GetEnvironmentVariable(variableName);
+        return string.IsNullOrWhiteSpace(resolved) ? null : resolved.Trim();
+    }
+
+    private static string ExpandHomeDirectory(string value)
+    {
+        if (value == "~")
+        {
+            return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
+        if (value.StartsWith("~/", StringComparison.Ordinal) || value.StartsWith("~\\", StringComparison.Ordinal))
+        {
+            var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(homeDirectory, value[2..]);
+        }
+
+        return value;
+    }
+
+    private static bool ContainsDirectorySeparator(string value)
+    {
+        return value.Contains(Path.DirectorySeparatorChar) || value.Contains(Path.AltDirectorySeparatorChar);
+    }
+
+    private static bool IsRepositoryName(string value)
+    {
+        var segments = value.Split('/', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 2;
+    }
+
+    private static WorkflowConfigurationException InvalidConfiguration(string message)
+    {
+        return new WorkflowConfigurationException("invalid_workflow_config", message);
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
+using Symphony.Application.Configuration;
 using Symphony.Abstractions.Workflows;
+using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Workflows;
 
 namespace Symphony.Infrastructure.DependencyInjection;
@@ -11,6 +13,7 @@ public static class InfrastructureServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<InfrastructureServiceMarker>();
+        services.AddSingleton<IWorkflowOptionsResolver, WorkflowOptionsResolver>();
         services.AddSingleton<IWorkflowLoader, YamlWorkflowLoader>();
         services.AddHostedService<WorkflowStartupValidationHostedService>();
 

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsResolverTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsResolverTests.cs
@@ -1,0 +1,208 @@
+using Symphony.Application.Configuration;
+using Symphony.Domain.Workflows;
+using Symphony.Infrastructure.Configuration;
+
+namespace Symphony.Infrastructure.Tests.Configuration;
+
+public sealed class WorkflowOptionsResolverTests
+{
+    private readonly WorkflowOptionsResolver _resolver = new();
+
+    [Fact]
+    public void Resolve_applies_defaults_for_minimal_github_configuration()
+    {
+        var definition = CreateDefinition(new Dictionary<string, object?>
+        {
+            ["tracker"] = new Dictionary<string, object?>
+            {
+                ["kind"] = "github",
+                ["api_key"] = "gh-token",
+                ["repository"] = "AGiorgetti/my-symphony"
+            }
+        });
+
+        var options = _resolver.Resolve(definition);
+
+        Assert.Equal("github", options.Tracker.Kind);
+        Assert.Equal("https://api.github.com", options.Tracker.Endpoint);
+        Assert.Equal("gh-token", options.Tracker.ApiKey);
+        Assert.Equal(new[] { "Todo", "In Progress" }, options.Tracker.ActiveStates);
+        Assert.Equal(new[] { "Closed", "Cancelled", "Canceled", "Duplicate", "Done" }, options.Tracker.TerminalStates);
+        Assert.Equal(30_000, options.Polling.IntervalMs);
+        Assert.Equal(Path.GetFullPath(Path.Combine(Path.GetTempPath(), "symphony_workspaces")), options.Workspace.Root);
+        Assert.Equal(60_000, options.Hooks.TimeoutMs);
+        Assert.Equal(10, options.Agent.MaxConcurrentAgents);
+        Assert.Equal(20, options.Agent.MaxTurns);
+        Assert.Equal(300_000, options.Agent.MaxRetryBackoffMs);
+        Assert.Empty(options.Agent.MaxConcurrentAgentsByState);
+        Assert.Equal("codex app-server", options.Codex.Command);
+        Assert.Equal(3_600_000, options.Codex.TurnTimeoutMs);
+        Assert.Equal(5_000, options.Codex.ReadTimeoutMs);
+        Assert.Equal(300_000, options.Codex.StallTimeoutMs);
+    }
+
+    [Fact]
+    public void Resolve_expands_environment_values_and_normalizes_state_caps()
+    {
+        const string apiKeyVariable = "SYMPHONY_TEST_API_KEY";
+        const string workspaceRootVariable = "SYMPHONY_TEST_WORKSPACE_ROOT";
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "resolver-root", Guid.NewGuid().ToString("N"));
+
+        using var apiKeyScope = new EnvironmentVariableScope(apiKeyVariable, "resolved-api-key");
+        using var workspaceRootScope = new EnvironmentVariableScope(workspaceRootVariable, workspaceRoot);
+
+        var definition = CreateDefinition(new Dictionary<string, object?>
+        {
+            ["tracker"] = new Dictionary<string, object?>
+            {
+                ["kind"] = "github",
+                ["api_key"] = $"${apiKeyVariable}",
+                ["repository"] = "AGiorgetti/my-symphony"
+            },
+            ["workspace"] = new Dictionary<string, object?>
+            {
+                ["root"] = $"${workspaceRootVariable}"
+            },
+            ["hooks"] = new Dictionary<string, object?>
+            {
+                ["timeout_ms"] = 0
+            },
+            ["agent"] = new Dictionary<string, object?>
+            {
+                ["max_concurrent_agents_by_state"] = new Dictionary<string, object?>
+                {
+                    ["Todo"] = 2,
+                    ["In Progress"] = 3,
+                    ["Ignored"] = 0,
+                    ["Broken"] = "oops"
+                }
+            },
+            ["codex"] = new Dictionary<string, object?>
+            {
+                ["approval_policy"] = "on-request",
+                ["thread_sandbox"] = "workspace-write",
+                ["turn_sandbox_policy"] = "read-only",
+                ["stall_timeout_ms"] = 0
+            }
+        });
+
+        var options = _resolver.Resolve(definition);
+
+        Assert.Equal("resolved-api-key", options.Tracker.ApiKey);
+        Assert.Equal(Path.GetFullPath(workspaceRoot), options.Workspace.Root);
+        Assert.Equal(60_000, options.Hooks.TimeoutMs);
+        Assert.Equal(2, options.Agent.MaxConcurrentAgentsByState["todo"]);
+        Assert.Equal(3, options.Agent.MaxConcurrentAgentsByState["in progress"]);
+        Assert.DoesNotContain("ignored", options.Agent.MaxConcurrentAgentsByState.Keys);
+        Assert.DoesNotContain("broken", options.Agent.MaxConcurrentAgentsByState.Keys);
+        Assert.Equal("on-request", options.Codex.ApprovalPolicy);
+        Assert.Equal("workspace-write", options.Codex.ThreadSandbox);
+        Assert.Equal("read-only", options.Codex.TurnSandboxPolicy);
+        Assert.Equal(0, options.Codex.StallTimeoutMs);
+    }
+
+    [Fact]
+    public void Resolve_rejects_missing_repository_for_github_tracker()
+    {
+        var definition = CreateDefinition(new Dictionary<string, object?>
+        {
+            ["tracker"] = new Dictionary<string, object?>
+            {
+                ["kind"] = "github",
+                ["api_key"] = "gh-token"
+            }
+        });
+
+        var exception = Assert.Throws<WorkflowConfigurationException>(() => _resolver.Resolve(definition));
+
+        Assert.Equal("missing_tracker_repository", exception.Code);
+    }
+
+    [Fact]
+    public void Resolve_rejects_empty_api_key_environment_reference()
+    {
+        const string apiKeyVariable = "SYMPHONY_EMPTY_API_KEY";
+        using var apiKeyScope = new EnvironmentVariableScope(apiKeyVariable, null);
+
+        var definition = CreateDefinition(new Dictionary<string, object?>
+        {
+            ["tracker"] = new Dictionary<string, object?>
+            {
+                ["kind"] = "github",
+                ["api_key"] = $"${apiKeyVariable}",
+                ["repository"] = "AGiorgetti/my-symphony"
+            }
+        });
+
+        var exception = Assert.Throws<WorkflowConfigurationException>(() => _resolver.Resolve(definition));
+
+        Assert.Equal("missing_tracker_api_key", exception.Code);
+    }
+
+    [Fact]
+    public void Resolve_rejects_overlapping_active_and_terminal_states()
+    {
+        var definition = CreateDefinition(new Dictionary<string, object?>
+        {
+            ["tracker"] = new Dictionary<string, object?>
+            {
+                ["kind"] = "github",
+                ["api_key"] = "gh-token",
+                ["repository"] = "AGiorgetti/my-symphony",
+                ["active_states"] = new object[] { "Todo", "Done" },
+                ["terminal_states"] = new object[] { "Done" }
+            }
+        });
+
+        var exception = Assert.Throws<WorkflowConfigurationException>(() => _resolver.Resolve(definition));
+
+        Assert.Equal("invalid_workflow_config", exception.Code);
+        Assert.Contains("cannot overlap", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_rejects_non_positive_agent_concurrency_limit()
+    {
+        var definition = CreateDefinition(new Dictionary<string, object?>
+        {
+            ["tracker"] = new Dictionary<string, object?>
+            {
+                ["kind"] = "github",
+                ["api_key"] = "gh-token",
+                ["repository"] = "AGiorgetti/my-symphony"
+            },
+            ["agent"] = new Dictionary<string, object?>
+            {
+                ["max_concurrent_agents"] = 0
+            }
+        });
+
+        var exception = Assert.Throws<WorkflowConfigurationException>(() => _resolver.Resolve(definition));
+
+        Assert.Equal("invalid_workflow_config", exception.Code);
+        Assert.Contains("agent.max_concurrent_agents", exception.Message);
+    }
+
+    private static WorkflowDefinition CreateDefinition(IReadOnlyDictionary<string, object?> config)
+    {
+        return new WorkflowDefinition(config, "Prompt body");
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _variableName;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableScope(string variableName, string? value)
+        {
+            _variableName = variableName;
+            _originalValue = Environment.GetEnvironmentVariable(variableName);
+            Environment.SetEnvironmentVariable(variableName, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_variableName, _originalValue);
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Symphony.Application.Configuration;
 using Symphony.Abstractions.Workflows;
 using Symphony.Infrastructure.DependencyInjection;
+using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Workflows;
 
 namespace Symphony.Infrastructure.Tests;
@@ -19,6 +21,7 @@ public class InfrastructureServiceCollectionExtensionsTests
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<InfrastructureServiceMarker>());
+        Assert.IsType<WorkflowOptionsResolver>(serviceProvider.GetRequiredService<IWorkflowOptionsResolver>());
         Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
 
         var hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();


### PR DESCRIPTION
Closes #13

#### Context

Implement story E2-S2 from the plan using SPEC.md as the source of truth for the workflow config layer.

#### TL;DR

*Add typed workflow options plus spec-driven defaulting, env resolution, and validation.*

#### Summary

- Add typed workflow service options for tracker, polling, workspace, hooks, agent, and codex settings.
- Map `WorkflowDefinition` config into those options with SPEC.md defaults and env/path handling.
- Validate tracker-specific requirements and invalid config combinations with infrastructure tests.

#### Alternatives

- Keep consuming raw YAML dictionaries in later stories, but that would spread config parsing and validation across the runtime.
- Bind directly to ASP.NET configuration primitives, but the workflow contract is repo-owned `WORKFLOW.md`, not appsettings.

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release` (equivalent gates run separately with restore/no-restore as appropriate)
- [x] `dotnet restore .\dotnet\Symphony.sln -v minimal`
- [x] `dotnet build .\dotnet\Symphony.sln -c Release --no-restore -m:1 -v minimal`
- [x] `dotnet test .\dotnet\Symphony.sln -c Release --no-build --no-restore -m:1 -v minimal`
- [x] `dotnet format .\dotnet\Symphony.sln --verify-no-changes --no-restore`
