### PR TITLE
E3-S3: implement session registry and targeted cancellation

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -223,6 +223,8 @@ Notes:
 - The application layer keeps dispatch staging in a bounded in-memory channel and enforces
   `agent.max_concurrent_agents` with a semaphore-backed execution gate. Status consumers can read
   queued and running work directly from the in-memory dispatch snapshot.
+- Active sessions are tracked in-memory by normalized issue id, can expose live session metadata,
+  and support targeted reconciliation cancellation without affecting unrelated executions.
 - Per-issue workspaces live under `workspace.root` using a sanitized issue identifier that keeps
   only letters, digits, `.`, `_`, and `-`.
 - Workspace paths that resolve outside the configured `workspace.root` are rejected before any

--- a/dotnet/src/Symphony.Abstractions/Orchestration/ActiveSessionSnapshot.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/ActiveSessionSnapshot.cs
@@ -1,0 +1,14 @@
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+
+namespace Symphony.Abstractions.Orchestration;
+
+public sealed record ActiveSessionSnapshot(
+    string IssueId,
+    string IssueIdentifier,
+    string IssueState,
+    int? Attempt,
+    DateTimeOffset StartedAt,
+    RunAttemptStatus Status,
+    string? Error,
+    LiveSessionMetadata? Session);

--- a/dotnet/src/Symphony.Abstractions/Orchestration/IActiveSessionRegistry.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/IActiveSessionRegistry.cs
@@ -1,0 +1,8 @@
+namespace Symphony.Abstractions.Orchestration;
+
+public interface IActiveSessionRegistry
+{
+    IReadOnlyList<ActiveSessionSnapshot> GetActiveSessions();
+
+    bool TryCancelForReconciliation(string issueId, string? trackerState = null);
+}

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ public static class ApplicationServiceCollectionExtensions
         services.TryAddSingleton<OrchestratorDispatchQueue>();
         services.TryAddSingleton<IOrchestratorDispatchQueue>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());
         services.TryAddSingleton<IOrchestratorDispatchStatusReader>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());
+        services.TryAddSingleton<ActiveSessionRegistry>();
+        services.TryAddSingleton<IActiveSessionRegistry>(serviceProvider => serviceProvider.GetRequiredService<ActiveSessionRegistry>());
         services.TryAddSingleton<IQueuedIssueWorker, NoOpQueuedIssueWorker>();
         services.TryAddSingleton<IPollingIterationHandler, NoOpPollingIterationHandler>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DispatchWorkerBackgroundService>());

