### PR TITLE
E3-S2: implement bounded dispatch queue and concurrency gate

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -220,6 +220,9 @@ Notes:
 - If a value is missing, defaults are used where defined by the implementation/spec.
 - `polling.interval_ms` controls the delay between poll ticks. After startup validation succeeds,
   Symphony runs an immediate tick and then continues on the configured interval.
+- The application layer keeps dispatch staging in a bounded in-memory channel and enforces
+  `agent.max_concurrent_agents` with a semaphore-backed execution gate. Status consumers can read
+  queued and running work directly from the in-memory dispatch snapshot.
 - Per-issue workspaces live under `workspace.root` using a sanitized issue identifier that keeps
   only letters, digits, `.`, `_`, and `-`.
 - Workspace paths that resolve outside the configured `workspace.root` are rejected before any

--- a/dotnet/src/Symphony.Abstractions/Orchestration/DispatchEnqueueResult.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/DispatchEnqueueResult.cs
@@ -1,0 +1,8 @@
+namespace Symphony.Abstractions.Orchestration;
+
+public enum DispatchEnqueueResult
+{
+    Enqueued,
+    AlreadyClaimed,
+    NoCapacity
+}

--- a/dotnet/src/Symphony.Abstractions/Orchestration/DispatchQueueSnapshot.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/DispatchQueueSnapshot.cs
@@ -1,0 +1,21 @@
+namespace Symphony.Abstractions.Orchestration;
+
+public sealed record DispatchQueueSnapshot(
+    IReadOnlyList<QueuedDispatchSnapshot> Queued,
+    IReadOnlyList<RunningDispatchSnapshot> Running,
+    int MaxConcurrentAgents,
+    int AvailableSlots);
+
+public sealed record QueuedDispatchSnapshot(
+    string IssueId,
+    string IssueIdentifier,
+    string IssueState,
+    int? Attempt,
+    DateTimeOffset QueuedAt);
+
+public sealed record RunningDispatchSnapshot(
+    string IssueId,
+    string IssueIdentifier,
+    string IssueState,
+    int? Attempt,
+    DateTimeOffset StartedAt);

--- a/dotnet/src/Symphony.Abstractions/Orchestration/IOrchestratorDispatchQueue.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/IOrchestratorDispatchQueue.cs
@@ -1,0 +1,11 @@
+using Symphony.Domain.Issues;
+
+namespace Symphony.Abstractions.Orchestration;
+
+public interface IOrchestratorDispatchQueue
+{
+    ValueTask<DispatchEnqueueResult> QueueAsync(
+        Issue issue,
+        int? attempt = null,
+        CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/Symphony.Abstractions/Orchestration/IOrchestratorDispatchStatusReader.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/IOrchestratorDispatchStatusReader.cs
@@ -1,0 +1,6 @@
+namespace Symphony.Abstractions.Orchestration;
+
+public interface IOrchestratorDispatchStatusReader
+{
+    DispatchQueueSnapshot GetSnapshot();
+}

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Symphony.Abstractions.Orchestration;
+using Symphony.Application.Orchestration;
 using Symphony.Application.Polling;
 
 namespace Symphony.Application.DependencyInjection;
@@ -12,7 +15,12 @@ public static class ApplicationServiceCollectionExtensions
 
         services.AddSingleton<ApplicationServiceMarker>();
         services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<OrchestratorDispatchQueue>();
+        services.TryAddSingleton<IOrchestratorDispatchQueue>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());
+        services.TryAddSingleton<IOrchestratorDispatchStatusReader>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());
+        services.TryAddSingleton<IQueuedIssueWorker, NoOpQueuedIssueWorker>();
         services.TryAddSingleton<IPollingIterationHandler, NoOpPollingIterationHandler>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DispatchWorkerBackgroundService>());
 
         return services;
     }

