### PR TITLE
E4-S1: implement safe workspace manager

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -218,6 +218,12 @@ Notes:
 - If a value is missing, defaults are used where defined by the implementation/spec.
 - `polling.interval_ms` controls the delay between poll ticks. After startup validation succeeds,
   Symphony runs an immediate tick and then continues on the configured interval.
+- Per-issue workspaces live under `workspace.root` using a sanitized issue identifier that keeps
+  only letters, digits, `.`, `_`, and `-`.
+- Workspace paths that resolve outside the configured `workspace.root` are rejected before any
+  directory creation or cleanup occurs.
+- `hooks.after_create` runs only when a workspace directory is newly created. `hooks.before_remove`
+  is best-effort during cleanup and does not block deletion.
 - `tracker.active_states` and `tracker.terminal_states` should be explicitly set for your tracker
   workflow.
 - If `WORKFLOW.md` is missing or has invalid YAML at startup, Symphony does not boot.

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -3,9 +3,11 @@ using Symphony.Application.Configuration;
 using Symphony.Application.Polling;
 using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Workflows;
+using Symphony.Abstractions.Workspaces;
 using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Processes;
 using Symphony.Infrastructure.Workflows;
+using Symphony.Infrastructure.Workspaces;
 
 namespace Symphony.Infrastructure.DependencyInjection;
 
@@ -22,6 +24,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddHostedService<WorkflowStartupValidationHostedService>();
         services.AddHostedService<PollingBackgroundService>();
         services.AddSingleton<IProcessRunner, ProcessRunner>();
+        services.AddSingleton<IWorkspaceManager, WorkspaceManager>();
 
         return services;
     }