--- a/dotnet/src/Symphony.Application/Orchestration/ActiveSessionRegistry.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/ActiveSessionRegistry.cs
@@ -1,0 +1,227 @@
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Orchestration;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class ActiveSessionRegistry(
+    TimeProvider timeProvider,
+    ILogger<ActiveSessionRegistry> logger) : IActiveSessionRegistry
+{
+    private readonly Lock _stateLock = new();
+    private readonly Dictionary<string, ActiveSessionEntry> _activeSessions = new(StringComparer.Ordinal);
+
+    public IReadOnlyList<ActiveSessionSnapshot> GetActiveSessions()
+    {
+        lock (_stateLock)
+        {
+            return _activeSessions.Values
+                .OrderBy(entry => entry.StartedAt)
+                .Select(CreateSnapshot)
+                .ToArray();
+        }
+    }
+
+    public bool TryCancelForReconciliation(string issueId, string? trackerState = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueId);
+
+        ActiveSessionEntry? entry;
+        lock (_stateLock)
+        {
+            _activeSessions.TryGetValue(NormalizeIssueId(issueId), out entry);
+
+            if (entry is null)
+            {
+                return false;
+            }
+
+            entry.Status = RunAttemptStatus.CanceledByReconciliation;
+            entry.Error = trackerState is null
+                ? "Session canceled after reconciliation determined the issue is no longer eligible."
+                : $"Session canceled after reconciliation transitioned the issue to '{trackerState}'.";
+            entry.CanceledByReconciliation = true;
+        }
+
+        logger.LogInformation(
+            "session_cancellation requested issue_id={IssueId} issue_identifier={IssueIdentifier} session_id={SessionId} tracker_state={TrackerState} outcome=completed",
+            entry.Issue.Id,
+            entry.Issue.Identifier,
+            entry.Session?.SessionId,
+            trackerState ?? "unknown");
+
+        entry.CancellationTokenSource.Cancel();
+        return true;
+    }
+
+    public TrackedActiveSession BeginSession(Issue issue, int? attempt, CancellationToken hostCancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        var normalizedIssueId = NormalizeIssueId(issue.Id);
+        var startedAt = timeProvider.GetUtcNow();
+        var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken);
+        var entry = new ActiveSessionEntry(issue, attempt, startedAt, cancellationTokenSource)
+        {
+            Status = RunAttemptStatus.InitializingSession
+        };
+
+        lock (_stateLock)
+        {
+            if (!_activeSessions.TryAdd(normalizedIssueId, entry))
+            {
+                cancellationTokenSource.Dispose();
+                throw new InvalidOperationException(
+                    $"An active session for issue '{issue.Id}' is already registered.");
+            }
+        }
+
+        logger.LogInformation(
+            "session_tracking started issue_id={IssueId} issue_identifier={IssueIdentifier} session_id={SessionId} outcome=started",
+            issue.Id,
+            issue.Identifier,
+            (string?)null);
+
+        return new TrackedActiveSession(this, normalizedIssueId, entry);
+    }
+
+    private void UpdateSession(ActiveSessionEntry entry, LiveSessionMetadata session)
+    {
+        lock (_stateLock)
+        {
+            entry.Session = session;
+        }
+
+        logger.LogInformation(
+            "session_tracking updated issue_id={IssueId} issue_identifier={IssueIdentifier} session_id={SessionId} outcome=completed",
+            entry.Issue.Id,
+            entry.Issue.Identifier,
+            session.SessionId);
+    }
+
+    private void UpdateStatus(ActiveSessionEntry entry, RunAttemptStatus status, string? error)
+    {
+        lock (_stateLock)
+        {
+            entry.Status = status;
+            entry.Error = string.IsNullOrWhiteSpace(error) ? null : error.Trim();
+        }
+
+        logger.LogInformation(
+            "session_status changed issue_id={IssueId} issue_identifier={IssueIdentifier} session_id={SessionId} status={Status} outcome=completed",
+            entry.Issue.Id,
+            entry.Issue.Identifier,
+            entry.Session?.SessionId,
+            status);
+    }
+
+    private bool WasCanceledByReconciliation(ActiveSessionEntry entry)
+    {
+        lock (_stateLock)
+        {
+            return entry.CanceledByReconciliation;
+        }
+    }
+
+    private void Complete(string normalizedIssueId, ActiveSessionEntry entry)
+    {
+        lock (_stateLock)
+        {
+            _activeSessions.Remove(normalizedIssueId);
+        }
+
+        logger.LogInformation(
+            "session_tracking completed issue_id={IssueId} issue_identifier={IssueIdentifier} session_id={SessionId} status={Status} outcome=completed",
+            entry.Issue.Id,
+            entry.Issue.Identifier,
+            entry.Session?.SessionId,
+            entry.Status);
+
+        entry.CancellationTokenSource.Dispose();
+    }
+
+    private static ActiveSessionSnapshot CreateSnapshot(ActiveSessionEntry entry)
+    {
+        return new ActiveSessionSnapshot(
+            entry.Issue.Id,
+            entry.Issue.Identifier,
+            entry.Issue.State,
+            entry.Attempt,
+            entry.StartedAt,
+            entry.Status,
+            entry.Error,
+            entry.Session);
+    }
+
+    private static string NormalizeIssueId(string issueId)
+    {
+        return issueId.Trim().ToUpperInvariant();
+    }
+
+    public sealed class TrackedActiveSession : IDisposable
+    {
+        private readonly ActiveSessionRegistry _owner;
+        private readonly string _normalizedIssueId;
+        private readonly ActiveSessionEntry _entry;
+        private int _disposed;
+
+        internal TrackedActiveSession(
+            ActiveSessionRegistry owner,
+            string normalizedIssueId,
+            ActiveSessionEntry entry)
+        {
+            _owner = owner;
+            _normalizedIssueId = normalizedIssueId;
+            _entry = entry;
+        }
+
+        public CancellationToken CancellationToken => _entry.CancellationTokenSource.Token;
+
+        public bool WasCanceledByReconciliation => _owner.WasCanceledByReconciliation(_entry);
+
+        public QueuedIssueExecutionContext CreateExecutionContext()
+        {
+            return new QueuedIssueExecutionContext(
+                _entry.Issue,
+                _entry.Attempt,
+                CancellationToken,
+                session => _owner.UpdateSession(_entry, session),
+                (status, error) => _owner.UpdateStatus(_entry, status, error));
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _owner.Complete(_normalizedIssueId, _entry);
+        }
+    }
+
+    internal sealed class ActiveSessionEntry(
+        Issue issue,
+        int? attempt,
+        DateTimeOffset startedAt,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        public Issue Issue { get; } = issue;
+
+        public int? Attempt { get; } = attempt;
+
+        public DateTimeOffset StartedAt { get; } = startedAt;
+
+        public CancellationTokenSource CancellationTokenSource { get; } = cancellationTokenSource;
+
+        public RunAttemptStatus Status { get; set; }
+
+        public string? Error { get; set; }
+
+        public LiveSessionMetadata? Session { get; set; }
+
+        public bool CanceledByReconciliation { get; set; }
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Symphony.Domain.Runs;
 
 namespace Symphony.Application.Orchestration;
 
 public sealed class DispatchWorkerBackgroundService(
     OrchestratorDispatchQueue dispatchQueue,
+    ActiveSessionRegistry activeSessionRegistry,
     IQueuedIssueWorker queuedIssueWorker,
     ILogger<DispatchWorkerBackgroundService> logger) : BackgroundService
 {
@@ -54,10 +56,19 @@ public sealed class DispatchWorkerBackgroundService(
         CancellationToken cancellationToken)
     {
         using var executionLease = dispatchQueue.BeginExecution(workItem);
+        using var activeSession = activeSessionRegistry.BeginSession(workItem.Issue, workItem.Attempt, cancellationToken);
+        var executionContext = activeSession.CreateExecutionContext();
 
         try
         {
-            await queuedIssueWorker.ExecuteAsync(workItem.Issue, workItem.Attempt, cancellationToken).ConfigureAwait(false);
+            await queuedIssueWorker.ExecuteAsync(executionContext).ConfigureAwait(false);
+            executionContext.UpdateStatus(RunAttemptStatus.Succeeded);
+        }
+        catch (OperationCanceledException) when (activeSession.WasCanceledByReconciliation)
+        {
+            executionContext.UpdateStatus(
+                RunAttemptStatus.CanceledByReconciliation,
+                "Execution canceled after reconciliation marked the issue ineligible.");
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -67,6 +78,7 @@ public sealed class DispatchWorkerBackgroundService(
         }
         catch (Exception exception)
         {
+            executionContext.UpdateStatus(RunAttemptStatus.Failed, exception.Message);
             logger.LogError(
                 exception,
                 "Queued execution for issue {IssueIdentifier} failed.",

--- a/dotnet/src/Symphony.Application/Orchestration/IQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/IQueuedIssueWorker.cs
@@ -1,8 +1,6 @@
-using Symphony.Domain.Issues;
-
 namespace Symphony.Application.Orchestration;
 
 public interface IQueuedIssueWorker
 {
-    Task ExecuteAsync(Issue issue, int? attempt, CancellationToken cancellationToken);
+    Task ExecuteAsync(QueuedIssueExecutionContext context);
 }

--- a/dotnet/src/Symphony.Application/Orchestration/NoOpQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/NoOpQueuedIssueWorker.cs
@@ -1,12 +1,10 @@
-using Symphony.Domain.Issues;
-
 namespace Symphony.Application.Orchestration;
 
 public sealed class NoOpQueuedIssueWorker : IQueuedIssueWorker
 {
-    public Task ExecuteAsync(Issue issue, int? attempt, CancellationToken cancellationToken)
+    public Task ExecuteAsync(QueuedIssueExecutionContext context)
     {
-        ArgumentNullException.ThrowIfNull(issue);
+        ArgumentNullException.ThrowIfNull(context);
 
         return Task.CompletedTask;
     }

--- a/dotnet/src/Symphony.Application/Orchestration/QueuedIssueExecutionContext.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/QueuedIssueExecutionContext.cs
@@ -1,0 +1,42 @@
+using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class QueuedIssueExecutionContext
+{
+    private readonly Action<LiveSessionMetadata> _updateSession;
+    private readonly Action<RunAttemptStatus, string?> _updateStatus;
+
+    internal QueuedIssueExecutionContext(
+        Issue issue,
+        int? attempt,
+        CancellationToken cancellationToken,
+        Action<LiveSessionMetadata> updateSession,
+        Action<RunAttemptStatus, string?> updateStatus)
+    {
+        Issue = issue ?? throw new ArgumentNullException(nameof(issue));
+        Attempt = attempt;
+        CancellationToken = cancellationToken;
+        _updateSession = updateSession ?? throw new ArgumentNullException(nameof(updateSession));
+        _updateStatus = updateStatus ?? throw new ArgumentNullException(nameof(updateStatus));
+    }
+
+    public Issue Issue { get; }
+
+    public int? Attempt { get; }
+
+    public CancellationToken CancellationToken { get; }
+
+    public void UpdateSession(LiveSessionMetadata session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        _updateSession(session);
+    }
+
+    public void UpdateStatus(RunAttemptStatus status, string? error = null)
+    {
+        _updateStatus(status, error);
+    }
+}

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -55,6 +55,7 @@ public class ApplicationServiceCollectionExtensionsTests
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<ApplicationServiceMarker>());
+        Assert.IsType<ActiveSessionRegistry>(serviceProvider.GetRequiredService<IActiveSessionRegistry>());
         Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchQueue>());
         Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchStatusReader>());
         Assert.IsType<NoOpQueuedIssueWorker>(serviceProvider.GetRequiredService<IQueuedIssueWorker>());

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/ActiveSessionRegistryTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/ActiveSessionRegistryTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+
+namespace Symphony.Application.Tests.Orchestration;
+
+public sealed class ActiveSessionRegistryTests
+{
+    [Fact]
+    public void BeginSession_tracks_active_sessions_by_normalized_issue_id()
+    {
+        var registry = CreateRegistry();
+        using var trackedSession = registry.BeginSession(CreateIssue("AbC-123", "ABC-123"), attempt: null, CancellationToken.None);
+
+        Assert.True(registry.TryCancelForReconciliation("abc-123", "Done"));
+        Assert.True(trackedSession.WasCanceledByReconciliation);
+        Assert.True(trackedSession.CancellationToken.IsCancellationRequested);
+
+        var snapshot = Assert.Single(registry.GetActiveSessions());
+        Assert.Equal("AbC-123", snapshot.IssueId);
+        Assert.Equal(RunAttemptStatus.CanceledByReconciliation, snapshot.Status);
+    }
+
+    [Fact]
+    public void TryCancelForReconciliation_cancels_matching_session_only()
+    {
+        var registry = CreateRegistry();
+        using var firstSession = registry.BeginSession(CreateIssue("ABC-1", "ABC-1"), attempt: null, CancellationToken.None);
+        using var secondSession = registry.BeginSession(CreateIssue("ABC-2", "ABC-2"), attempt: 2, CancellationToken.None);
+
+        Assert.True(registry.TryCancelForReconciliation("abc-2", "Canceled"));
+        Assert.False(firstSession.CancellationToken.IsCancellationRequested);
+        Assert.True(secondSession.CancellationToken.IsCancellationRequested);
+
+        var snapshots = registry.GetActiveSessions().OrderBy(snapshot => snapshot.IssueIdentifier).ToArray();
+        Assert.Equal(RunAttemptStatus.InitializingSession, snapshots[0].Status);
+        Assert.Equal(RunAttemptStatus.CanceledByReconciliation, snapshots[1].Status);
+    }
+
+    [Fact]
+    public void ExecutionContext_updates_session_metadata_and_status_snapshot()
+    {
+        var registry = CreateRegistry();
+        using var trackedSession = registry.BeginSession(CreateIssue("ABC-9", "ABC-9"), attempt: 1, CancellationToken.None);
+        var context = trackedSession.CreateExecutionContext();
+
+        context.UpdateStatus(RunAttemptStatus.StreamingTurn);
+        context.UpdateSession(
+            new LiveSessionMetadata(
+                "thread-9",
+                "turn-1",
+                codexAppServerPid: "1234",
+                lastCodexEvent: "turn_started",
+                lastCodexTimestamp: DateTimeOffset.UtcNow,
+                lastCodexMessage: "Session started",
+                codexInputTokens: 10,
+                codexOutputTokens: 20,
+                codexTotalTokens: 30,
+                lastReportedInputTokens: 10,
+                lastReportedOutputTokens: 20,
+                lastReportedTotalTokens: 30,
+                turnCount: 1));
+
+        var snapshot = Assert.Single(registry.GetActiveSessions());
+
+        Assert.Equal(RunAttemptStatus.StreamingTurn, snapshot.Status);
+        Assert.NotNull(snapshot.Session);
+        Assert.Equal("thread-9-turn-1", snapshot.Session!.SessionId);
+        Assert.Equal(1, snapshot.Session.TurnCount);
+    }
+
+    private static ActiveSessionRegistry CreateRegistry()
+    {
+        return new ActiveSessionRegistry(TimeProvider.System, NullLogger<ActiveSessionRegistry>.Instance);
+    }
+
+    private static Issue CreateIssue(string id, string identifier)
+    {
+        return new Issue(
+            id,
+            identifier,
+            $"Issue {identifier}",
+            description: "Active session registry test",
+            state: "In Progress",
+            createdAt: DateTimeOffset.UtcNow);
+    }
+}

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
@@ -3,6 +3,7 @@ using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
 using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
 
 namespace Symphony.Application.Tests.Orchestration;
 
@@ -13,7 +14,8 @@ public sealed class OrchestratorDispatchQueueTests
     {
         var queue = CreateQueue(maxConcurrentAgents: 1);
         var worker = new BlockingQueuedIssueWorker();
-        var hostedService = CreateHostedService(queue, worker);
+        var registry = CreateRegistry();
+        var hostedService = CreateHostedService(queue, registry, worker);
         var issue = CreateIssue("1", "ABC-1");
 
         var enqueueResult = await queue.QueueAsync(issue);
@@ -30,7 +32,7 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Single(runningSnapshot.Running);
         Assert.Equal("ABC-1", runningSnapshot.Running[0].IssueIdentifier);
 
-        worker.AllowCompletion();
+        worker.AllowCompletion("ABC-1");
         await worker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await hostedService.StopAsync(CancellationToken.None);
 
@@ -47,7 +49,8 @@ public sealed class OrchestratorDispatchQueueTests
     {
         var queue = CreateQueue(maxConcurrentAgents: 1);
         var worker = new BlockingQueuedIssueWorker();
-        var hostedService = CreateHostedService(queue, worker);
+        var registry = CreateRegistry();
+        var hostedService = CreateHostedService(queue, registry, worker);
 
         await hostedService.StartAsync(CancellationToken.None);
 
@@ -59,7 +62,7 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal(DispatchEnqueueResult.NoCapacity, secondResult);
         Assert.Equal(0, queue.GetSnapshot().AvailableSlots);
 
-        worker.AllowCompletion();
+        worker.AllowCompletion("ABC-1");
         await worker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await hostedService.StopAsync(CancellationToken.None);
     }
@@ -70,7 +73,8 @@ public sealed class OrchestratorDispatchQueueTests
         var optionsProvider = new MutableWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents: 1));
         var queue = CreateQueue(optionsProvider);
         var firstWorker = new BlockingQueuedIssueWorker();
-        var firstHostedService = CreateHostedService(queue, firstWorker);
+        var registry = CreateRegistry();
+        var firstHostedService = CreateHostedService(queue, registry, firstWorker);
 
         await firstHostedService.StartAsync(CancellationToken.None);
         await queue.QueueAsync(CreateIssue("1", "ABC-1"));
@@ -83,7 +87,7 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal(DispatchEnqueueResult.Enqueued, secondResult);
         Assert.Equal(2, queue.GetSnapshot().MaxConcurrentAgents);
 
-        firstWorker.AllowCompletion();
+        firstWorker.AllowCompletion("ABC-1");
         await firstWorker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await firstHostedService.StopAsync(CancellationToken.None);
     }
@@ -101,6 +105,35 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Single(queue.GetSnapshot().Queued);
     }
 
+    [Fact]
+    public async Task DispatchWorker_uses_active_session_registry_for_targeted_cancellation()
+    {
+        var queue = CreateQueue(maxConcurrentAgents: 2);
+        var registry = CreateRegistry();
+        var worker = new BlockingQueuedIssueWorker();
+        var hostedService = CreateHostedService(queue, registry, worker);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("ABC-1", "ABC-1"));
+        await queue.QueueAsync(CreateIssue("ABC-2", "ABC-2"));
+        await worker.WaitForStartsAsync(2, TimeSpan.FromSeconds(2));
+
+        Assert.True(registry.TryCancelForReconciliation("abc-2", "Done"));
+        await worker.WaitForCancellationAsync("ABC-2", TimeSpan.FromSeconds(2));
+
+        Assert.DoesNotContain(
+            worker.CancellationLog,
+            entry => string.Equals(entry, "ABC-1", StringComparison.Ordinal));
+        Assert.Contains(
+            registry.GetActiveSessions(),
+            session => session.IssueIdentifier == "ABC-1" && session.Status == RunAttemptStatus.InitializingSession);
+
+        worker.AllowCompletion("ABC-1");
+        await worker.WaitForCompletionAsync("ABC-1", TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+        Assert.Empty(registry.GetActiveSessions());
+    }
+
     private static OrchestratorDispatchQueue CreateQueue(int maxConcurrentAgents)
     {
         return CreateQueue(new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents)));
