### PR TITLE
E3-S1: implement polling background service

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -216,11 +216,13 @@ Title: {{ issue.title }} Body: {{ issue.description }}
 Notes:
 
 - If a value is missing, defaults are used where defined by the implementation/spec.
+- `polling.interval_ms` controls the delay between poll ticks. After startup validation succeeds,
+  Symphony runs an immediate tick and then continues on the configured interval.
 - `tracker.active_states` and `tracker.terminal_states` should be explicitly set for your tracker
   workflow.
 - If `WORKFLOW.md` is missing or has invalid YAML at startup, Symphony does not boot.
-- If a later reload fails, Symphony keeps running with the last known good workflow and logs the
-  reload error until the file is fixed.
+- If a later reload fails, Symphony keeps running with the last known good workflow settings,
+  including the last valid poll interval, and logs the reload error until the file is fixed.
 
 ## Web dashboard
 

--- a/dotnet/src/Symphony.Application/Configuration/IWorkflowOptionsProvider.cs
+++ b/dotnet/src/Symphony.Application/Configuration/IWorkflowOptionsProvider.cs
@@ -1,0 +1,6 @@
+namespace Symphony.Application.Configuration;
+
+public interface IWorkflowOptionsProvider
+{
+    Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Symphony.Application.Polling;
 
 namespace Symphony.Application.DependencyInjection;
 
@@ -9,6 +11,8 @@ public static class ApplicationServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<ApplicationServiceMarker>();
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<IPollingIterationHandler, NoOpPollingIterationHandler>();
 
         return services;
     }

--- a/dotnet/src/Symphony.Application/Polling/IPollingIterationHandler.cs
+++ b/dotnet/src/Symphony.Application/Polling/IPollingIterationHandler.cs
@@ -1,0 +1,8 @@
+using Symphony.Application.Configuration;
+
+namespace Symphony.Application.Polling;
+
+public interface IPollingIterationHandler
+{
+    Task ExecuteAsync(WorkflowServiceOptions workflowOptions, CancellationToken cancellationToken);
+}