--- a/dotnet/src/Symphony.Infrastructure/Workspaces/WorkspaceManager.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workspaces/WorkspaceManager.cs
@@ -1,0 +1,231 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Processes;
+using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Workspaces;
+
+namespace Symphony.Infrastructure.Workspaces;
+
+public sealed class WorkspaceManager(
+    IWorkflowOptionsProvider workflowOptionsProvider,
+    IProcessRunner processRunner,
+    ILogger<WorkspaceManager> logger) : IWorkspaceManager
+{
+    public async Task<Workspace> CreateForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+    {
+        var options = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var workspacePathInfo = ResolveWorkspacePath(issueIdentifier, options.Workspace.Root);
+
+        if (File.Exists(workspacePathInfo.WorkspacePath) && !Directory.Exists(workspacePathInfo.WorkspacePath))
+        {
+            throw new InvalidOperationException(
+                $"Cannot create workspace '{workspacePathInfo.WorkspacePath}' because a non-directory entry already exists at that path.");
+        }
+
+        var createdNow = false;
+        if (!Directory.Exists(workspacePathInfo.WorkspacePath))
+        {
+            Directory.CreateDirectory(workspacePathInfo.WorkspacePath);
+            createdNow = true;
+        }
+
+        try
+        {
+            if (createdNow && options.Hooks.AfterCreate is not null)
+            {
+                await RunRequiredHookAsync(
+                        "after_create",
+                        options.Hooks.AfterCreate,
+                        workspacePathInfo.WorkspacePath,
+                        options.Hooks.TimeoutMs,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            if (createdNow && Directory.Exists(workspacePathInfo.WorkspacePath))
+            {
+                Directory.Delete(workspacePathInfo.WorkspacePath, recursive: true);
+            }
+
+            throw;
+        }
+
+        return new Workspace(workspacePathInfo.WorkspacePath, workspacePathInfo.WorkspaceKey, createdNow);
+    }
+
+    public async Task DeleteForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+    {
+        var options = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var workspacePathInfo = ResolveWorkspacePath(issueIdentifier, options.Workspace.Root);
+
+        if (Directory.Exists(workspacePathInfo.WorkspacePath))
+        {
+            if (options.Hooks.BeforeRemove is not null)
+            {
+                await RunBestEffortHookAsync(
+                        "before_remove",
+                        options.Hooks.BeforeRemove,
+                        workspacePathInfo.WorkspacePath,
+                        options.Hooks.TimeoutMs,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            Directory.Delete(workspacePathInfo.WorkspacePath, recursive: true);
+            return;
+        }
+
+        if (File.Exists(workspacePathInfo.WorkspacePath))
+        {
+            File.Delete(workspacePathInfo.WorkspacePath);
+        }
+    }
+
+    private async Task RunRequiredHookAsync(
+        string hookName,
+        string script,
+        string workspacePath,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        var result = await RunHookAsync(hookName, script, workspacePath, timeoutMs, cancellationToken).ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Workspace hook '{hookName}' failed for '{workspacePath}' with exit code {result.ExitCode}.");
+        }
+    }
+
+    private async Task RunBestEffortHookAsync(
+        string hookName,
+        string script,
+        string workspacePath,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await RunHookAsync(hookName, script, workspacePath, timeoutMs, cancellationToken).ConfigureAwait(false);
+            if (result.ExitCode != 0)
+            {
+                logger.LogWarning(
+                    "Workspace hook '{HookName}' failed for '{WorkspacePath}' with exit code {ExitCode}. Cleanup will continue.",
+                    hookName,
+                    workspacePath,
+                    result.ExitCode);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Workspace hook '{HookName}' failed for '{WorkspacePath}'. Cleanup will continue.",
+                hookName,
+                workspacePath);
+        }
+    }
+
+    private async Task<ProcessRunResult> RunHookAsync(
+        string hookName,
+        string script,
+        string workspacePath,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "Running workspace hook '{HookName}' in '{WorkspacePath}'.",
+            hookName,
+            workspacePath);
+
+        return await processRunner.RunAsync(
+                CreateHookRequest(script, workspacePath, timeoutMs),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static ProcessRunRequest CreateHookRequest(string script, string workspacePath, int timeoutMs)
+    {
+        return OperatingSystem.IsWindows()
+            ? new ProcessRunRequest(
+                fileName: "pwsh",
+                arguments: ["-NoProfile", "-NonInteractive", "-Command", script],
+                workingDirectory: workspacePath,
+                timeout: TimeSpan.FromMilliseconds(timeoutMs))
+            : new ProcessRunRequest(
+                fileName: "sh",
+                arguments: ["-lc", script],
+                workingDirectory: workspacePath,
+                timeout: TimeSpan.FromMilliseconds(timeoutMs));
+    }
+
+    private static WorkspacePathInfo ResolveWorkspacePath(string issueIdentifier, string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
+
+        var workspaceKey = SanitizeIssueIdentifier(issueIdentifier);
+        var normalizedWorkspaceRoot = Path.GetFullPath(workspaceRoot);
+        var workspacePath = Path.GetFullPath(Path.Combine(normalizedWorkspaceRoot, workspaceKey));
+
+        if (!IsWithinRoot(normalizedWorkspaceRoot, workspacePath))
+        {
+            throw new InvalidOperationException(
+                $"Workspace path '{workspacePath}' must stay inside the configured workspace root '{normalizedWorkspaceRoot}'.");
+        }
+
+        return new WorkspacePathInfo(workspacePath, workspaceKey);
+    }
+
+    private static string SanitizeIssueIdentifier(string issueIdentifier)
+    {
+        var sanitized = new StringBuilder(issueIdentifier.Trim().Length);
+        var previousWasHyphen = false;
+
+        foreach (var character in issueIdentifier.Trim())
+        {
+            var normalizedCharacter = IsAllowedWorkspaceCharacter(character) ? character : '-';
+            if (normalizedCharacter == '-' && previousWasHyphen)
+            {
+                continue;
+            }
+
+            sanitized.Append(normalizedCharacter);
+            previousWasHyphen = normalizedCharacter == '-';
+        }
+
+        var workspaceKey = sanitized.ToString().Trim('-');
+        if (string.IsNullOrWhiteSpace(workspaceKey))
+        {
+            throw new InvalidOperationException("Issue identifier did not produce a valid workspace key.");
+        }
+
+        return workspaceKey;
+    }
+
+    private static bool IsAllowedWorkspaceCharacter(char character)
+    {
+        return char.IsLetterOrDigit(character) || character is '.' or '_' or '-';
+    }
+
+    private static bool IsWithinRoot(string workspaceRoot, string workspacePath)
+    {
+        var normalizedWorkspaceRoot = Path.TrimEndingDirectorySeparator(workspaceRoot);
+        var normalizedWorkspacePath = Path.TrimEndingDirectorySeparator(workspacePath);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return normalizedWorkspacePath.StartsWith(
+            normalizedWorkspaceRoot + Path.DirectorySeparatorChar,
+            comparison);
+    }
+
+    private sealed record WorkspacePathInfo(string WorkspacePath, string WorkspaceKey);
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -5,10 +5,12 @@ using Symphony.Application.DependencyInjection;
 using Symphony.Application.Polling;
 using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Workflows;
+using Symphony.Abstractions.Workspaces;
 using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.DependencyInjection;
 using Symphony.Infrastructure.Processes;
 using Symphony.Infrastructure.Workflows;
+using Symphony.Infrastructure.Workspaces;
 
 namespace Symphony.Infrastructure.Tests;
 
@@ -30,6 +32,7 @@ public class InfrastructureServiceCollectionExtensionsTests
         Assert.IsType<WorkflowOptionsProvider>(serviceProvider.GetRequiredService<IWorkflowOptionsProvider>());
         Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
         Assert.IsType<ProcessRunner>(serviceProvider.GetRequiredService<IProcessRunner>());
+        Assert.IsType<WorkspaceManager>(serviceProvider.GetRequiredService<IWorkspaceManager>());
         var hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
 
         Assert.Contains(hostedServices, service => service is WorkflowStartupValidationHostedService);

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workspaces/WorkspaceManagerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workspaces/WorkspaceManagerTests.cs
@@ -1,0 +1,223 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Abstractions.Processes;
+using Symphony.Application.Configuration;
+using Symphony.Infrastructure.Workspaces;
+
+namespace Symphony.Infrastructure.Tests.Workspaces;
+
+public sealed class WorkspaceManagerTests
+{
+    [Fact]
+    public async Task CreateForIssueAsync_creates_deterministic_sanitized_workspace()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner: new RecordingProcessRunner());
+
+            var createdWorkspace = await manager.CreateForIssueAsync("GH-123 / fix bug");
+            var reusedWorkspace = await manager.CreateForIssueAsync("GH-123 / fix bug");
+
+            Assert.Equal("GH-123-fix-bug", createdWorkspace.WorkspaceKey);
+            Assert.Equal(Path.Combine(Path.GetFullPath(workspaceRoot), "GH-123-fix-bug"), createdWorkspace.Path);
+            Assert.True(createdWorkspace.CreatedNow);
+            Assert.False(reusedWorkspace.CreatedNow);
+            Assert.True(Directory.Exists(createdWorkspace.Path));
+            Assert.Equal(createdWorkspace.Path, reusedWorkspace.Path);
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
+    [Fact]
+    public async Task CreateForIssueAsync_rejects_workspace_path_outside_root()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner: new RecordingProcessRunner());
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => manager.CreateForIssueAsync(".."));
+
+            Assert.Contains("must stay inside the configured workspace root", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
+    [Fact]
+    public async Task CreateForIssueAsync_runs_after_create_hook_only_for_new_workspace()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+        var processRunner = new RecordingProcessRunner();
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner,
+                afterCreate: "Write-Host created",
+                hookTimeoutMs: 12_345);
+
+            var workspace = await manager.CreateForIssueAsync("ISSUE-42");
+            _ = await manager.CreateForIssueAsync("ISSUE-42");
+
+            var request = Assert.Single(processRunner.Requests);
+            Assert.Equal(workspace.Path, request.WorkingDirectory);
+            Assert.Equal(TimeSpan.FromMilliseconds(12_345), request.Timeout);
+            Assert.Equal(OperatingSystem.IsWindows() ? "pwsh" : "sh", request.FileName);
+            Assert.Equal("Write-Host created", request.Arguments.Last());
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
+    [Fact]
+    public async Task CreateForIssueAsync_after_create_failure_removes_new_workspace()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner: new RecordingProcessRunner(resultFactory: _ => new ProcessRunResult(
+                    exitCode: 1,
+                    standardOutput: string.Empty,
+                    standardError: "hook failed",
+                    startedAt: DateTimeOffset.UtcNow,
+                    finishedAt: DateTimeOffset.UtcNow)),
+                afterCreate: "Write-Error boom");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => manager.CreateForIssueAsync("ISSUE-99"));
+
+            Assert.Contains("after_create", exception.Message, StringComparison.Ordinal);
+            Assert.False(Directory.Exists(Path.Combine(Path.GetFullPath(workspaceRoot), "ISSUE-99")));
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteForIssueAsync_runs_before_remove_and_ignores_failures()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+        var processRunner = new RecordingProcessRunner(exceptionFactory: _ => new InvalidOperationException("hook failed"));
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner,
+                beforeRemove: "Write-Host cleanup");
+            var workspacePath = Path.Combine(Path.GetFullPath(workspaceRoot), "ISSUE-123");
+            Directory.CreateDirectory(workspacePath);
+
+            await manager.DeleteForIssueAsync("ISSUE-123");
+
+            Assert.Single(processRunner.Requests);
+            Assert.False(Directory.Exists(workspacePath));
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
+    private static WorkspaceManager CreateWorkspaceManager(
+        string workspaceRoot,
+        RecordingProcessRunner processRunner,
+        string? afterCreate = null,
+        string? beforeRemove = null,
+        int hookTimeoutMs = 60_000)
+    {
+        return new WorkspaceManager(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions(workspaceRoot, afterCreate, beforeRemove, hookTimeoutMs)),
+            processRunner,
+            NullLogger<WorkspaceManager>.Instance);
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions(
+        string workspaceRoot,
+        string? afterCreate,
+        string? beforeRemove,
+        int hookTimeoutMs)
+    {
+        return new WorkflowServiceOptions(
+            new WorkflowTrackerOptions(
+                "github",
+                "https://api.github.com",
+                "token",
+                null,
+                "owner/repo",
+                null,
+                null,
+                ["open"],
+                ["closed"]),
+            new WorkflowPollingOptions(30_000),
+            new WorkflowWorkspaceOptions(workspaceRoot),
+            new WorkflowHookOptions(afterCreate, null, null, beforeRemove, hookTimeoutMs),
+            new WorkflowAgentOptions(1, 20, 300_000, new Dictionary<string, int>(StringComparer.Ordinal)),
+            new WorkflowCodexOptions("codex app-server", null, null, null, 3_600_000, 5_000, 300_000));
+    }
+
+    private static string CreateTemporaryWorkspaceRoot()
+    {
+        return Path.Combine(Path.GetTempPath(), "symphony-workspaces-tests", Guid.NewGuid().ToString("N"));
+    }
+
+    private static void DeleteDirectoryIfPresent(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class RecordingProcessRunner(
+        Func<ProcessRunRequest, ProcessRunResult>? resultFactory = null,
+        Func<ProcessRunRequest, Exception>? exceptionFactory = null) : IProcessRunner
+    {
+        public List<ProcessRunRequest> Requests { get; } = [];
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+
+            if (exceptionFactory is not null)
+            {
+                throw exceptionFactory(request);
+            }
+
+            return Task.FromResult(
+                resultFactory?.Invoke(request) ?? new ProcessRunResult(
+                    exitCode: 0,
+                    standardOutput: string.Empty,
+                    standardError: string.Empty,
+                    startedAt: DateTimeOffset.UtcNow,
+                    finishedAt: DateTimeOffset.UtcNow));
+        }
+    }
+}


### PR DESCRIPTION
#### Context

Implement E4-S1 from SPEC.md so workspace creation and cleanup enforce sanitized per-issue paths, stay inside `workspace.root`, and honor lifecycle hook semantics.

#### TL;DR

*Add a safe workspace manager with deterministic paths, containment checks, and cleanup hooks.*

#### Summary

- implement `WorkspaceManager` in infrastructure with deterministic sanitized workspace paths
- reject any workspace path that resolves outside the configured `workspace.root`
- run `after_create` only for new workspaces, make `before_remove` best-effort, and cover both with tests

#### Alternatives

- defer workspace safety until agent execution stories, which would leave filesystem invariants unenforced
- allow implicit path normalization without explicit containment checks, which is unsafe for traversal-like identifiers

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added workspace manager tests for sanitization, root containment, new-workspace hooks, and cleanup behavior

Closes #19
