### PR TITLE
E3-S4: implement orchestrator-managed retries

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -223,6 +223,9 @@ Notes:
 - The application layer keeps dispatch staging in a bounded in-memory channel and enforces
   `agent.max_concurrent_agents` with a semaphore-backed execution gate. Status consumers can read
   queued and running work directly from the in-memory dispatch snapshot.
+- Successful worker exits schedule a one-second continuation retry. Failed worker exits are retried
+  with exponential backoff starting at 10 seconds, capped by `agent.max_retry_backoff_ms`, and are
+  surfaced through the in-memory retry snapshot.
 - Active sessions are tracked in-memory by normalized issue id, can expose live session metadata,
   and support targeted reconciliation cancellation without affecting unrelated executions.
 - Per-issue workspaces live under `workspace.root` using a sanitized issue identifier that keeps

--- a/dotnet/src/Symphony.Abstractions/Orchestration/DispatchQueueSnapshot.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/DispatchQueueSnapshot.cs
@@ -3,6 +3,7 @@ namespace Symphony.Abstractions.Orchestration;
 public sealed record DispatchQueueSnapshot(
     IReadOnlyList<QueuedDispatchSnapshot> Queued,
     IReadOnlyList<RunningDispatchSnapshot> Running,
+    IReadOnlyList<RetryDispatchSnapshot> Retrying,
     int MaxConcurrentAgents,
     int AvailableSlots);
 
@@ -19,3 +20,10 @@ public sealed record RunningDispatchSnapshot(
     string IssueState,
     int? Attempt,
     DateTimeOffset StartedAt);
+
+public sealed record RetryDispatchSnapshot(
+    string IssueId,
+    string IssueIdentifier,
+    int Attempt,
+    DateTimeOffset DueAt,
+    string? Error);

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ApplicationServiceCollectionExtensions
 
         services.AddSingleton<ApplicationServiceMarker>();
         services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<RetryDelayPlanner>();
         services.TryAddSingleton<OrchestratorDispatchQueue>();
         services.TryAddSingleton<IOrchestratorDispatchQueue>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());
         services.TryAddSingleton<IOrchestratorDispatchStatusReader>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());
@@ -23,6 +24,7 @@ public static class ApplicationServiceCollectionExtensions
         services.TryAddSingleton<IQueuedIssueWorker, NoOpQueuedIssueWorker>();
         services.TryAddSingleton<IPollingIterationHandler, NoOpPollingIterationHandler>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DispatchWorkerBackgroundService>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, RetryDispatchBackgroundService>());
 
         return services;
     }

--- a/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
@@ -63,6 +63,8 @@ public sealed class DispatchWorkerBackgroundService(
         {
             await queuedIssueWorker.ExecuteAsync(executionContext).ConfigureAwait(false);
             executionContext.UpdateStatus(RunAttemptStatus.Succeeded);
+            await dispatchQueue.ScheduleContinuationRetryAsync(workItem, cancellationToken).ConfigureAwait(false);
+            executionLease.PreserveClaimForRetry();
         }
         catch (OperationCanceledException) when (activeSession.WasCanceledByReconciliation)
         {
@@ -76,6 +78,14 @@ public sealed class DispatchWorkerBackgroundService(
                 "Queued execution for issue {IssueIdentifier} was canceled during shutdown.",
                 workItem.Issue.Identifier);
         }
+        catch (NonTransientIssueExecutionException exception)
+        {
+            executionContext.UpdateStatus(RunAttemptStatus.Failed, exception.Message);
+            logger.LogWarning(
+                exception,
+                "Queued execution for issue {IssueIdentifier} failed with a non-transient error and will not be retried.",
+                workItem.Issue.Identifier);
+        }
         catch (Exception exception)
         {
             executionContext.UpdateStatus(RunAttemptStatus.Failed, exception.Message);
@@ -83,6 +93,8 @@ public sealed class DispatchWorkerBackgroundService(
                 exception,
                 "Queued execution for issue {IssueIdentifier} failed.",
                 workItem.Issue.Identifier);
+            await dispatchQueue.ScheduleFailureRetryAsync(workItem, exception, cancellationToken).ConfigureAwait(false);
+            executionLease.PreserveClaimForRetry();
         }
     }
 }