@@ -116,12 +149,19 @@ public sealed class OrchestratorDispatchQueueTests
 
     private static DispatchWorkerBackgroundService CreateHostedService(
         OrchestratorDispatchQueue queue,
+        ActiveSessionRegistry registry,
         IQueuedIssueWorker queuedIssueWorker)
     {
         return new DispatchWorkerBackgroundService(
             queue,
+            registry,
             queuedIssueWorker,
             NullLogger<DispatchWorkerBackgroundService>.Instance);
+    }
+
+    private static ActiveSessionRegistry CreateRegistry()
+    {
+        return new ActiveSessionRegistry(TimeProvider.System, NullLogger<ActiveSessionRegistry>.Instance);
     }
 
     private static WorkflowServiceOptions CreateWorkflowOptions(int maxConcurrentAgents)
@@ -191,24 +231,99 @@ public sealed class OrchestratorDispatchQueueTests
 
     private sealed class BlockingQueuedIssueWorker : IQueuedIssueWorker
     {
-        private readonly TaskCompletionSource _allowCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly Lock _lock = new();
+        private readonly Dictionary<string, TaskCompletionSource> _allowCompletionByIssue = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TaskCompletionSource> _completionByIssue = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TaskCompletionSource> _cancellationByIssue = new(StringComparer.Ordinal);
+        private readonly TaskCompletionSource _allStarts = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _startCount;
+
+        public List<string> CancellationLog { get; } = [];
 
         public TaskCompletionSource ExecutionStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public TaskCompletionSource ExecutionCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public async Task ExecuteAsync(Issue issue, int? attempt, CancellationToken cancellationToken)
+        public async Task ExecuteAsync(QueuedIssueExecutionContext context)
         {
-            ArgumentNullException.ThrowIfNull(issue);
+            ArgumentNullException.ThrowIfNull(context);
 
+            lock (_lock)
+            {
+                _allowCompletionByIssue[context.Issue.Identifier] = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _completionByIssue[context.Issue.Identifier] = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _cancellationByIssue[context.Issue.Identifier] = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            var currentCount = Interlocked.Increment(ref _startCount);
             ExecutionStarted.TrySetResult();
-            await _allowCompletion.Task.WaitAsync(cancellationToken);
-            ExecutionCompleted.TrySetResult();
+            if (currentCount >= 2)
+            {
+                _allStarts.TrySetResult();
+            }
+
+            try
+            {
+                await GetAllowCompletion(context.Issue.Identifier).Task.WaitAsync(context.CancellationToken);
+                GetCompletion(context.Issue.Identifier).TrySetResult();
+                ExecutionCompleted.TrySetResult();
+            }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                lock (_lock)
+                {
+                    CancellationLog.Add(context.Issue.Identifier);
+                }
+
+                GetCancellation(context.Issue.Identifier).TrySetResult();
+                throw;
+            }
         }
 
-        public void AllowCompletion()
+        public void AllowCompletion(string issueIdentifier)
         {
-            _allowCompletion.TrySetResult();
+            GetAllowCompletion(issueIdentifier).TrySetResult();
+        }
+
+        public Task WaitForStartsAsync(int expectedCount, TimeSpan timeout)
+        {
+            return expectedCount <= 1
+                ? ExecutionStarted.Task.WaitAsync(timeout)
+                : _allStarts.Task.WaitAsync(timeout);
+        }
+
+        public Task WaitForCancellationAsync(string issueIdentifier, TimeSpan timeout)
+        {
+            return GetCancellation(issueIdentifier).Task.WaitAsync(timeout);
+        }
+
+        public Task WaitForCompletionAsync(string issueIdentifier, TimeSpan timeout)
+        {
+            return GetCompletion(issueIdentifier).Task.WaitAsync(timeout);
+        }
+
+        private TaskCompletionSource GetAllowCompletion(string issueIdentifier)
+        {
+            lock (_lock)
+            {
+                return _allowCompletionByIssue[issueIdentifier];
+            }
+        }
+
+        private TaskCompletionSource GetCompletion(string issueIdentifier)
+        {
+            lock (_lock)
+            {
+                return _completionByIssue[issueIdentifier];
+            }
+        }
+
+        private TaskCompletionSource GetCancellation(string issueIdentifier)
+        {
+            lock (_lock)
+            {
+                return _cancellationByIssue[issueIdentifier];
+            }
         }
     }
 }


### PR DESCRIPTION
#### Context

E3-S3 from SPEC.md needs active sessions to be tracked independently of the dispatch queue so reconciliation can cancel only the matching execution and later status surfaces can read live session state.

#### TL;DR

*Add a normalized active-session registry, tracked execution contexts, and targeted reconciliation cancellation for queued work.*

#### Summary

- add active session registry contracts and snapshots keyed by normalized issue id
- route queued worker execution through tracked contexts that carry cancellation, run status, and live session metadata updates
- add application tests for normalized registration, metadata updates, and targeted cancellation that only affects the matching issue

#### Alternatives

- keep session state embedded only in the dispatch queue, which would mix queue accounting with cancellation ownership and make targeted cancellation harder to evolve
- defer session tracking until the Codex runner story, which would leave reconciliation cancellation and session snapshots untested in the shared orchestration layer

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added application tests for normalized session registration, live session metadata snapshots, and targeted reconciliation cancellation through the dispatch worker

Closes #17