--- a/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class DispatchWorkerBackgroundService(
+    OrchestratorDispatchQueue dispatchQueue,
+    IQueuedIssueWorker queuedIssueWorker,
+    ILogger<DispatchWorkerBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var inFlightTasks = new List<Task>();
+
+        try
+        {
+            await foreach (var workItem in dispatchQueue.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            {
+                var executionTask = ExecuteQueuedWorkItemAsync(workItem, stoppingToken);
+
+                lock (inFlightTasks)
+                {
+                    inFlightTasks.Add(executionTask);
+                }
+
+                _ = executionTask.ContinueWith(
+                    completedTask =>
+                    {
+                        lock (inFlightTasks)
+                        {
+                            inFlightTasks.Remove(completedTask);
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+
+        Task[] tasksToAwait;
+        lock (inFlightTasks)
+        {
+            tasksToAwait = inFlightTasks.ToArray();
+        }
+
+        await Task.WhenAll(tasksToAwait).ConfigureAwait(false);
+    }
+
+    private async Task ExecuteQueuedWorkItemAsync(
+        OrchestratorDispatchQueue.DispatchQueueWorkItem workItem,
+        CancellationToken cancellationToken)
+    {
+        using var executionLease = dispatchQueue.BeginExecution(workItem);
+
+        try
+        {
+            await queuedIssueWorker.ExecuteAsync(workItem.Issue, workItem.Attempt, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            logger.LogDebug(
+                "Queued execution for issue {IssueIdentifier} was canceled during shutdown.",
+                workItem.Issue.Identifier);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Queued execution for issue {IssueIdentifier} failed.",
+                workItem.Issue.Identifier);
+        }
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/IQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/IQueuedIssueWorker.cs
@@ -1,0 +1,8 @@
+using Symphony.Domain.Issues;
+
+namespace Symphony.Application.Orchestration;
+
+public interface IQueuedIssueWorker
+{
+    Task ExecuteAsync(Issue issue, int? attempt, CancellationToken cancellationToken);
+}

--- a/dotnet/src/Symphony.Application/Orchestration/NoOpQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/NoOpQueuedIssueWorker.cs
@@ -1,0 +1,13 @@
+using Symphony.Domain.Issues;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class NoOpQueuedIssueWorker : IQueuedIssueWorker
+{
+    public Task ExecuteAsync(Issue issue, int? attempt, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/OrchestratorDispatchQueue.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/OrchestratorDispatchQueue.cs
@@ -1,0 +1,280 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Orchestration;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Issues;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class OrchestratorDispatchQueue(
+    IWorkflowOptionsProvider workflowOptionsProvider,
+    TimeProvider timeProvider,
+    ILogger<OrchestratorDispatchQueue> logger) : IOrchestratorDispatchQueue, IOrchestratorDispatchStatusReader
+{
+    private const int DispatchQueueCapacity = 4_096;
+
+    private readonly Channel<DispatchQueueWorkItem> _dispatchChannel =
+        Channel.CreateBounded<DispatchQueueWorkItem>(
+            new BoundedChannelOptions(DispatchQueueCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+    private readonly Lock _stateLock = new();
+    private readonly Dictionary<string, QueuedDispatchEntry> _queued = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, RunningDispatchEntry> _running = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _claimed = new(StringComparer.Ordinal);
+
+    private SemaphoreSlim? _concurrencyGate;
+    private int _configuredConcurrency;
+    private int _pendingPermitReduction;
+
+    public async ValueTask<DispatchEnqueueResult> QueueAsync(
+        Issue issue,
+        int? attempt = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        if (attempt is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(attempt), attempt, "Attempt must be null or greater than zero.");
+        }
+
+        await RefreshConcurrencyGateAsync(cancellationToken).ConfigureAwait(false);
+
+        lock (_stateLock)
+        {
+            if (_claimed.Contains(issue.Id))
+            {
+                logger.LogDebug(
+                    "Issue {IssueIdentifier} is already claimed and will not be enqueued again.",
+                    issue.Identifier);
+
+                return DispatchEnqueueResult.AlreadyClaimed;
+            }
+        }
+
+        var concurrencyGate = GetConcurrencyGate();
+        var acquiredSlot = await concurrencyGate.WaitAsync(0, cancellationToken).ConfigureAwait(false);
+        if (!acquiredSlot)
+        {
+            logger.LogDebug(
+                "Issue {IssueIdentifier} could not be enqueued because no execution slots are available.",
+                issue.Identifier);
+
+            return DispatchEnqueueResult.NoCapacity;
+        }
+
+        var workItem = new DispatchQueueWorkItem(issue, attempt, timeProvider.GetUtcNow());
+
+        lock (_stateLock)
+        {
+            if (!_claimed.Add(issue.Id))
+            {
+                ReleaseExecutionSlot();
+
+                logger.LogDebug(
+                    "Issue {IssueIdentifier} became claimed before it could be enqueued.",
+                    issue.Identifier);
+
+                return DispatchEnqueueResult.AlreadyClaimed;
+            }
+
+            _queued[issue.Id] = new QueuedDispatchEntry(issue, attempt, workItem.QueuedAt);
+        }
+
+        try
+        {
+            await _dispatchChannel.Writer.WriteAsync(workItem, cancellationToken).ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Enqueued issue {IssueIdentifier} for dispatch attempt {Attempt}.",
+                issue.Identifier,
+                attempt);
+
+            return DispatchEnqueueResult.Enqueued;
+        }
+        catch
+        {
+            lock (_stateLock)
+            {
+                _queued.Remove(issue.Id);
+                _claimed.Remove(issue.Id);
+            }
+
+            ReleaseExecutionSlot();
+            throw;
+        }
+    }
+
+    public DispatchQueueSnapshot GetSnapshot()
+    {
+        lock (_stateLock)
+        {
+            return new DispatchQueueSnapshot(
+                _queued.Values
+                    .OrderBy(entry => entry.QueuedAt)
+                    .Select(
+                        entry => new QueuedDispatchSnapshot(
+                            entry.Issue.Id,
+                            entry.Issue.Identifier,
+                            entry.Issue.State,
+                            entry.Attempt,
+                            entry.QueuedAt))
+                    .ToArray(),
+                _running.Values
+                    .OrderBy(entry => entry.StartedAt)
+                    .Select(
+                        entry => new RunningDispatchSnapshot(
+                            entry.Issue.Id,
+                            entry.Issue.Identifier,
+                            entry.Issue.State,
+                            entry.Attempt,
+                            entry.StartedAt))
+                    .ToArray(),
+                _configuredConcurrency,
+                Math.Max(_configuredConcurrency - _queued.Count - _running.Count, 0));
+        }
+    }
+
+    internal IAsyncEnumerable<DispatchQueueWorkItem> ReadAllAsync(CancellationToken cancellationToken)
+    {
+        return _dispatchChannel.Reader.ReadAllAsync(cancellationToken);
+    }
+
+    internal IDisposable BeginExecution(DispatchQueueWorkItem workItem)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+
+        var startedAt = timeProvider.GetUtcNow();
+
+        lock (_stateLock)
+        {
+            _queued.Remove(workItem.Issue.Id);
+            _running[workItem.Issue.Id] = new RunningDispatchEntry(workItem.Issue, workItem.Attempt, startedAt);
+        }
+
+        logger.LogInformation(
+            "Started queued execution for issue {IssueIdentifier} at {StartedAt}.",
+            workItem.Issue.Identifier,
+            startedAt);
+
+        return new ExecutionLease(this, workItem.Issue);
+    }
+
+    private async Task RefreshConcurrencyGateAsync(CancellationToken cancellationToken)
+    {
+        var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var targetConcurrency = workflowOptions.Agent.MaxConcurrentAgents;
+
+        lock (_stateLock)
+        {
+            if (_concurrencyGate is null)
+            {
+                _concurrencyGate = new SemaphoreSlim(targetConcurrency, int.MaxValue);
+                _configuredConcurrency = targetConcurrency;
+                _pendingPermitReduction = 0;
+                return;
+            }
+
+            if (targetConcurrency == _configuredConcurrency)
+            {
+                return;
+            }
+
+            if (targetConcurrency > _configuredConcurrency)
+            {
+                var permitsToAdd = targetConcurrency - _configuredConcurrency;
+                _configuredConcurrency = targetConcurrency;
+
+                if (_pendingPermitReduction >= permitsToAdd)
+                {
+                    _pendingPermitReduction -= permitsToAdd;
+                    return;
+                }
+
+                permitsToAdd -= _pendingPermitReduction;
+                _pendingPermitReduction = 0;
+                _concurrencyGate.Release(permitsToAdd);
+                return;
+            }
+
+            var permitsToRemove = _configuredConcurrency - targetConcurrency;
+            _configuredConcurrency = targetConcurrency;
+
+            while (permitsToRemove > 0 && _concurrencyGate.Wait(0))
+            {
+                permitsToRemove--;
+            }
+
+            _pendingPermitReduction += permitsToRemove;
+        }
+    }
+
+    private SemaphoreSlim GetConcurrencyGate()
+    {
+        lock (_stateLock)
+        {
+            return _concurrencyGate
+                ?? throw new InvalidOperationException("The dispatch queue concurrency gate has not been initialized.");
+        }
+    }
+
+    private void CompleteExecution(Issue issue)
+    {
+        lock (_stateLock)
+        {
+            _running.Remove(issue.Id);
+            _claimed.Remove(issue.Id);
+        }
+
+        ReleaseExecutionSlot();
+
+        logger.LogInformation(
+            "Completed queued execution for issue {IssueIdentifier}.",
+            issue.Identifier);
+    }
+
+    private void ReleaseExecutionSlot()
+    {
+        lock (_stateLock)
+        {
+            if (_concurrencyGate is null)
+            {
+                return;
+            }
+
+            if (_pendingPermitReduction > 0)
+            {
+                _pendingPermitReduction--;
+                return;
+            }
+
+            _concurrencyGate.Release();
+        }
+    }
+
+    internal sealed record DispatchQueueWorkItem(Issue Issue, int? Attempt, DateTimeOffset QueuedAt);
+
+    private sealed record QueuedDispatchEntry(Issue Issue, int? Attempt, DateTimeOffset QueuedAt);
+
+    private sealed record RunningDispatchEntry(Issue Issue, int? Attempt, DateTimeOffset StartedAt);
+
+    private sealed class ExecutionLease(OrchestratorDispatchQueue owner, Issue issue) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            owner.CompleteExecution(issue);
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -1,6 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Symphony.Abstractions.Orchestration;
+using Symphony.Application.Configuration;
 using Symphony.Application.Polling;
 using Symphony.Application.DependencyInjection;
+using Symphony.Application.Orchestration;
 
 namespace Symphony.Application.Tests;
 
@@ -10,13 +14,62 @@ public class ApplicationServiceCollectionExtensionsTests
     public void AddSymphonyApplication_registers_application_services()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IWorkflowOptionsProvider>(
+            new StaticWorkflowOptionsProvider(
+                new WorkflowServiceOptions(
+                    new WorkflowTrackerOptions(
+                        "github",
+                        "https://api.github.com",
+                        "token",
+                        null,
+                        "owner/repo",
+                        null,
+                        null,
+                        ["Todo"],
+                        ["Done"]),
+                    new WorkflowPollingOptions(1_000),
+                    new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                    new WorkflowHookOptions(
+                        null,
+                        null,
+                        null,
+                        null,
+                        60_000),
+                    new WorkflowAgentOptions(
+                        1,
+                        20,
+                        300_000,
+                        new Dictionary<string, int>(StringComparer.Ordinal)),
+                    new WorkflowCodexOptions(
+                        "codex app-server",
+                        null,
+                        null,
+                        null,
+                        3_600_000,
+                        5_000,
+                        300_000))));
 
         services.AddSymphonyApplication();
 
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<ApplicationServiceMarker>());
+        Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchQueue>());
+        Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchStatusReader>());
+        Assert.IsType<NoOpQueuedIssueWorker>(serviceProvider.GetRequiredService<IQueuedIssueWorker>());
         Assert.IsType<NoOpPollingIterationHandler>(serviceProvider.GetRequiredService<IPollingIterationHandler>());
         Assert.Same(TimeProvider.System, serviceProvider.GetRequiredService<TimeProvider>());
+        Assert.Contains(
+            serviceProvider.GetServices<IHostedService>(),
+            hostedService => hostedService is DispatchWorkerBackgroundService);
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
     }
 }

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Abstractions.Orchestration;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Issues;
+
+namespace Symphony.Application.Tests.Orchestration;
+
+public sealed class OrchestratorDispatchQueueTests
+{
+    [Fact]
+    public async Task QueueAsync_tracks_queued_and_running_state_for_status_readers()
+    {
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var worker = new BlockingQueuedIssueWorker();
+        var hostedService = CreateHostedService(queue, worker);
+        var issue = CreateIssue("1", "ABC-1");
+
+        var enqueueResult = await queue.QueueAsync(issue);
+
+        Assert.Equal(DispatchEnqueueResult.Enqueued, enqueueResult);
+        Assert.Single(queue.GetSnapshot().Queued);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await worker.ExecutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var runningSnapshot = queue.GetSnapshot();
+
+        Assert.Empty(runningSnapshot.Queued);
+        Assert.Single(runningSnapshot.Running);
+        Assert.Equal("ABC-1", runningSnapshot.Running[0].IssueIdentifier);
+
+        worker.AllowCompletion();
+        await worker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var completedSnapshot = queue.GetSnapshot();
+
+        Assert.Empty(completedSnapshot.Queued);
+        Assert.Empty(completedSnapshot.Running);
+        Assert.Equal(1, completedSnapshot.MaxConcurrentAgents);
+        Assert.Equal(1, completedSnapshot.AvailableSlots);
+    }
+
+    [Fact]
+    public async Task QueueAsync_uses_concurrency_gate_to_reject_work_when_capacity_is_exhausted()
+    {
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var worker = new BlockingQueuedIssueWorker();
+        var hostedService = CreateHostedService(queue, worker);
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        var firstResult = await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.ExecutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var secondResult = await queue.QueueAsync(CreateIssue("2", "ABC-2"));
+
+        Assert.Equal(DispatchEnqueueResult.Enqueued, firstResult);
+        Assert.Equal(DispatchEnqueueResult.NoCapacity, secondResult);
+        Assert.Equal(0, queue.GetSnapshot().AvailableSlots);
+
+        worker.AllowCompletion();
+        await worker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task QueueAsync_refreshes_max_concurrency_for_future_dispatches()
+    {
+        var optionsProvider = new MutableWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents: 1));
+        var queue = CreateQueue(optionsProvider);
+        var firstWorker = new BlockingQueuedIssueWorker();
+        var firstHostedService = CreateHostedService(queue, firstWorker);
+
+        await firstHostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await firstWorker.ExecutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        optionsProvider.Current = CreateWorkflowOptions(maxConcurrentAgents: 2);
+
+        var secondResult = await queue.QueueAsync(CreateIssue("2", "ABC-2"));
+
+        Assert.Equal(DispatchEnqueueResult.Enqueued, secondResult);
+        Assert.Equal(2, queue.GetSnapshot().MaxConcurrentAgents);
+
+        firstWorker.AllowCompletion();
+        await firstWorker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await firstHostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task QueueAsync_returns_already_claimed_for_duplicate_issue_ids()
+    {
+        var queue = CreateQueue(maxConcurrentAgents: 2);
+
+        var firstResult = await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        var secondResult = await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+
+        Assert.Equal(DispatchEnqueueResult.Enqueued, firstResult);
+        Assert.Equal(DispatchEnqueueResult.AlreadyClaimed, secondResult);
+        Assert.Single(queue.GetSnapshot().Queued);
+    }
+
+    private static OrchestratorDispatchQueue CreateQueue(int maxConcurrentAgents)
+    {
+        return CreateQueue(new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents)));
+    }
+
+    private static OrchestratorDispatchQueue CreateQueue(IWorkflowOptionsProvider workflowOptionsProvider)
+    {
+        return new OrchestratorDispatchQueue(
+            workflowOptionsProvider,
+            TimeProvider.System,
+            NullLogger<OrchestratorDispatchQueue>.Instance);
+    }
+
+    private static DispatchWorkerBackgroundService CreateHostedService(
+        OrchestratorDispatchQueue queue,
+        IQueuedIssueWorker queuedIssueWorker)
+    {
+        return new DispatchWorkerBackgroundService(
+            queue,
+            queuedIssueWorker,
+            NullLogger<DispatchWorkerBackgroundService>.Instance);
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions(int maxConcurrentAgents)
+    {
+        return new WorkflowServiceOptions(
+            new WorkflowTrackerOptions(
+                "github",
+                "https://api.github.com",
+                "token",
+                null,
+                "owner/repo",
+                null,
+                null,
+                ["Todo"],
+                ["Done"]),
+            new WorkflowPollingOptions(1_000),
+            new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+            new WorkflowHookOptions(
+                null,
+                null,
+                null,
+                null,
+                60_000),
+            new WorkflowAgentOptions(
+                maxConcurrentAgents,
+                20,
+                300_000,
+                new Dictionary<string, int>(StringComparer.Ordinal)),
+            new WorkflowCodexOptions(
+                "codex app-server",
+                null,
+                null,
+                null,
+                3_600_000,
+                5_000,
+                300_000));
+    }
+
+    private static Issue CreateIssue(string id, string identifier)
+    {
+        return new Issue(
+            id,
+            identifier,
+            $"Issue {identifier}",
+            description: "Dispatch queue test",
+            state: "Todo",
+            createdAt: DateTimeOffset.UtcNow);
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class MutableWorkflowOptionsProvider(WorkflowServiceOptions current) : IWorkflowOptionsProvider
+    {
+        public WorkflowServiceOptions Current { get; set; } = current;
+
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Current);
+        }
+    }
+
+    private sealed class BlockingQueuedIssueWorker : IQueuedIssueWorker
+    {
+        private readonly TaskCompletionSource _allowCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ExecutionStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ExecutionCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task ExecuteAsync(Issue issue, int? attempt, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(issue);
+
+            ExecutionStarted.TrySetResult();
+            await _allowCompletion.Task.WaitAsync(cancellationToken);
+            ExecutionCompleted.TrySetResult();
+        }
+
+        public void AllowCompletion()
+        {
+            _allowCompletion.TrySetResult();
+        }
+    }
+}


### PR DESCRIPTION
#### Context

E3-S2 from SPEC.md needs a real dispatch coordination layer so polling can stage work safely and later stories can query queued and running execution state.

#### TL;DR

*Add a channel-backed dispatch queue, a semaphore concurrency gate, and status snapshots for queued and running work.*

#### Summary

- add orchestration contracts and application services for channel-backed dispatch and queued and running snapshots
- register a hosted dispatch worker and default no-op queued worker in application DI
- add application tests for queue visibility, duplicate claims, capacity gating, and dynamic concurrency refresh

#### Alternatives

- keep dispatch inline in the polling service, which would couple polling to execution and leave no reusable status surface
- wait until the agent runner story to add the queue, which would force later orchestration work to land without isolated queue tests

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added application tests for queued and running snapshots, duplicate claim rejection, max concurrency rejection, and future-dispatch concurrency refresh

Closes #16