--- a/dotnet/src/Symphony.Application/Orchestration/NonTransientIssueExecutionException.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/NonTransientIssueExecutionException.cs
@@ -1,0 +1,14 @@
+namespace Symphony.Application.Orchestration;
+
+public sealed class NonTransientIssueExecutionException : Exception
+{
+    public NonTransientIssueExecutionException(string message)
+        : base(message)
+    {
+    }
+
+    public NonTransientIssueExecutionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/OrchestratorDispatchQueue.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/OrchestratorDispatchQueue.cs
@@ -8,6 +8,7 @@ namespace Symphony.Application.Orchestration;
 
 public sealed class OrchestratorDispatchQueue(
     IWorkflowOptionsProvider workflowOptionsProvider,
+    RetryDelayPlanner retryDelayPlanner,
     TimeProvider timeProvider,
     ILogger<OrchestratorDispatchQueue> logger) : IOrchestratorDispatchQueue, IOrchestratorDispatchStatusReader
 {
@@ -25,7 +26,9 @@ public sealed class OrchestratorDispatchQueue(
     private readonly Lock _stateLock = new();
     private readonly Dictionary<string, QueuedDispatchEntry> _queued = new(StringComparer.Ordinal);
     private readonly Dictionary<string, RunningDispatchEntry> _running = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, RetryDispatchEntry> _retrying = new(StringComparer.Ordinal);
     private readonly HashSet<string> _claimed = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _retrySignal = new(0, int.MaxValue);
 
     private SemaphoreSlim? _concurrencyGate;
     private int _configuredConcurrency;
@@ -43,16 +46,233 @@ public sealed class OrchestratorDispatchQueue(
             throw new ArgumentOutOfRangeException(nameof(attempt), attempt, "Attempt must be null or greater than zero.");
         }
 
+        return await QueueInternalAsync(issue, attempt, claimRequired: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    public DispatchQueueSnapshot GetSnapshot()
+    {
+        lock (_stateLock)
+        {
+            return new DispatchQueueSnapshot(
+                _queued.Values
+                    .OrderBy(entry => entry.QueuedAt)
+                    .Select(
+                        entry => new QueuedDispatchSnapshot(
+                            entry.Issue.Id,
+                            entry.Issue.Identifier,
+                            entry.Issue.State,
+                            entry.Attempt,
+                            entry.QueuedAt))
+                    .ToArray(),
+                _running.Values
+                    .OrderBy(entry => entry.StartedAt)
+                    .Select(
+                        entry => new RunningDispatchSnapshot(
+                            entry.Issue.Id,
+                            entry.Issue.Identifier,
+                            entry.Issue.State,
+                            entry.Attempt,
+                            entry.StartedAt))
+                    .ToArray(),
+                _retrying.Values
+                    .OrderBy(entry => entry.DueAt)
+                    .Select(
+                        entry => new RetryDispatchSnapshot(
+                            entry.Issue.Id,
+                            entry.Issue.Identifier,
+                            entry.Attempt,
+                            entry.DueAt,
+                            entry.Error))
+                    .ToArray(),
+                _configuredConcurrency,
+                Math.Max(_configuredConcurrency - _queued.Count - _running.Count, 0));
+        }
+    }
+
+    internal IAsyncEnumerable<DispatchQueueWorkItem> ReadAllAsync(CancellationToken cancellationToken)
+    {
+        return _dispatchChannel.Reader.ReadAllAsync(cancellationToken);
+    }
+
+    internal ExecutionLease BeginExecution(DispatchQueueWorkItem workItem)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+
+        var startedAt = timeProvider.GetUtcNow();
+
+        lock (_stateLock)
+        {
+            _queued.Remove(workItem.Issue.Id);
+            _running[workItem.Issue.Id] = new RunningDispatchEntry(workItem.Issue, workItem.Attempt, startedAt);
+        }
+
+        logger.LogInformation(
+            "Started queued execution for issue {IssueIdentifier} at {StartedAt}.",
+            workItem.Issue.Identifier,
+            startedAt);
+
+        return new ExecutionLease(this, workItem.Issue);
+    }
+
+    internal async Task ScheduleContinuationRetryAsync(
+        DispatchQueueWorkItem workItem,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+
+        var delay = retryDelayPlanner.GetContinuationDelay();
+        await ScheduleRetryInternalAsync(
+                workItem.Issue,
+                attempt: 1,
+                dueAt: timeProvider.GetUtcNow().Add(delay),
+                error: null,
+                logReason: "continuation",
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    internal async Task ScheduleFailureRetryAsync(
+        DispatchQueueWorkItem workItem,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var nextAttempt = workItem.Attempt is null
+            ? 1
+            : workItem.Attempt.Value + 1;
+        var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var delay = await retryDelayPlanner.GetFailureDelayAsync(
+                nextAttempt,
+                workflowOptions.Agent.MaxRetryBackoffMs,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        await ScheduleRetryInternalAsync(
+                workItem.Issue,
+                nextAttempt,
+                timeProvider.GetUtcNow().Add(delay),
+                exception.Message,
+                "failure",
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    internal void ReleaseClaim(string issueId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueId);
+
+        lock (_stateLock)
+        {
+            _retrying.Remove(issueId);
+            _claimed.Remove(issueId);
+        }
+    }
+
+    internal TimeSpan? GetTimeUntilNextRetry()
+    {
+        lock (_stateLock)
+        {
+            if (_retrying.Count == 0)
+            {
+                return null;
+            }
+
+            var now = timeProvider.GetUtcNow();
+            var nextDueAt = _retrying.Values.Min(entry => entry.DueAt);
+            return nextDueAt <= now ? TimeSpan.Zero : nextDueAt - now;
+        }
+    }
+
+    internal Task WaitForRetrySignalAsync(CancellationToken cancellationToken)
+    {
+        return _retrySignal.WaitAsync(cancellationToken);
+    }
+
+    internal async Task ProcessDueRetriesAsync(CancellationToken cancellationToken)
+    {
+        RetryDispatchEntry[] dueEntries;
+        lock (_stateLock)
+        {
+            var now = timeProvider.GetUtcNow();
+            dueEntries = _retrying.Values
+                .Where(entry => entry.DueAt <= now)
+                .OrderBy(entry => entry.DueAt)
+                .ToArray();
+
+            foreach (var dueEntry in dueEntries)
+            {
+                _retrying.Remove(dueEntry.Issue.Id);
+            }
+        }
+
+        foreach (var dueEntry in dueEntries)
+        {
+            var enqueueResult = await QueueInternalAsync(
+                    dueEntry.Issue,
+                    dueEntry.Attempt,
+                    claimRequired: false,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (enqueueResult == DispatchEnqueueResult.Enqueued)
+            {
+                logger.LogInformation(
+                    "Scheduled retry attempt {Attempt} for issue {IssueIdentifier} became ready for dispatch.",
+                    dueEntry.Attempt,
+                    dueEntry.Issue.Identifier);
+                continue;
+            }
+
+            if (enqueueResult == DispatchEnqueueResult.NoCapacity)
+            {
+                var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+                var nextAttempt = dueEntry.Attempt + 1;
+                var delay = await retryDelayPlanner.GetFailureDelayAsync(
+                        nextAttempt,
+                        workflowOptions.Agent.MaxRetryBackoffMs,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                await ScheduleRetryInternalAsync(
+                        dueEntry.Issue,
+                        nextAttempt,
+                        timeProvider.GetUtcNow().Add(delay),
+                        "no available orchestrator slots",
+                        "capacity",
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                continue;
+            }
+
+            ReleaseClaim(dueEntry.Issue.Id);
+        }
+    }
+
+    private async ValueTask<DispatchEnqueueResult> QueueInternalAsync(
+        Issue issue,
+        int? attempt,
+        bool claimRequired,
+        CancellationToken cancellationToken)
+    {
         await RefreshConcurrencyGateAsync(cancellationToken).ConfigureAwait(false);
 
         lock (_stateLock)
         {
-            if (_claimed.Contains(issue.Id))
+            if (claimRequired)
             {
-                logger.LogDebug(
-                    "Issue {IssueIdentifier} is already claimed and will not be enqueued again.",
-                    issue.Identifier);
+                if (_claimed.Contains(issue.Id))
+                {
+                    logger.LogDebug(
+                        "Issue {IssueIdentifier} is already claimed and will not be enqueued again.",
+                        issue.Identifier);
 
+                    return DispatchEnqueueResult.AlreadyClaimed;
+                }
+            }
+            else if (_queued.ContainsKey(issue.Id) || _running.ContainsKey(issue.Id) || _retrying.ContainsKey(issue.Id))
+            {
                 return DispatchEnqueueResult.AlreadyClaimed;
             }
         }
@@ -72,7 +292,7 @@ public sealed class OrchestratorDispatchQueue(
 
         lock (_stateLock)
         {
-            if (!_claimed.Add(issue.Id))
+            if (claimRequired && !_claimed.Add(issue.Id))
             {
                 ReleaseExecutionSlot();
 
@@ -110,59 +330,34 @@ public sealed class OrchestratorDispatchQueue(
         }
     }
 
-    public DispatchQueueSnapshot GetSnapshot()
+    private Task ScheduleRetryInternalAsync(
+        Issue issue,
+        int attempt,
+        DateTimeOffset dueAt,
+        string? error,
+        string logReason,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         lock (_stateLock)
         {
-            return new DispatchQueueSnapshot(
-                _queued.Values
-                    .OrderBy(entry => entry.QueuedAt)
-                    .Select(
-                        entry => new QueuedDispatchSnapshot(
-                            entry.Issue.Id,
-                            entry.Issue.Identifier,
-                            entry.Issue.State,
-                            entry.Attempt,
-                            entry.QueuedAt))
-                    .ToArray(),
-                _running.Values
-                    .OrderBy(entry => entry.StartedAt)
-                    .Select(
-                        entry => new RunningDispatchSnapshot(
-                            entry.Issue.Id,
-                            entry.Issue.Identifier,
-                            entry.Issue.State,
-                            entry.Attempt,
-                            entry.StartedAt))
-                    .ToArray(),
-                _configuredConcurrency,
-                Math.Max(_configuredConcurrency - _queued.Count - _running.Count, 0));
+            _retrying[issue.Id] = new RetryDispatchEntry(issue, attempt, dueAt, string.IsNullOrWhiteSpace(error) ? null : error.Trim());
         }
-    }
 
-    internal IAsyncEnumerable<DispatchQueueWorkItem> ReadAllAsync(CancellationToken cancellationToken)
-    {
-        return _dispatchChannel.Reader.ReadAllAsync(cancellationToken);
-    }
-
-    internal IDisposable BeginExecution(DispatchQueueWorkItem workItem)
-    {
-        ArgumentNullException.ThrowIfNull(workItem);
-
-        var startedAt = timeProvider.GetUtcNow();
-
-        lock (_stateLock)
+        if (_retrySignal.CurrentCount == 0)
         {
-            _queued.Remove(workItem.Issue.Id);
-            _running[workItem.Issue.Id] = new RunningDispatchEntry(workItem.Issue, workItem.Attempt, startedAt);
+            _retrySignal.Release();
         }
 
         logger.LogInformation(
-            "Started queued execution for issue {IssueIdentifier} at {StartedAt}.",
-            workItem.Issue.Identifier,
-            startedAt);
+            "Scheduled retry attempt {Attempt} for issue {IssueIdentifier} due at {DueAt} ({Reason}).",
+            attempt,
+            issue.Identifier,
+            dueAt,
+            logReason);
 
-        return new ExecutionLease(this, workItem.Issue);
+        return Task.CompletedTask;
     }
 
     private async Task RefreshConcurrencyGateAsync(CancellationToken cancellationToken)
@@ -223,12 +418,15 @@ public sealed class OrchestratorDispatchQueue(
         }
     }
 
-    private void CompleteExecution(Issue issue)
+    private void CompleteExecution(Issue issue, bool releaseClaim)
     {
         lock (_stateLock)
         {
             _running.Remove(issue.Id);
-            _claimed.Remove(issue.Id);
+            if (releaseClaim)
+            {
+                _claimed.Remove(issue.Id);
+            }
         }
 
         ReleaseExecutionSlot();
@@ -263,9 +461,17 @@ public sealed class OrchestratorDispatchQueue(
 
     private sealed record RunningDispatchEntry(Issue Issue, int? Attempt, DateTimeOffset StartedAt);
 
-    private sealed class ExecutionLease(OrchestratorDispatchQueue owner, Issue issue) : IDisposable
+    private sealed record RetryDispatchEntry(Issue Issue, int Attempt, DateTimeOffset DueAt, string? Error);
+
+    internal sealed class ExecutionLease(OrchestratorDispatchQueue owner, Issue issue) : IDisposable
     {
         private int _disposed;
+        private bool _releaseClaim = true;
+
+        public void PreserveClaimForRetry()
+        {
+            _releaseClaim = false;
+        }
 
         public void Dispose()
         {
@@ -274,7 +480,7 @@ public sealed class OrchestratorDispatchQueue(
                 return;
             }
 
-            owner.CompleteExecution(issue);
+            owner.CompleteExecution(issue, _releaseClaim);
         }
     }
 }

--- a/dotnet/src/Symphony.Application/Orchestration/RetryDelayPlanner.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/RetryDelayPlanner.cs
@@ -1,0 +1,64 @@
+using Polly;
+using Polly.Retry;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class RetryDelayPlanner
+{
+    private static readonly RetryStrategyOptions DelayStrategy = new()
+    {
+        MaxRetryAttempts = int.MaxValue,
+        Delay = TimeSpan.FromSeconds(10),
+        BackoffType = DelayBackoffType.Exponential,
+        UseJitter = true
+    };
+
+    private readonly Func<double> _nextJitterSample;
+
+    public RetryDelayPlanner()
+        : this(() => Random.Shared.NextDouble())
+    {
+    }
+
+    public RetryDelayPlanner(Func<double> nextJitterSample)
+    {
+        _nextJitterSample = nextJitterSample ?? throw new ArgumentNullException(nameof(nextJitterSample));
+    }
+
+    public TimeSpan GetContinuationDelay()
+    {
+        return TimeSpan.FromSeconds(1);
+    }
+
+    public ValueTask<TimeSpan> GetFailureDelayAsync(
+        int attempt,
+        int maxRetryBackoffMs,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(attempt);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRetryBackoffMs);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(ComputeFailureDelay(attempt, maxRetryBackoffMs));
+    }
+
+    private TimeSpan ComputeFailureDelay(int attempt, int maxRetryBackoffMs)
+    {
+        var baseDelayMs = DelayStrategy.Delay.TotalMilliseconds;
+        var delayMs = DelayStrategy.BackoffType switch
+        {
+            DelayBackoffType.Exponential => baseDelayMs * Math.Pow(2d, attempt - 1),
+            DelayBackoffType.Linear => baseDelayMs * attempt,
+            _ => baseDelayMs
+        };
+
+        delayMs = Math.Min(delayMs, maxRetryBackoffMs);
+        if (DelayStrategy.UseJitter)
+        {
+            var jitterSample = Math.Clamp(_nextJitterSample(), 0d, 1d);
+            delayMs *= 0.5d + (0.5d * jitterSample);
+        }
+
+        return TimeSpan.FromMilliseconds(Math.Max(1d, Math.Min(delayMs, maxRetryBackoffMs)));
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/RetryDispatchBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/RetryDispatchBackgroundService.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class RetryDispatchBackgroundService(
+    OrchestratorDispatchQueue dispatchQueue,
+    TimeProvider timeProvider,
+    ILogger<RetryDispatchBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await dispatchQueue.ProcessDueRetriesAsync(stoppingToken).ConfigureAwait(false);
+
+                var delay = dispatchQueue.GetTimeUntilNextRetry();
+                if (delay is null)
+                {
+                    await dispatchQueue.WaitForRetrySignalAsync(stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (delay <= TimeSpan.Zero)
+                {
+                    continue;
+                }
+
+                var signalTask = dispatchQueue.WaitForRetrySignalAsync(stoppingToken);
+                var delayTask = Task.Delay(delay.Value, timeProvider, stoppingToken);
+                await Task.WhenAny(signalTask, delayTask).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            logger.LogDebug("Retry dispatch background service stopped during shutdown.");
+        }
+    }
+}

--- a/dotnet/src/Symphony.Application/Symphony.Application.csproj
+++ b/dotnet/src/Symphony.Application/Symphony.Application.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Polly.Core" Version="8.6.5" />
     <ProjectReference Include="..\Symphony.Domain\Symphony.Domain.csproj" />
     <ProjectReference Include="..\Symphony.Abstractions\Symphony.Abstractions.csproj" />
   </ItemGroup>

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -55,6 +55,7 @@ public class ApplicationServiceCollectionExtensionsTests
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.NotNull(serviceProvider.GetService<ApplicationServiceMarker>());
+        Assert.NotNull(serviceProvider.GetService<RetryDelayPlanner>());
         Assert.IsType<ActiveSessionRegistry>(serviceProvider.GetRequiredService<IActiveSessionRegistry>());
         Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchQueue>());
         Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchStatusReader>());
@@ -64,6 +65,9 @@ public class ApplicationServiceCollectionExtensionsTests
         Assert.Contains(
             serviceProvider.GetServices<IHostedService>(),
             hostedService => hostedService is DispatchWorkerBackgroundService);
+        Assert.Contains(
+            serviceProvider.GetServices<IHostedService>(),
+            hostedService => hostedService is RetryDispatchBackgroundService);
     }
 
     private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
@@ -10,7 +13,7 @@ namespace Symphony.Application.Tests.Orchestration;
 public sealed class OrchestratorDispatchQueueTests
 {
     [Fact]
-    public async Task QueueAsync_tracks_queued_and_running_state_for_status_readers()
+    public async Task QueueAsync_tracks_queued_running_and_retry_state_for_status_readers()
     {
         var queue = CreateQueue(maxConcurrentAgents: 1);
         var worker = new BlockingQueuedIssueWorker();
@@ -33,13 +36,18 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal("ABC-1", runningSnapshot.Running[0].IssueIdentifier);
 
         worker.AllowCompletion("ABC-1");
-        await worker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await worker.WaitForCompletionAsync("ABC-1", TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => queue.GetSnapshot().Retrying.Count == 1, TimeSpan.FromSeconds(2));
         await hostedService.StopAsync(CancellationToken.None);
 
         var completedSnapshot = queue.GetSnapshot();
+        var retry = Assert.Single(completedSnapshot.Retrying);
 
         Assert.Empty(completedSnapshot.Queued);
         Assert.Empty(completedSnapshot.Running);
+        Assert.Equal(1, retry.Attempt);
+        Assert.Equal("ABC-1", retry.IssueIdentifier);
+        Assert.Null(retry.Error);
         Assert.Equal(1, completedSnapshot.MaxConcurrentAgents);
         Assert.Equal(1, completedSnapshot.AvailableSlots);
     }
@@ -63,7 +71,7 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal(0, queue.GetSnapshot().AvailableSlots);
 
         worker.AllowCompletion("ABC-1");
-        await worker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await worker.WaitForCompletionAsync("ABC-1", TimeSpan.FromSeconds(2));
         await hostedService.StopAsync(CancellationToken.None);
     }
 
@@ -88,7 +96,7 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal(2, queue.GetSnapshot().MaxConcurrentAgents);
 
         firstWorker.AllowCompletion("ABC-1");
-        await firstWorker.ExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await firstWorker.WaitForCompletionAsync("ABC-1", TimeSpan.FromSeconds(2));
         await firstHostedService.StopAsync(CancellationToken.None);
     }
 
@@ -134,17 +142,87 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Empty(registry.GetActiveSessions());
     }
 
+    [Fact]
+    public async Task DispatchWorker_schedules_failure_retry_for_transient_exception()
+    {
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var registry = CreateRegistry();
+        var worker = new ThrowingQueuedIssueWorker(new InvalidOperationException("transient failure"));
+        var hostedService = CreateHostedService(queue, registry, worker);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.ExecutionAttempted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => queue.GetSnapshot().Retrying.Count == 1, TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var retry = Assert.Single(queue.GetSnapshot().Retrying);
+
+        Assert.Equal(1, retry.Attempt);
+        Assert.Equal("ABC-1", retry.IssueIdentifier);
+        Assert.Equal("transient failure", retry.Error);
+        Assert.Equal(1, queue.GetSnapshot().AvailableSlots);
+    }
+
+    [Fact]
+    public async Task DispatchWorker_releases_claim_after_non_transient_failure()
+    {
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var registry = CreateRegistry();
+        var worker = new ThrowingQueuedIssueWorker(new NonTransientIssueExecutionException("do not retry"));
+        var hostedService = CreateHostedService(queue, registry, worker);
+        var issue = CreateIssue("1", "ABC-1");
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(issue);
+        await worker.ExecutionAttempted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var enqueueResult = await queue.QueueAsync(issue);
+
+        Assert.Equal(DispatchEnqueueResult.Enqueued, enqueueResult);
+        Assert.Single(queue.GetSnapshot().Queued);
+    }
+
+    [Fact]
+    public async Task RetryDispatchBackgroundService_dispatches_due_retry_attempts()
+    {
+        var timeProvider = TimeProvider.System;
+        var queue = CreateQueue(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents: 1, maxRetryBackoffMs: 25)),
+            new RetryDelayPlanner(() => 1d),
+            timeProvider);
+        var registry = CreateRegistry(timeProvider);
+        var worker = new FailOnceQueuedIssueWorker();
+        var dispatchHostedService = CreateHostedService(queue, registry, worker);
+        var retryHostedService = CreateRetryHostedService(queue, timeProvider);
+
+        await dispatchHostedService.StartAsync(CancellationToken.None);
+        await retryHostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.RetryExecutionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await retryHostedService.StopAsync(CancellationToken.None);
+        await dispatchHostedService.StopAsync(CancellationToken.None);
+
+        Assert.Equal(new int?[] { null, 1 }, worker.Attempts.ToArray());
+    }
+
     private static OrchestratorDispatchQueue CreateQueue(int maxConcurrentAgents)
     {
         return CreateQueue(new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents)));
     }
 
-    private static OrchestratorDispatchQueue CreateQueue(IWorkflowOptionsProvider workflowOptionsProvider)
+    private static OrchestratorDispatchQueue CreateQueue(
+        IWorkflowOptionsProvider workflowOptionsProvider,
+        RetryDelayPlanner? retryDelayPlanner = null,
+        TimeProvider? timeProvider = null,
+        ILogger<OrchestratorDispatchQueue>? logger = null)
     {
         return new OrchestratorDispatchQueue(
             workflowOptionsProvider,
-            TimeProvider.System,
-            NullLogger<OrchestratorDispatchQueue>.Instance);
+            retryDelayPlanner ?? new RetryDelayPlanner(() => 1d),
+            timeProvider ?? TimeProvider.System,
+            logger ?? NullLogger<OrchestratorDispatchQueue>.Instance);
     }
 
     private static DispatchWorkerBackgroundService CreateHostedService(
@@ -159,12 +237,26 @@ public sealed class OrchestratorDispatchQueueTests
             NullLogger<DispatchWorkerBackgroundService>.Instance);
     }
 
-    private static ActiveSessionRegistry CreateRegistry()
+    private static RetryDispatchBackgroundService CreateRetryHostedService(
+        OrchestratorDispatchQueue queue,
+        TimeProvider? timeProvider = null)
     {
-        return new ActiveSessionRegistry(TimeProvider.System, NullLogger<ActiveSessionRegistry>.Instance);
+        return new RetryDispatchBackgroundService(
+            queue,
+            timeProvider ?? TimeProvider.System,
+            NullLogger<RetryDispatchBackgroundService>.Instance);
     }
 
-    private static WorkflowServiceOptions CreateWorkflowOptions(int maxConcurrentAgents)
+    private static ActiveSessionRegistry CreateRegistry(TimeProvider? timeProvider = null)
+    {
+        return new ActiveSessionRegistry(
+            timeProvider ?? TimeProvider.System,
+            NullLogger<ActiveSessionRegistry>.Instance);
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions(
+        int maxConcurrentAgents,
+        int maxRetryBackoffMs = 300_000)
     {
         return new WorkflowServiceOptions(
             new WorkflowTrackerOptions(
@@ -188,7 +280,7 @@ public sealed class OrchestratorDispatchQueueTests
             new WorkflowAgentOptions(
                 maxConcurrentAgents,
                 20,
-                300_000,
+                maxRetryBackoffMs,
                 new Dictionary<string, int>(StringComparer.Ordinal)),
             new WorkflowCodexOptions(
                 "codex app-server",
@@ -209,6 +301,22 @@ public sealed class OrchestratorDispatchQueueTests
             description: "Dispatch queue test",
             state: "Todo",
             createdAt: DateTimeOffset.UtcNow);
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(condition(), "Timed out waiting for the expected condition.");
     }
 
     private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
@@ -242,8 +350,6 @@ public sealed class OrchestratorDispatchQueueTests
 
         public TaskCompletionSource ExecutionStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource ExecutionCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
         public async Task ExecuteAsync(QueuedIssueExecutionContext context)
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -266,7 +372,6 @@ public sealed class OrchestratorDispatchQueueTests
             {
                 await GetAllowCompletion(context.Issue.Identifier).Task.WaitAsync(context.CancellationToken);
                 GetCompletion(context.Issue.Identifier).TrySetResult();
-                ExecutionCompleted.TrySetResult();
             }
             catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
             {
@@ -324,6 +429,43 @@ public sealed class OrchestratorDispatchQueueTests
             {
                 return _cancellationByIssue[issueIdentifier];
             }
+        }
+    }
+
+    private sealed class ThrowingQueuedIssueWorker(Exception exception) : IQueuedIssueWorker
+    {
+        public TaskCompletionSource ExecutionAttempted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ExecuteAsync(QueuedIssueExecutionContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            ExecutionAttempted.TrySetResult();
+            return Task.FromException(exception);
+        }
+    }
+
+    private sealed class FailOnceQueuedIssueWorker : IQueuedIssueWorker
+    {
+        private int _executionCount;
+
+        public ConcurrentQueue<int?> Attempts { get; } = new();
+
+        public TaskCompletionSource RetryExecutionCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ExecuteAsync(QueuedIssueExecutionContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            Attempts.Enqueue(context.Attempt);
+
+            if (Interlocked.Increment(ref _executionCount) == 1)
+            {
+                return Task.FromException(new InvalidOperationException("transient failure"));
+            }
+
+            RetryExecutionCompleted.TrySetResult();
+            return Task.CompletedTask;
         }
     }
 }

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/RetryDelayPlannerTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/RetryDelayPlannerTests.cs
@@ -1,0 +1,34 @@
+using Symphony.Application.Orchestration;
+
+namespace Symphony.Application.Tests.Orchestration;
+
+public sealed class RetryDelayPlannerTests
+{
+    [Fact]
+    public void GetContinuationDelay_returns_one_second()
+    {
+        var planner = new RetryDelayPlanner(() => 1d);
+
+        var delay = planner.GetContinuationDelay();
+
+        Assert.Equal(TimeSpan.FromSeconds(1), delay);
+    }
+
+    [Theory]
+    [InlineData(1, 300_000, 0d, 5_000)]
+    [InlineData(1, 300_000, 1d, 10_000)]
+    [InlineData(3, 300_000, 1d, 40_000)]
+    [InlineData(10, 25_000, 1d, 25_000)]
+    public async Task GetFailureDelayAsync_applies_exponential_backoff_with_cap_and_jitter(
+        int attempt,
+        int maxRetryBackoffMs,
+        double jitterSample,
+        int expectedDelayMs)
+    {
+        var planner = new RetryDelayPlanner(() => jitterSample);
+
+        var delay = await planner.GetFailureDelayAsync(attempt, maxRetryBackoffMs);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(expectedDelayMs), delay);
+    }
+}


### PR DESCRIPTION
#### Context

Issue #18 requires the orchestrator to own retry state and backoff behavior from `SPEC.md` so transient failures and normal continuation runs can be safely re-dispatched.

#### TL;DR

*Add scheduler-managed retry state, backoff planning, and retry dispatch services.*

#### Summary

- add retry entries and retry status snapshots to the application dispatch queue
- schedule continuation and transient-failure retries while non-transient failures exit cleanly
- add retry planner, hosted-service coverage, and README notes for retry behavior

#### Alternatives

- Keep retry timing inside Polly execution pipelines, but that blocks the worker and conflicts with the orchestrator-owned retry queue in `SPEC.md`.
- Retry immediately inside the worker, but that hides retry state from orchestration and observability.

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Verified continuation, transient-failure, non-transient, and due-retry paths in application tests.

Closes #18