--- a/dotnet/src/Symphony.Application/Polling/NoOpPollingIterationHandler.cs
+++ b/dotnet/src/Symphony.Application/Polling/NoOpPollingIterationHandler.cs
@@ -1,0 +1,13 @@
+using Symphony.Application.Configuration;
+
+namespace Symphony.Application.Polling;
+
+public sealed class NoOpPollingIterationHandler : IPollingIterationHandler
+{
+    public Task ExecuteAsync(WorkflowServiceOptions workflowOptions, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workflowOptions);
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet/src/Symphony.Application/Polling/PollingBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Polling/PollingBackgroundService.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Symphony.Application.Configuration;
+
+namespace Symphony.Application.Polling;
+
+public sealed class PollingBackgroundService : BackgroundService
+{
+    private readonly IPollingIterationHandler _pollingIterationHandler;
+    private readonly ILogger<PollingBackgroundService> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly IWorkflowOptionsProvider _workflowOptionsProvider;
+
+    public PollingBackgroundService(
+        IWorkflowOptionsProvider workflowOptionsProvider,
+        IPollingIterationHandler pollingIterationHandler,
+        TimeProvider timeProvider,
+        ILogger<PollingBackgroundService> logger)
+    {
+        _workflowOptionsProvider = workflowOptionsProvider;
+        _pollingIterationHandler = pollingIterationHandler;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var currentOptions = await _workflowOptionsProvider.GetCurrentAsync(stoppingToken).ConfigureAwait(false);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _pollingIterationHandler.ExecuteAsync(currentOptions, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(
+                    exception,
+                    "Polling iteration failed. Continuing after {PollingIntervalMs}ms.",
+                    currentOptions.Polling.IntervalMs);
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            currentOptions = await TryRefreshWorkflowOptionsAsync(currentOptions, stoppingToken).ConfigureAwait(false);
+
+            try
+            {
+                await Task.Delay(
+                        TimeSpan.FromMilliseconds(currentOptions.Polling.IntervalMs),
+                        _timeProvider,
+                        stoppingToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task<WorkflowServiceOptions> TryRefreshWorkflowOptionsAsync(
+        WorkflowServiceOptions currentOptions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to re-apply workflow configuration. Continuing with previous polling interval {PollingIntervalMs}ms.",
+                currentOptions.Polling.IntervalMs);
+
+            return currentOptions;
+        }
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsProvider.cs
+++ b/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsProvider.cs
@@ -1,0 +1,26 @@
+using Symphony.Abstractions.Workflows;
+using Symphony.Application.Configuration;
+
+namespace Symphony.Infrastructure.Configuration;
+
+public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider
+{
+    private readonly IWorkflowLoader _workflowLoader;
+    private readonly IWorkflowOptionsResolver _workflowOptionsResolver;
+
+    public WorkflowOptionsProvider(
+        IWorkflowLoader workflowLoader,
+        IWorkflowOptionsResolver workflowOptionsResolver)
+    {
+        _workflowLoader = workflowLoader;
+        _workflowOptionsResolver = workflowOptionsResolver;
+    }
+
+    public async Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+    {
+        var workflowPath = Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md");
+        var workflowDefinition = await _workflowLoader.LoadAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+
+        return _workflowOptionsResolver.Resolve(workflowDefinition);
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
 using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Workflows;
 using Symphony.Infrastructure.Configuration;
@@ -16,8 +17,10 @@ public static class InfrastructureServiceCollectionExtensions
 
         services.AddSingleton<InfrastructureServiceMarker>();
         services.AddSingleton<IWorkflowOptionsResolver, WorkflowOptionsResolver>();
+        services.AddSingleton<IWorkflowOptionsProvider, WorkflowOptionsProvider>();
         services.AddSingleton<IWorkflowLoader, YamlWorkflowLoader>();
         services.AddHostedService<WorkflowStartupValidationHostedService>();
+        services.AddHostedService<PollingBackgroundService>();
         services.AddSingleton<IProcessRunner, ProcessRunner>();
 
         return services;

--- a/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowStartupValidationHostedService.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowStartupValidationHostedService.cs
@@ -1,19 +1,20 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Symphony.Abstractions.Workflows;
+using Symphony.Application.Configuration;
 
 namespace Symphony.Infrastructure.Workflows;
 
 public sealed class WorkflowStartupValidationHostedService : IHostedService
 {
     private readonly ILogger<WorkflowStartupValidationHostedService> _logger;
-    private readonly IWorkflowLoader _workflowLoader;
+    private readonly IWorkflowOptionsProvider _workflowOptionsProvider;
 
     public WorkflowStartupValidationHostedService(
-        IWorkflowLoader workflowLoader,
+        IWorkflowOptionsProvider workflowOptionsProvider,
         ILogger<WorkflowStartupValidationHostedService> logger)
     {
-        _workflowLoader = workflowLoader;
+        _workflowOptionsProvider = workflowOptionsProvider;
         _logger = logger;
     }
 
@@ -23,24 +24,36 @@ public sealed class WorkflowStartupValidationHostedService : IHostedService
 
         try
         {
-            await _workflowLoader.LoadAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+            await _workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (WorkflowLoadException exception)
         {
-            _logger.LogError(
-                exception,
-                "Failed to load workflow file '{WorkflowPath}' ({ErrorCode}). Fix WORKFLOW.md before starting Symphony.",
-                exception.WorkflowPath,
-                exception.Code);
-
-            throw new InvalidOperationException(
-                $"Failed to load workflow file '{exception.WorkflowPath}' ({exception.Code}). {exception.Message}",
-                exception);
+            throw CreateStartupValidationFailure(exception, exception.Code, workflowPath);
+        }
+        catch (WorkflowConfigurationException exception)
+        {
+            throw CreateStartupValidationFailure(exception, exception.Code, workflowPath);
         }
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
+    }
+
+    private InvalidOperationException CreateStartupValidationFailure(
+        Exception exception,
+        string errorCode,
+        string workflowPath)
+    {
+        _logger.LogError(
+            exception,
+            "Failed to validate workflow file '{WorkflowPath}' ({ErrorCode}). Fix WORKFLOW.md before starting Symphony.",
+            workflowPath,
+            errorCode);
+
+        return new InvalidOperationException(
+            $"Failed to validate workflow file '{workflowPath}' ({errorCode}). {exception.Message}",
+            exception);
     }
 }

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Symphony.Application.Polling;
 using Symphony.Application.DependencyInjection;
 
 namespace Symphony.Application.Tests;
@@ -6,7 +7,7 @@ namespace Symphony.Application.Tests;
 public class ApplicationServiceCollectionExtensionsTests
 {
     [Fact]
-    public void AddSymphonyApplication_registers_application_marker()
+    public void AddSymphonyApplication_registers_application_services()
     {
         var services = new ServiceCollection();
 
@@ -15,5 +16,7 @@ public class ApplicationServiceCollectionExtensionsTests
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<ApplicationServiceMarker>());
+        Assert.IsType<NoOpPollingIterationHandler>(serviceProvider.GetRequiredService<IPollingIterationHandler>());
+        Assert.Same(TimeProvider.System, serviceProvider.GetRequiredService<TimeProvider>());
     }
 }

--- a/dotnet/tests/Symphony.Application.Tests/Polling/PollingBackgroundServiceTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Polling/PollingBackgroundServiceTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
+
+namespace Symphony.Application.Tests.Polling;
+
+public sealed class PollingBackgroundServiceTests
+{
+    [Fact]
+    public async Task StartAsync_uses_poll_interval_from_typed_config()
+    {
+        var firstTick = new TaskCompletionSource<DateTimeOffset>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondTick = new TaskCompletionSource<DateTimeOffset>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationCount = 0;
+        var service = new PollingBackgroundService(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions(intervalMs: 80)),
+            new DelegatePollingIterationHandler(
+                (_, _) =>
+                {
+                    var now = DateTimeOffset.UtcNow;
+                    var currentCount = Interlocked.Increment(ref invocationCount);
+
+                    if (currentCount == 1)
+                    {
+                        firstTick.TrySetResult(now);
+                    }
+                    else if (currentCount == 2)
+                    {
+                        secondTick.TrySetResult(now);
+                    }
+
+                    return Task.CompletedTask;
+                }),
+            TimeProvider.System,
+            NullLogger<PollingBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var firstTickTimestamp = await firstTick.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var secondTickTimestamp = await secondTick.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.True(
+            secondTickTimestamp - firstTickTimestamp >= TimeSpan.FromMilliseconds(50),
+            "The polling loop should wait for the typed workflow polling interval before the next tick.");
+    }
+
+    [Fact]
+    public async Task StopAsync_cancels_active_iteration_and_waits_for_completion()
+    {
+        var iterationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var capturedToken = CancellationToken.None;
+        var service = new PollingBackgroundService(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions(intervalMs: 1_000)),
+            new DelegatePollingIterationHandler(
+                async (_, cancellationToken) =>
+                {
+                    capturedToken = cancellationToken;
+                    iterationStarted.TrySetResult();
+
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationObserved.TrySetResult();
+                        throw;
+                    }
+                }),
+            TimeProvider.System,
+            NullLogger<PollingBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await iterationStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await service.StopAsync(stopCts.Token);
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.True(capturedToken.CanBeCanceled);
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions(int intervalMs)
+    {
+        return new WorkflowServiceOptions(
+            new WorkflowTrackerOptions(
+                "github",
+                "https://api.github.com",
+                "token",
+                null,
+                "owner/repo",
+                null,
+                null,
+                ["Todo"],
+                ["Done"]),
+            new WorkflowPollingOptions(intervalMs),
+            new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+            new WorkflowHookOptions(
+                null,
+                null,
+                null,
+                null,
+                60_000),
+            new WorkflowAgentOptions(
+                1,
+                20,
+                300_000,
+                new Dictionary<string, int>(StringComparer.Ordinal)),
+            new WorkflowCodexOptions(
+                "codex app-server",
+                null,
+                null,
+                null,
+                3_600_000,
+                5_000,
+                300_000));
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class DelegatePollingIterationHandler(
+        Func<WorkflowServiceOptions, CancellationToken, Task> onExecuteAsync) : IPollingIterationHandler
+    {
+        public Task ExecuteAsync(WorkflowServiceOptions workflowOptions, CancellationToken cancellationToken)
+        {
+            return onExecuteAsync(workflowOptions, cancellationToken);
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Symphony.Application.Configuration;
+using Symphony.Application.DependencyInjection;
+using Symphony.Application.Polling;
 using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Workflows;
-using Symphony.Infrastructure.DependencyInjection;
 using Symphony.Infrastructure.Configuration;
+using Symphony.Infrastructure.DependencyInjection;
 using Symphony.Infrastructure.Processes;
 using Symphony.Infrastructure.Workflows;
 
@@ -17,6 +19,7 @@ public class InfrastructureServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSymphonyApplication();
 
         services.AddSymphonyInfrastructure();
 
@@ -24,10 +27,12 @@ public class InfrastructureServiceCollectionExtensionsTests
 
         Assert.NotNull(serviceProvider.GetService<InfrastructureServiceMarker>());
         Assert.IsType<WorkflowOptionsResolver>(serviceProvider.GetRequiredService<IWorkflowOptionsResolver>());
+        Assert.IsType<WorkflowOptionsProvider>(serviceProvider.GetRequiredService<IWorkflowOptionsProvider>());
         Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
         Assert.IsType<ProcessRunner>(serviceProvider.GetRequiredService<IProcessRunner>());
         var hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
 
         Assert.Contains(hostedServices, service => service is WorkflowStartupValidationHostedService);
+        Assert.Contains(hostedServices, service => service is PollingBackgroundService);
     }
 }

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.Logging;
+using Symphony.Application.Configuration;
+using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Workflows;
 
 namespace Symphony.Infrastructure.Tests.Workflows;
@@ -25,7 +27,7 @@ public sealed class WorkflowStartupValidationHostedServiceTests
         var loggerProvider = new TestLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
         var service = new WorkflowStartupValidationHostedService(
-            new YamlWorkflowLoader(),
+            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver()),
             loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
 
         await CurrentDirectoryGate.WaitAsync();
@@ -40,6 +42,56 @@ public sealed class WorkflowStartupValidationHostedServiceTests
                 var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.StartAsync(CancellationToken.None));
 
                 Assert.Contains("workflow_parse_error", exception.Message);
+                Assert.Contains("WORKFLOW.md", exception.Message);
+                Assert.Contains(
+                    loggerProvider.Messages,
+                    message => message.Contains("Fix WORKFLOW.md before starting Symphony.", StringComparison.Ordinal));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousDirectory);
+            }
+        }
+        finally
+        {
+            CurrentDirectoryGate.Release();
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_invalid_typed_config_logs_actionable_error_and_throws()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"symphony-startup-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(tempDirectory, "WORKFLOW.md"),
+            """
+            ---
+            tracker:
+              kind: github
+              repository: owner/repo
+            ---
+            Prompt
+            """);
+
+        var loggerProvider = new TestLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+        var service = new WorkflowStartupValidationHostedService(
+            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver()),
+            loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
+
+        await CurrentDirectoryGate.WaitAsync();
+
+        try
+        {
+            var previousDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDirectory);
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.StartAsync(CancellationToken.None));
+
+                Assert.Contains("missing_tracker_api_key", exception.Message);
                 Assert.Contains("WORKFLOW.md", exception.Message);
                 Assert.Contains(
                     loggerProvider.Messages,


### PR DESCRIPTION
#### Context

Implement E3-S1 from SPEC.md so Symphony has a real polling BackgroundService that validates WORKFLOW.md, runs an immediate tick, and uses typed polling intervals.

#### TL;DR

*Add the polling BackgroundService, shared workflow options provider, and shutdown-safe tests.*

#### Summary

- add `PollingBackgroundService` plus a polling iteration seam for later orchestration work
- load typed workflow options from `WORKFLOW.md` through a shared infrastructure provider
- validate startup and reloads through the same typed config path and document poll interval behavior

#### Alternatives

- keep startup validation and polling on separate config paths, which would duplicate logic and drift
- defer the polling seam until dispatch logic lands, which would make later stories couple orchestration and scheduling

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added polling tests for interval scheduling, graceful stop, and cancellation propagation

Closes #15
