### PR TITLE
E4-S3: implement Codex agent runner

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -230,6 +230,11 @@ Notes:
   surfaced through the in-memory retry snapshot.
 - Active sessions are tracked in-memory by normalized issue id, can expose live session metadata,
   and support targeted reconciliation cancellation without affecting unrelated executions.
+- Worker attempts now create a validated workspace, optionally run `hooks.before_run`, launch Codex
+  through `bash -lc <codex.command>`, send the `initialize` / `thread/start` / `turn/start`
+  handshake, then run `hooks.after_run` as a best-effort cleanup step after the attempt ends.
+- `codex.turn_sandbox_policy` is treated as a structured object and is forwarded to Codex in the
+  `turn/start` payload instead of being flattened into a string.
 - Per-issue workspaces live under `workspace.root` using a sanitized issue identifier that keeps
   only letters, digits, `.`, `_`, and `-`.
 - Workspace paths that resolve outside the configured `workspace.root` are rejected before any

--- a/dotnet/src/Symphony.Application/Configuration/WorkflowServiceOptions.cs
+++ b/dotnet/src/Symphony.Application/Configuration/WorkflowServiceOptions.cs
@@ -40,7 +40,7 @@ public sealed record WorkflowCodexOptions(
     string Command,
     string? ApprovalPolicy,
     string? ThreadSandbox,
-    string? TurnSandboxPolicy,
+    IReadOnlyDictionary<string, object?>? TurnSandboxPolicy,
     int TurnTimeoutMs,
     int ReadTimeoutMs,
     int StallTimeoutMs);

--- a/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
+++ b/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
@@ -1,0 +1,784 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+
+namespace Symphony.Infrastructure.Codex;
+
+internal sealed class CodexAppServerClient(
+    ICodexProcessSessionFactory processSessionFactory,
+    TimeProvider timeProvider,
+    ILogger<CodexAppServerClient> logger)
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task RunAsync(
+        QueuedIssueExecutionContext context,
+        string workspacePath,
+        string prompt,
+        WorkflowCodexOptions codexOptions)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspacePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+        ArgumentNullException.ThrowIfNull(codexOptions);
+
+        await using var session = await processSessionFactory.StartAsync(
+                new CodexProcessStartRequest(codexOptions.Command, workspacePath),
+                context.CancellationToken)
+            .ConfigureAwait(false);
+
+        using var stderrCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+        var standardErrorPump = PumpStandardErrorAsync(session, context, stderrCancellationTokenSource.Token);
+
+        try
+        {
+            logger.LogInformation(
+                "codex_launch started issue_id={issue_id} issue_identifier={issue_identifier} workspace_path={workspace_path} command={command} outcome=started",
+                context.Issue.Id,
+                context.Issue.Identifier,
+                workspacePath,
+                codexOptions.Command);
+
+            await SendAsync(
+                    session,
+                    new
+                    {
+                        id = 1,
+                        method = "initialize",
+                        @params = new
+                        {
+                            clientInfo = new
+                            {
+                                name = "symphony",
+                                version = typeof(CodexAppServerClient).Assembly.GetName().Version?.ToString() ?? "1.0.0"
+                            },
+                            capabilities = new { }
+                        }
+                    },
+                    context.CancellationToken)
+                .ConfigureAwait(false);
+            _ = await ReadResponseAsync(session, 1, codexOptions.ReadTimeoutMs, context, context.CancellationToken).ConfigureAwait(false);
+
+            await SendAsync(
+                    session,
+                    new
+                    {
+                        method = "initialized",
+                        @params = new { }
+                    },
+                    context.CancellationToken)
+                .ConfigureAwait(false);
+
+            context.UpdateStatus(RunAttemptStatus.InitializingSession);
+
+            await SendAsync(
+                    session,
+                    new
+                    {
+                        id = 2,
+                        method = "thread/start",
+                        @params = new
+                        {
+                            approvalPolicy = codexOptions.ApprovalPolicy,
+                            sandbox = codexOptions.ThreadSandbox,
+                            cwd = workspacePath
+                        }
+                    },
+                    context.CancellationToken)
+                .ConfigureAwait(false);
+            var threadStartResponse = await ReadResponseAsync(session, 2, codexOptions.ReadTimeoutMs, context, context.CancellationToken)
+                .ConfigureAwait(false);
+            var threadId = ExtractRequiredNestedId(threadStartResponse, "thread");
+
+            await SendAsync(
+                    session,
+                    new
+                    {
+                        id = 3,
+                        method = "turn/start",
+                        @params = new
+                        {
+                            threadId,
+                            input = new object[]
+                            {
+                                new
+                                {
+                                    type = "text",
+                                    text = prompt
+                                }
+                            },
+                            cwd = workspacePath,
+                            title = $"{context.Issue.Identifier}: {context.Issue.Title}",
+                            approvalPolicy = codexOptions.ApprovalPolicy,
+                            sandboxPolicy = codexOptions.TurnSandboxPolicy
+                        }
+                    },
+                    context.CancellationToken)
+                .ConfigureAwait(false);
+            var turnStartResponse = await ReadResponseAsync(session, 3, codexOptions.ReadTimeoutMs, context, context.CancellationToken)
+                .ConfigureAwait(false);
+            var turnId = ExtractRequiredNestedId(turnStartResponse, "turn");
+
+            context.UpdateSession(
+                new LiveSessionMetadata(
+                    threadId,
+                    turnId,
+                    codexAppServerPid: session.ProcessId?.ToString(CultureInfo.InvariantCulture),
+                    lastCodexEvent: "session_started",
+                    lastCodexTimestamp: timeProvider.GetUtcNow(),
+                    lastCodexMessage: "turn_started",
+                    turnCount: 1));
+            context.UpdateStatus(RunAttemptStatus.StreamingTurn);
+
+            await ReadTurnStreamAsync(session, context, codexOptions.TurnTimeoutMs).ConfigureAwait(false);
+
+            logger.LogInformation(
+                "codex_launch completed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} outcome=completed",
+                context.Issue.Id,
+                context.Issue.Identifier,
+                context.SessionId);
+        }
+        finally
+        {
+            stderrCancellationTokenSource.Cancel();
+            session.Kill();
+
+            try
+            {
+                await session.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or OperationCanceledException)
+            {
+            }
+
+            try
+            {
+                await standardErrorPump.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private async Task<JsonElement> ReadResponseAsync(
+        ICodexProcessSession session,
+        int expectedId,
+        int readTimeoutMs,
+        QueuedIssueExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            string? line;
+            try
+            {
+                line = await session.ReadStandardOutputLineAsync(
+                        TimeSpan.FromMilliseconds(readTimeoutMs),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException exception)
+            {
+                throw new CodexAgentException("response_timeout", "Timed out waiting for Codex app-server response.", exception);
+            }
+
+            if (line is null)
+            {
+                throw new CodexAgentException(
+                    "port_exit",
+                    "Codex app-server exited before completing the startup handshake.");
+            }
+
+            JsonElement payload;
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                payload = document.RootElement.Clone();
+            }
+            catch (JsonException exception)
+            {
+                throw new CodexAgentException(
+                    "response_error",
+                    "Codex app-server emitted malformed JSON during the startup handshake.",
+                    exception);
+            }
+
+            var responseId = TryGetId(payload);
+            if (responseId is not null && string.Equals(responseId, expectedId.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal))
+            {
+                if (payload.TryGetProperty("error", out var errorElement))
+                {
+                    throw new CodexAgentException("response_error", FormatErrorMessage(errorElement));
+                }
+
+                return payload;
+            }
+
+            await ProcessProtocolMessageAsync(session, context, payload, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ReadTurnStreamAsync(
+        ICodexProcessSession session,
+        QueuedIssueExecutionContext context,
+        int turnTimeoutMs)
+    {
+        using var turnTimeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+        turnTimeoutCancellationTokenSource.CancelAfter(TimeSpan.FromMilliseconds(turnTimeoutMs));
+
+        try
+        {
+            while (true)
+            {
+                var line = await session.ReadStandardOutputLineAsync(null, turnTimeoutCancellationTokenSource.Token).ConfigureAwait(false);
+                if (line is null)
+                {
+                    throw new CodexAgentException(
+                        "port_exit",
+                        "Codex app-server exited before the turn reached a terminal event.");
+                }
+
+                JsonElement payload;
+                try
+                {
+                    using var document = JsonDocument.Parse(line);
+                    payload = document.RootElement.Clone();
+                }
+                catch (JsonException)
+                {
+                    UpdateSessionMetadata(context, "malformed", "malformed_protocol_message", default);
+                    logger.LogWarning(
+                        "codex_protocol malformed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} outcome=failed",
+                        context.Issue.Id,
+                        context.Issue.Identifier,
+                        context.SessionId);
+                    continue;
+                }
+
+                var terminalOutcome = await ProcessProtocolMessageAsync(session, context, payload, turnTimeoutCancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+                if (terminalOutcome == CodexTerminalOutcome.Completed)
+                {
+                    return;
+                }
+
+                if (terminalOutcome == CodexTerminalOutcome.Failed)
+                {
+                    throw new CodexAgentException("turn_failed", "Codex app-server reported a failed turn.");
+                }
+
+                if (terminalOutcome == CodexTerminalOutcome.Canceled)
+                {
+                    throw new CodexAgentException("turn_cancelled", "Codex app-server reported a cancelled turn.");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException exception)
+        {
+            throw new CodexAgentException("turn_timeout", "Codex app-server turn timed out.", exception);
+        }
+    }
+
+    private async Task PumpStandardErrorAsync(
+        ICodexProcessSession session,
+        QueuedIssueExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var line = await session.ReadStandardErrorLineAsync(null, cancellationToken).ConfigureAwait(false);
+            if (line is null)
+            {
+                return;
+            }
+
+            logger.LogInformation(
+                "codex_stderr completed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} diagnostic={diagnostic} outcome=completed",
+                context.Issue.Id,
+                context.Issue.Identifier,
+                context.SessionId,
+                line);
+        }
+    }
+
+    private async Task<CodexTerminalOutcome> ProcessProtocolMessageAsync(
+        ICodexProcessSession session,
+        QueuedIssueExecutionContext context,
+        JsonElement payload,
+        CancellationToken cancellationToken)
+    {
+        var method = TryGetMethod(payload);
+        if (method is null)
+        {
+            return CodexTerminalOutcome.None;
+        }
+
+        if (TryGetId(payload) is { } requestId)
+        {
+            if (method.Contains("requestUserInput", StringComparison.OrdinalIgnoreCase)
+                || method.Contains("user_input", StringComparison.OrdinalIgnoreCase)
+                || method.Contains("input_required", StringComparison.OrdinalIgnoreCase))
+            {
+                UpdateSessionMetadata(context, "turn_input_required", "user_input_required", payload);
+                throw new CodexAgentException("turn_input_required", "Codex app-server requested user input.");
+            }
+
+            if (method.Contains("approval", StringComparison.OrdinalIgnoreCase))
+            {
+                await SendAsync(
+                        session,
+                        new
+                        {
+                            id = requestId,
+                            result = new
+                            {
+                                approved = true
+                            }
+                        },
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                UpdateSessionMetadata(context, "approval_auto_approved", "approval_auto_approved", payload);
+                return CodexTerminalOutcome.None;
+            }
+
+            if (method.Contains("tool/call", StringComparison.OrdinalIgnoreCase)
+                || method.Contains("tool_call", StringComparison.OrdinalIgnoreCase))
+            {
+                await SendAsync(
+                        session,
+                        new
+                        {
+                            id = requestId,
+                            result = new
+                            {
+                                success = false,
+                                error = "unsupported_tool_call"
+                            }
+                        },
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                UpdateSessionMetadata(context, "unsupported_tool_call", "unsupported_tool_call", payload);
+                return CodexTerminalOutcome.None;
+            }
+        }
+
+        return method switch
+        {
+            "turn/completed" => CompleteTerminalEvent(context, "turn_completed", payload, CodexTerminalOutcome.Completed),
+            "turn/failed" => CompleteTerminalEvent(context, "turn_failed", payload, CodexTerminalOutcome.Failed),
+            "turn/cancelled" => CompleteTerminalEvent(context, "turn_cancelled", payload, CodexTerminalOutcome.Canceled),
+            _ => ObserveEvent(context, method.Replace('/', '_'), payload)
+        };
+    }
+
+    private static CodexTerminalOutcome CompleteTerminalEvent(
+        QueuedIssueExecutionContext context,
+        string eventName,
+        JsonElement payload,
+        CodexTerminalOutcome outcome)
+    {
+        UpdateSessionMetadata(context, eventName, null, payload);
+        return outcome;
+    }
+
+    private static CodexTerminalOutcome ObserveEvent(
+        QueuedIssueExecutionContext context,
+        string eventName,
+        JsonElement payload)
+    {
+        UpdateSessionMetadata(context, eventName, null, payload);
+        return CodexTerminalOutcome.None;
+    }
+
+    private static void UpdateSessionMetadata(
+        QueuedIssueExecutionContext context,
+        string eventName,
+        string? fallbackMessage,
+        JsonElement payload)
+    {
+        if (context.Session is null)
+        {
+            return;
+        }
+
+        var usage = ExtractUsage(payload);
+        var lastReportedInputTokens = usage.InputTokens ?? context.Session.LastReportedInputTokens;
+        var lastReportedOutputTokens = usage.OutputTokens ?? context.Session.LastReportedOutputTokens;
+        var lastReportedTotalTokens = usage.TotalTokens
+            ?? Math.Max(context.Session.LastReportedTotalTokens, lastReportedInputTokens + lastReportedOutputTokens);
+        var codexInputTokens = Math.Max(context.Session.CodexInputTokens, lastReportedInputTokens);
+        var codexOutputTokens = Math.Max(context.Session.CodexOutputTokens, lastReportedOutputTokens);
+        var codexTotalTokens = Math.Max(
+            Math.Max(context.Session.CodexTotalTokens, lastReportedTotalTokens),
+            codexInputTokens + codexOutputTokens);
+
+        context.UpdateSession(
+            new LiveSessionMetadata(
+                context.Session.ThreadId,
+                context.Session.TurnId,
+                context.Session.CodexAppServerPid,
+                eventName,
+                DateTimeOffset.UtcNow,
+                ExtractMessage(payload) ?? fallbackMessage ?? eventName,
+                codexInputTokens,
+                codexOutputTokens,
+                codexTotalTokens,
+                lastReportedInputTokens,
+                lastReportedOutputTokens,
+                lastReportedTotalTokens,
+                context.Session.TurnCount));
+    }
+
+    private static async Task SendAsync(
+        ICodexProcessSession session,
+        object payload,
+        CancellationToken cancellationToken)
+    {
+        var line = JsonSerializer.Serialize(payload, SerializerOptions);
+        await session.SendAsync(line, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string ExtractRequiredNestedId(JsonElement payload, string propertyName)
+    {
+        if (payload.TryGetProperty("result", out var result)
+            && result.ValueKind == JsonValueKind.Object)
+        {
+            if (result.TryGetProperty(propertyName, out var nested)
+                && nested.ValueKind == JsonValueKind.Object
+                && nested.TryGetProperty("id", out var idElement))
+            {
+                return GetRequiredString(idElement, $"result.{propertyName}.id");
+            }
+
+            if (result.TryGetProperty($"{propertyName}Id", out var camelCaseId))
+            {
+                return GetRequiredString(camelCaseId, $"result.{propertyName}Id");
+            }
+
+            if (result.TryGetProperty($"{propertyName}_id", out var snakeCaseId))
+            {
+                return GetRequiredString(snakeCaseId, $"result.{propertyName}_id");
+            }
+        }
+
+        throw new CodexAgentException("response_error", $"Codex app-server response was missing result.{propertyName}.id.");
+    }
+
+    private static string GetRequiredString(JsonElement element, string fieldName)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String when !string.IsNullOrWhiteSpace(element.GetString()) => element.GetString()!,
+            JsonValueKind.Number => element.GetRawText(),
+            _ => throw new CodexAgentException("response_error", $"Codex app-server response field '{fieldName}' was not a string.")
+        };
+    }
+
+    private static string? TryGetMethod(JsonElement payload)
+    {
+        return payload.TryGetProperty("method", out var methodElement)
+            && methodElement.ValueKind == JsonValueKind.String
+            ? methodElement.GetString()
+            : null;
+    }
+
+    private static string? TryGetId(JsonElement payload)
+    {
+        if (!payload.TryGetProperty("id", out var idElement))
+        {
+            return null;
+        }
+
+        return idElement.ValueKind switch
+        {
+            JsonValueKind.String => idElement.GetString(),
+            JsonValueKind.Number => idElement.GetRawText(),
+            _ => null
+        };
+    }
+
+    private static string FormatErrorMessage(JsonElement errorElement)
+    {
+        return ExtractMessage(errorElement) ?? errorElement.GetRawText();
+    }
+
+    private static string? ExtractMessage(JsonElement payload)
+    {
+        return FindFirstString(
+            payload,
+            static name => name is "message" or "text" or "reason" or "error");
+    }
+
+    private static UsageInfo ExtractUsage(JsonElement payload)
+    {
+        return new UsageInfo(
+            FindFirstInt(payload, static name => name is "input_tokens" or "inputTokens"),
+            FindFirstInt(payload, static name => name is "output_tokens" or "outputTokens"),
+            FindFirstInt(payload, static name => name is "total_tokens" or "totalTokens"));
+    }
+
+    private static int? FindFirstInt(JsonElement element, Func<string, bool> nameMatcher)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => FindFirstIntInObject(element, nameMatcher),
+            JsonValueKind.Array => FindFirstIntInArray(element, nameMatcher),
+            _ => null
+        };
+    }
+
+    private static int? FindFirstIntInObject(JsonElement element, Func<string, bool> nameMatcher)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (nameMatcher(property.Name) && property.Value.TryGetInt32(out var intValue))
+            {
+                return intValue;
+            }
+
+            var nested = FindFirstInt(property.Value, nameMatcher);
+            if (nested is not null)
+            {
+                return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static int? FindFirstIntInArray(JsonElement element, Func<string, bool> nameMatcher)
+    {
+        foreach (var item in element.EnumerateArray())
+        {
+            var nested = FindFirstInt(item, nameMatcher);
+            if (nested is not null)
+            {
+                return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? FindFirstString(JsonElement element, Func<string, bool> nameMatcher)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => FindFirstStringInObject(element, nameMatcher),
+            JsonValueKind.Array => FindFirstStringInArray(element, nameMatcher),
+            _ => null
+        };
+    }
+
+    private static string? FindFirstStringInObject(JsonElement element, Func<string, bool> nameMatcher)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (nameMatcher(property.Name) && property.Value.ValueKind == JsonValueKind.String)
+            {
+                return property.Value.GetString();
+            }
+
+            var nested = FindFirstString(property.Value, nameMatcher);
+            if (nested is not null)
+            {
+                return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? FindFirstStringInArray(JsonElement element, Func<string, bool> nameMatcher)
+    {
+        foreach (var item in element.EnumerateArray())
+        {
+            var nested = FindFirstString(item, nameMatcher);
+            if (nested is not null)
+            {
+                return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private readonly record struct UsageInfo(int? InputTokens, int? OutputTokens, int? TotalTokens);
+
+    private enum CodexTerminalOutcome
+    {
+        None,
+        Completed,
+        Failed,
+        Canceled
+    }
+}
+
+internal interface ICodexProcessSessionFactory
+{
+    Task<ICodexProcessSession> StartAsync(CodexProcessStartRequest request, CancellationToken cancellationToken);
+}
+
+internal readonly record struct CodexProcessStartRequest(string Command, string WorkingDirectory);
+
+internal interface ICodexProcessSession : IAsyncDisposable
+{
+    int? ProcessId { get; }
+
+    int? ExitCode { get; }
+
+    bool HasExited { get; }
+
+    Task SendAsync(string line, CancellationToken cancellationToken);
+
+    Task<string?> ReadStandardOutputLineAsync(TimeSpan? timeout, CancellationToken cancellationToken);
+
+    Task<string?> ReadStandardErrorLineAsync(TimeSpan? timeout, CancellationToken cancellationToken);
+
+    Task WaitForExitAsync(CancellationToken cancellationToken);
+
+    void Kill();
+}
+
+internal sealed class ProcessCodexProcessSessionFactory : ICodexProcessSessionFactory
+{
+    public Task<ICodexProcessSession> StartAsync(CodexProcessStartRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkingDirectory);
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "bash",
+                WorkingDirectory = request.WorkingDirectory,
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            startInfo.ArgumentList.Add("-lc");
+            startInfo.ArgumentList.Add(request.Command);
+
+            var process = new Process
+            {
+                StartInfo = startInfo
+            };
+
+            if (!process.Start())
+            {
+                throw new CodexAgentException("codex_not_found", $"Failed to launch Codex command '{request.Command}'.");
+            }
+
+            return Task.FromResult<ICodexProcessSession>(new ProcessCodexProcessSession(process));
+        }
+        catch (CodexAgentException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new CodexAgentException(
+                "codex_not_found",
+                $"Failed to launch Codex command '{request.Command}'. {exception.Message}",
+                exception);
+        }
+    }
+
+    private sealed class ProcessCodexProcessSession(Process process) : ICodexProcessSession
+    {
+        private int _disposed;
+
+        public int? ProcessId => process.HasExited ? null : process.Id;
+
+        public int? ExitCode => process.HasExited ? process.ExitCode : null;
+
+        public bool HasExited => process.HasExited;
+
+        public async Task SendAsync(string line, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await process.StandardInput.WriteLineAsync(line).ConfigureAwait(false);
+            await process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<string?> ReadStandardOutputLineAsync(TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            return ReadLineAsync(process.StandardOutput, timeout, cancellationToken);
+        }
+
+        public Task<string?> ReadStandardErrorLineAsync(TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            return ReadLineAsync(process.StandardError, timeout, cancellationToken);
+        }
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            return process.WaitForExitAsync(cancellationToken);
+        }
+
+        public void Kill()
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            Kill();
+
+            try
+            {
+                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            process.Dispose();
+        }
+
+        private static Task<string?> ReadLineAsync(
+            StreamReader reader,
+            TimeSpan? timeout,
+            CancellationToken cancellationToken)
+        {
+            var readTask = reader.ReadLineAsync();
+            return timeout is null
+                ? readTask.WaitAsync(cancellationToken)
+                : readTask.WaitAsync(timeout.Value, cancellationToken);
+        }
+    }
+}
+
+internal sealed class CodexAgentException(string code, string message, Exception? innerException = null)
+    : InvalidOperationException(message, innerException)
+{
+    public string Code { get; } = code;
+}

--- a/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsResolver.cs
+++ b/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsResolver.cs
@@ -114,7 +114,7 @@ public sealed class WorkflowOptionsResolver : IWorkflowOptionsResolver
             command,
             GetOptionalString(codexSection, "approval_policy", "codex.approval_policy"),
             GetOptionalString(codexSection, "thread_sandbox", "codex.thread_sandbox"),
-            GetOptionalString(codexSection, "turn_sandbox_policy", "codex.turn_sandbox_policy"),
+            GetOptionalObjectMap(codexSection, "turn_sandbox_policy", "codex.turn_sandbox_policy"),
             GetPositiveIntOrDefault(codexSection, "turn_timeout_ms", DefaultTurnTimeoutMs, "codex.turn_timeout_ms"),
             GetPositiveIntOrDefault(codexSection, "read_timeout_ms", DefaultReadTimeoutMs, "codex.read_timeout_ms"),
             GetIntOrDefault(codexSection, "stall_timeout_ms", DefaultStallTimeoutMs, "codex.stall_timeout_ms"));
@@ -390,6 +390,69 @@ public sealed class WorkflowOptionsResolver : IWorkflowOptionsResolver
 
         var trimmed = stringValue.Trim();
         return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static IReadOnlyDictionary<string, object?>? GetOptionalObjectMap(
+        IReadOnlyDictionary<string, object?> section,
+        string key,
+        string fieldName)
+    {
+        if (!section.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            IReadOnlyDictionary<string, object?> readOnlyDictionary => CloneObjectMap(readOnlyDictionary, fieldName),
+            IDictionary<string, object?> dictionary => CloneObjectMap((IReadOnlyDictionary<string, object?>)dictionary, fieldName),
+            IDictionary<object, object?> dictionary => CloneObjectMap(dictionary, fieldName),
+            _ => throw InvalidConfiguration($"{fieldName} must be an object.")
+        };
+    }
+
+    private static IReadOnlyDictionary<string, object?> CloneObjectMap(
+        IReadOnlyDictionary<string, object?> source,
+        string fieldName)
+    {
+        return new ReadOnlyDictionary<string, object?>(
+            source.ToDictionary(
+                pair => pair.Key,
+                pair => NormalizeObjectValue(pair.Value, fieldName),
+                StringComparer.Ordinal));
+    }
+
+    private static IReadOnlyDictionary<string, object?> CloneObjectMap(
+        IDictionary<object, object?> source,
+        string fieldName)
+    {
+        var normalized = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        foreach (var (rawKey, rawValue) in source)
+        {
+            if (rawKey is not string key || string.IsNullOrWhiteSpace(key))
+            {
+                throw InvalidConfiguration($"{fieldName} must contain only string keys.");
+            }
+
+            normalized[key.Trim()] = NormalizeObjectValue(rawValue, fieldName);
+        }
+
+        return new ReadOnlyDictionary<string, object?>(normalized);
+    }
+
+    private static object? NormalizeObjectValue(object? value, string fieldName)
+    {
+        return value switch
+        {
+            null => null,
+            string or bool or char or byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal => value,
+            IReadOnlyDictionary<string, object?> readOnlyDictionary => CloneObjectMap(readOnlyDictionary, fieldName),
+            IDictionary<string, object?> dictionary => CloneObjectMap((IReadOnlyDictionary<string, object?>)dictionary, fieldName),
+            IDictionary<object, object?> dictionary => CloneObjectMap(dictionary, fieldName),
+            IEnumerable<object?> enumerable => enumerable.Select(item => NormalizeObjectValue(item, fieldName)).ToArray(),
+            _ => throw InvalidConfiguration($"{fieldName} contains unsupported value type '{value.GetType().Name}'.")
+        };
     }
 
     private static string GetRequiredStringValue(object? value, string fieldName)

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -5,7 +5,10 @@ using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Workflows;
 using Symphony.Abstractions.Workspaces;
 using Symphony.Abstractions.Trackers;
+using Symphony.Application.Orchestration;
 using Symphony.Infrastructure.Configuration;
+using Symphony.Infrastructure.Codex;
+using Symphony.Infrastructure.Orchestration;
 using Symphony.Infrastructure.Processes;
 using Symphony.Infrastructure.Workflows;
 using Symphony.Infrastructure.Workspaces;
@@ -27,6 +30,10 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddHostedService<PollingBackgroundService>();
         services.AddSingleton<IProcessRunner, ProcessRunner>();
         services.AddSingleton<IWorkspaceManager, WorkspaceManager>();
+        services.AddSingleton<WorkflowPromptRenderer>();
+        services.AddSingleton<ICodexProcessSessionFactory, ProcessCodexProcessSessionFactory>();
+        services.AddSingleton<CodexAppServerClient>();
+        services.AddSingleton<IQueuedIssueWorker, CodexQueuedIssueWorker>();
 
         return services;
     }

--- a/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
@@ -1,0 +1,159 @@
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Processes;
+using Symphony.Abstractions.Workflows;
+using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Runs;
+using Symphony.Infrastructure.Codex;
+using Symphony.Infrastructure.Processes;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Infrastructure.Orchestration;
+
+internal sealed class CodexQueuedIssueWorker(
+    IWorkflowOptionsProvider workflowOptionsProvider,
+    IWorkflowLoader workflowLoader,
+    IWorkspaceManager workspaceManager,
+    IProcessRunner processRunner,
+    WorkflowPromptRenderer workflowPromptRenderer,
+    CodexAppServerClient codexAppServerClient,
+    ILogger<CodexQueuedIssueWorker> logger) : IQueuedIssueWorker
+{
+    public async Task ExecuteAsync(QueuedIssueExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(context.CancellationToken).ConfigureAwait(false);
+
+        context.UpdateStatus(RunAttemptStatus.PreparingWorkspace);
+        var workspace = await workspaceManager.CreateForIssueAsync(context.Issue.Identifier, context.CancellationToken).ConfigureAwait(false);
+        var shouldRunAfterRunHook = false;
+
+        try
+        {
+            if (workflowOptions.Hooks.BeforeRun is not null)
+            {
+                await RunRequiredHookAsync(
+                        "before_run",
+                        workflowOptions.Hooks.BeforeRun,
+                        context.Issue.Identifier,
+                        workspace.Path,
+                        workflowOptions.Hooks.TimeoutMs,
+                        context.CancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            shouldRunAfterRunHook = true;
+
+            context.UpdateStatus(RunAttemptStatus.BuildingPrompt);
+            var workflowDefinition = await workflowLoader.LoadAsync(GetWorkflowPath(), context.CancellationToken).ConfigureAwait(false);
+            var prompt = workflowPromptRenderer.Render(workflowDefinition, context.Issue, context.Attempt);
+
+            context.UpdateStatus(RunAttemptStatus.LaunchingAgentProcess);
+            await codexAppServerClient.RunAsync(context, workspace.Path, prompt, workflowOptions.Codex).ConfigureAwait(false);
+            context.UpdateStatus(RunAttemptStatus.Finishing);
+        }
+        catch (WorkflowPromptRenderer.WorkflowPromptException exception)
+        {
+            logger.LogError(
+                exception,
+                "prompt_render failed issue_id={issue_id} issue_identifier={issue_identifier} outcome=failed",
+                context.Issue.Id,
+                context.Issue.Identifier);
+            throw;
+        }
+        finally
+        {
+            if (shouldRunAfterRunHook && workflowOptions.Hooks.AfterRun is not null)
+            {
+                await RunBestEffortHookAsync(
+                        "after_run",
+                        workflowOptions.Hooks.AfterRun,
+                        context.Issue.Identifier,
+                        workspace.Path,
+                        workflowOptions.Hooks.TimeoutMs,
+                        context.CancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task RunRequiredHookAsync(
+        string hookName,
+        string command,
+        string issueIdentifier,
+        string workspacePath,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        var result = await RunHookAsync(hookName, command, issueIdentifier, workspacePath, timeoutMs, cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Workflow hook '{hookName}' failed for '{workspacePath}' with exit code {result.ExitCode}.");
+        }
+    }
+
+    private async Task RunBestEffortHookAsync(
+        string hookName,
+        string command,
+        string issueIdentifier,
+        string workspacePath,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await RunHookAsync(hookName, command, issueIdentifier, workspacePath, timeoutMs, cancellationToken).ConfigureAwait(false);
+            if (result.ExitCode != 0)
+            {
+                logger.LogWarning(
+                    "workflow_hook failed issue_identifier={issue_identifier} hook_name={hook_name} workspace_path={workspace_path} exit_code={exit_code} outcome=failed",
+                    issueIdentifier,
+                    hookName,
+                    workspacePath,
+                    result.ExitCode);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(
+                exception,
+                "workflow_hook failed issue_identifier={issue_identifier} hook_name={hook_name} workspace_path={workspace_path} outcome=failed",
+                issueIdentifier,
+                hookName,
+                workspacePath);
+        }
+    }
+
+    private async Task<ProcessRunResult> RunHookAsync(
+        string hookName,
+        string command,
+        string issueIdentifier,
+        string workspacePath,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "workflow_hook started issue_identifier={issue_identifier} hook_name={hook_name} workspace_path={workspace_path} timeout_ms={timeout_ms} outcome=started",
+            issueIdentifier,
+            hookName,
+            workspacePath,
+            timeoutMs);
+
+        return await processRunner.RunAsync(
+                ShellCommandRequestFactory.Create(command, workspacePath, timeoutMs),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static string GetWorkflowPath()
+    {
+        return Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md");
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Processes/ShellCommandRequestFactory.cs
+++ b/dotnet/src/Symphony.Infrastructure/Processes/ShellCommandRequestFactory.cs
@@ -1,0 +1,24 @@
+using Symphony.Abstractions.Processes;
+
+namespace Symphony.Infrastructure.Processes;
+
+internal static class ShellCommandRequestFactory
+{
+    public static ProcessRunRequest Create(
+        string command,
+        string workingDirectory,
+        int timeoutMs)
+    {
+        return OperatingSystem.IsWindows()
+            ? new ProcessRunRequest(
+                fileName: "pwsh",
+                arguments: ["-NoProfile", "-NonInteractive", "-Command", command],
+                workingDirectory: workingDirectory,
+                timeout: TimeSpan.FromMilliseconds(timeoutMs))
+            : new ProcessRunRequest(
+                fileName: "sh",
+                arguments: ["-lc", command],
+                workingDirectory: workingDirectory,
+                timeout: TimeSpan.FromMilliseconds(timeoutMs));
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Properties/AssemblyInfo.cs
+++ b/dotnet/src/Symphony.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Symphony.Infrastructure.Tests")]

--- a/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowPromptRenderer.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowPromptRenderer.cs
@@ -1,0 +1,331 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Workflows;
+
+namespace Symphony.Infrastructure.Workflows;
+
+internal sealed class WorkflowPromptRenderer
+{
+    private const string DefaultPrompt = "You are working on an issue from Linear.";
+
+    public string Render(WorkflowDefinition workflowDefinition, Issue issue, int? attempt)
+    {
+        ArgumentNullException.ThrowIfNull(workflowDefinition);
+        ArgumentNullException.ThrowIfNull(issue);
+
+        var template = string.IsNullOrWhiteSpace(workflowDefinition.PromptTemplate)
+            ? DefaultPrompt
+            : workflowDefinition.PromptTemplate;
+        var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["issue"] = BuildIssueModel(issue),
+            ["attempt"] = attempt
+        };
+
+        var tokens = Tokenize(template);
+        var index = 0;
+        var (nodes, stopToken) = ParseBlock(tokens, ref index, allowElse: false);
+        if (stopToken != StopToken.None)
+        {
+            throw WorkflowPromptException.Parse("Unexpected block terminator in workflow prompt template.");
+        }
+
+        var builder = new StringBuilder(template.Length);
+        foreach (var node in nodes)
+        {
+            node.Render(builder, variables);
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static IReadOnlyDictionary<string, object?> BuildIssueModel(Issue issue)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = issue.Id,
+            ["identifier"] = issue.Identifier,
+            ["title"] = issue.Title,
+            ["description"] = issue.Description,
+            ["priority"] = issue.Priority,
+            ["state"] = issue.State,
+            ["branch_name"] = issue.BranchName,
+            ["url"] = issue.Url,
+            ["labels"] = issue.Labels.ToArray(),
+            ["blocked_by"] = issue.BlockedBy
+                .Select(
+                    blocker => (object)new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["id"] = blocker.Id,
+                        ["identifier"] = blocker.Identifier,
+                        ["state"] = blocker.State
+                    })
+                .ToArray(),
+            ["created_at"] = issue.CreatedAt?.ToString("O", CultureInfo.InvariantCulture),
+            ["updated_at"] = issue.UpdatedAt?.ToString("O", CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static IReadOnlyList<Token> Tokenize(string template)
+    {
+        var tokens = new List<Token>();
+        var cursor = 0;
+
+        while (cursor < template.Length)
+        {
+            var outputStart = template.IndexOf("{{", cursor, StringComparison.Ordinal);
+            var tagStart = template.IndexOf("{%", cursor, StringComparison.Ordinal);
+            var nextStart = MinPositive(outputStart, tagStart);
+
+            if (nextStart < 0)
+            {
+                tokens.Add(new Token(TokenType.Text, template[cursor..], cursor));
+                break;
+            }
+
+            if (nextStart > cursor)
+            {
+                tokens.Add(new Token(TokenType.Text, template[cursor..nextStart], cursor));
+            }
+
+            var isOutput = nextStart == outputStart;
+            var closeDelimiter = isOutput ? "}}" : "%}";
+            var contentStart = nextStart + 2;
+            var contentEnd = template.IndexOf(closeDelimiter, contentStart, StringComparison.Ordinal);
+            if (contentEnd < 0)
+            {
+                throw WorkflowPromptException.Parse($"Unterminated {(isOutput ? "output" : "tag")} block in workflow prompt template.");
+            }
+
+            var content = template[contentStart..contentEnd].Trim();
+            tokens.Add(new Token(isOutput ? TokenType.Output : TokenType.Tag, content, nextStart));
+            cursor = contentEnd + 2;
+        }
+
+        return tokens;
+    }
+
+    private static (IReadOnlyList<TemplateNode> Nodes, StopToken StopToken) ParseBlock(
+        IReadOnlyList<Token> tokens,
+        ref int index,
+        bool allowElse)
+    {
+        var nodes = new List<TemplateNode>();
+
+        while (index < tokens.Count)
+        {
+            var token = tokens[index++];
+
+            switch (token.Type)
+            {
+                case TokenType.Text:
+                    nodes.Add(new TextNode(token.Content));
+                    break;
+                case TokenType.Output:
+                    nodes.Add(new OutputNode(token.Content));
+                    break;
+                case TokenType.Tag:
+                    if (string.Equals(token.Content, "endif", StringComparison.Ordinal))
+                    {
+                        return (nodes, StopToken.EndIf);
+                    }
+
+                    if (string.Equals(token.Content, "else", StringComparison.Ordinal))
+                    {
+                        if (!allowElse)
+                        {
+                            throw WorkflowPromptException.Parse("Unexpected else block in workflow prompt template.");
+                        }
+
+                        return (nodes, StopToken.Else);
+                    }
+
+                    if (!token.Content.StartsWith("if ", StringComparison.Ordinal))
+                    {
+                        throw WorkflowPromptException.Parse($"Unsupported tag '{token.Content}' in workflow prompt template.");
+                    }
+
+                    var condition = token.Content[3..].Trim();
+                    if (condition.Length == 0)
+                    {
+                        throw WorkflowPromptException.Parse("Workflow prompt if-blocks must declare a condition.");
+                    }
+
+                    var (thenNodes, stopToken) = ParseBlock(tokens, ref index, allowElse: true);
+                    IReadOnlyList<TemplateNode> elseNodes = Array.Empty<TemplateNode>();
+
+                    if (stopToken == StopToken.Else)
+                    {
+                        (elseNodes, stopToken) = ParseBlock(tokens, ref index, allowElse: false);
+                    }
+
+                    if (stopToken != StopToken.EndIf)
+                    {
+                        throw WorkflowPromptException.Parse("Workflow prompt if-blocks must end with endif.");
+                    }
+
+                    nodes.Add(new IfNode(condition, thenNodes, elseNodes));
+                    break;
+                default:
+                    throw new UnreachableException();
+            }
+        }
+
+        return (nodes, StopToken.None);
+    }
+
+    private static int MinPositive(int left, int right)
+    {
+        if (left < 0)
+        {
+            return right;
+        }
+
+        if (right < 0)
+        {
+            return left;
+        }
+
+        return Math.Min(left, right);
+    }
+
+    private abstract class TemplateNode
+    {
+        public abstract void Render(StringBuilder builder, IReadOnlyDictionary<string, object?> variables);
+    }
+
+    private sealed class TextNode(string content) : TemplateNode
+    {
+        public override void Render(StringBuilder builder, IReadOnlyDictionary<string, object?> variables)
+        {
+            builder.Append(content);
+        }
+    }
+
+    private sealed class OutputNode(string expression) : TemplateNode
+    {
+        public override void Render(StringBuilder builder, IReadOnlyDictionary<string, object?> variables)
+        {
+            var value = ResolveExpression(expression, variables);
+            builder.Append(FormatValue(value));
+        }
+    }
+
+    private sealed class IfNode(
+        string condition,
+        IReadOnlyList<TemplateNode> thenNodes,
+        IReadOnlyList<TemplateNode> elseNodes) : TemplateNode
+    {
+        public override void Render(StringBuilder builder, IReadOnlyDictionary<string, object?> variables)
+        {
+            var conditionValue = ResolveExpression(condition, variables);
+            var selectedNodes = IsTruthy(conditionValue)
+                ? thenNodes
+                : elseNodes;
+
+            foreach (var node in selectedNodes)
+            {
+                node.Render(builder, variables);
+            }
+        }
+    }
+
+    private static object? ResolveExpression(string expression, IReadOnlyDictionary<string, object?> variables)
+    {
+        var normalizedExpression = expression.Trim();
+        if (normalizedExpression.Length == 0)
+        {
+            throw WorkflowPromptException.Render("Workflow prompt expressions must not be empty.");
+        }
+
+        if (normalizedExpression.Contains('|', StringComparison.Ordinal))
+        {
+            throw WorkflowPromptException.Render($"Unsupported filter expression '{normalizedExpression}'.");
+        }
+
+        object? current = variables;
+        foreach (var segment in normalizedExpression.Split('.', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = current switch
+            {
+                IReadOnlyDictionary<string, object?> dictionary when dictionary.TryGetValue(segment, out var value) => value,
+                IDictionary<string, object?> dictionary when dictionary.TryGetValue(segment, out var value) => value,
+                _ => throw WorkflowPromptException.Render($"Unknown workflow prompt variable '{normalizedExpression}'.")
+            };
+        }
+
+        return current;
+    }
+
+    private static bool IsTruthy(object? value)
+    {
+        return value switch
+        {
+            null => false,
+            bool boolean => boolean,
+            string text => !string.IsNullOrEmpty(text),
+            Array array => array.Length > 0,
+            IEnumerable<object?> enumerable => enumerable.Any(),
+            int integer => integer != 0,
+            long integer => integer != 0,
+            short integer => integer != 0,
+            byte integer => integer != 0,
+            sbyte integer => integer != 0,
+            uint integer => integer != 0,
+            ulong integer => integer != 0,
+            ushort integer => integer != 0,
+            float number => number != 0,
+            double number => number != 0,
+            decimal number => number != 0,
+            _ => true
+        };
+    }
+
+    private static string FormatValue(object? value)
+    {
+        return value switch
+        {
+            null => string.Empty,
+            string text => text,
+            IReadOnlyDictionary<string, object?> dictionary => string.Join(", ", dictionary.Select(pair => $"{pair.Key}={FormatValue(pair.Value)}")),
+            IDictionary<string, object?> dictionary => string.Join(", ", dictionary.Select(pair => $"{pair.Key}={FormatValue(pair.Value)}")),
+            IEnumerable<object?> enumerable => string.Join(", ", enumerable.Select(FormatValue)),
+            Array array => string.Join(", ", array.Cast<object?>().Select(FormatValue)),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+
+    private sealed record Token(TokenType Type, string Content, int Position);
+
+    private enum TokenType
+    {
+        Text,
+        Output,
+        Tag
+    }
+
+    private enum StopToken
+    {
+        None,
+        Else,
+        EndIf
+    }
+
+    internal sealed class WorkflowPromptException(string code, string message) : InvalidOperationException(message)
+    {
+        public string Code { get; } = code;
+
+        public static WorkflowPromptException Parse(string message)
+        {
+            return new WorkflowPromptException("template_parse_error", message);
+        }
+
+        public static WorkflowPromptException Render(string message)
+        {
+            return new WorkflowPromptException("template_render_error", message);
+        }
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Workspaces/WorkspaceManager.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workspaces/WorkspaceManager.cs
@@ -4,6 +4,7 @@ using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Workspaces;
 using Symphony.Application.Configuration;
 using Symphony.Domain.Workspaces;
+using Symphony.Infrastructure.Processes;
 
 namespace Symphony.Infrastructure.Workspaces;
 
@@ -178,17 +179,7 @@ public sealed class WorkspaceManager(
 
     private static ProcessRunRequest CreateHookRequest(string script, string workspacePath, int timeoutMs)
     {
-        return OperatingSystem.IsWindows()
-            ? new ProcessRunRequest(
-                fileName: "pwsh",
-                arguments: ["-NoProfile", "-NonInteractive", "-Command", script],
-                workingDirectory: workspacePath,
-                timeout: TimeSpan.FromMilliseconds(timeoutMs))
-            : new ProcessRunRequest(
-                fileName: "sh",
-                arguments: ["-lc", script],
-                workingDirectory: workspacePath,
-                timeout: TimeSpan.FromMilliseconds(timeoutMs));
+        return ShellCommandRequestFactory.Create(script, workspacePath, timeoutMs);
     }
 
     private static WorkspacePathInfo ResolveWorkspacePath(string issueIdentifier, string workspaceRoot)

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+using Symphony.Infrastructure.Codex;
+
+namespace Symphony.Infrastructure.Tests.Codex;
+
+public sealed class CodexAppServerClientTests
+{
+    [Fact]
+    public async Task RunAsync_sends_handshake_updates_session_and_handles_approval_and_tool_calls()
+    {
+        var sessionFactory = new TestCodexProcessSessionFactory(
+            async (line, session) =>
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var method = root.TryGetProperty("method", out var methodElement)
+                    ? methodElement.GetString()
+                    : null;
+
+                if (method == "initialize")
+                {
+                    session.EnqueueStdout(new { id = 1, result = new { } });
+                    return;
+                }
+
+                if (method == "thread/start")
+                {
+                    session.EnqueueStdout(new { id = 2, result = new { thread = new { id = "thread-123" } } });
+                    return;
+                }
+
+                if (method == "turn/start")
+                {
+                    session.EnqueueStdout(new { id = 3, result = new { turn = new { id = "turn-456" } } });
+                    session.EnqueueStdout(new { id = "approval-1", method = "approval/request", @params = new { reason = "shell" } });
+                    session.EnqueueStdout(new { id = "tool-1", method = "item/tool/call", @params = new { name = "unsupported" } });
+                    session.EnqueueStdout(new
+                    {
+                        method = "turn/completed",
+                        @params = new
+                        {
+                            message = "done",
+                            usage = new
+                            {
+                                input_tokens = 12,
+                                output_tokens = 5,
+                                total_tokens = 17
+                            }
+                        }
+                    });
+                }
+
+                await Task.CompletedTask;
+            });
+        var client = new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance);
+        using var testContext = CreateContext();
+
+        await client.RunAsync(testContext.Context, Path.GetTempPath(), "Prompt body", CreateCodexOptions());
+
+        var startRequest = Assert.Single(sessionFactory.Requests);
+        Assert.Equal("codex app-server", startRequest.Command);
+        Assert.Equal(Path.GetTempPath(), startRequest.WorkingDirectory);
+        Assert.Equal(
+            [RunAttemptStatus.InitializingSession, RunAttemptStatus.StreamingTurn],
+            testContext.Logger.Entries
+                .Where(entry => entry.Message.Contains("session_status completed", StringComparison.Ordinal))
+                .Select(entry => Assert.IsType<RunAttemptStatus>(entry.State["status"]))
+                .ToArray());
+
+        var latestSession = Assert.IsType<LiveSessionMetadata>(testContext.Context.Session);
+        Assert.Equal("thread-123-turn-456", latestSession.SessionId);
+        Assert.Equal("turn_completed", latestSession.LastCodexEvent);
+        Assert.Equal("done", latestSession.LastCodexMessage);
+        Assert.Equal(12, latestSession.CodexInputTokens);
+        Assert.Equal(5, latestSession.CodexOutputTokens);
+        Assert.Equal(17, latestSession.CodexTotalTokens);
+
+        Assert.NotNull(sessionFactory.Session);
+        Assert.Contains(
+            sessionFactory.Session!.SentLines,
+            line => line.Contains("\"approved\":true", StringComparison.Ordinal));
+        Assert.Contains(
+            sessionFactory.Session.SentLines,
+            line => line.Contains("\"error\":\"unsupported_tool_call\"", StringComparison.Ordinal));
+        Assert.True(sessionFactory.Session.WasKilled);
+    }
+
+    [Fact]
+    public async Task RunAsync_fails_when_codex_requests_user_input()
+    {
+        var sessionFactory = new TestCodexProcessSessionFactory(
+            async (line, session) =>
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var method = root.TryGetProperty("method", out var methodElement)
+                    ? methodElement.GetString()
+                    : null;
+
+                if (method == "initialize")
+                {
+                    session.EnqueueStdout(new { id = 1, result = new { } });
+                    return;
+                }
+
+                if (method == "thread/start")
+                {
+                    session.EnqueueStdout(new { id = 2, result = new { thread = new { id = "thread-123" } } });
+                    return;
+                }
+
+                if (method == "turn/start")
+                {
+                    session.EnqueueStdout(new { id = 3, result = new { turn = new { id = "turn-456" } } });
+                    session.EnqueueStdout(new { id = "input-1", method = "item/tool/requestUserInput", @params = new { prompt = "Need help" } });
+                }
+
+                await Task.CompletedTask;
+            });
+        var client = new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance);
+        using var testContext = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<CodexAgentException>(
+            () => client.RunAsync(testContext.Context, Path.GetTempPath(), "Prompt body", CreateCodexOptions()));
+
+        Assert.Equal("turn_input_required", exception.Code);
+        Assert.NotNull(sessionFactory.Session);
+        Assert.True(sessionFactory.Session!.WasKilled);
+    }
+
+    private static WorkflowCodexOptions CreateCodexOptions()
+    {
+        return new WorkflowCodexOptions(
+            "codex app-server",
+            "never",
+            "workspace-write",
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = "workspaceWrite"
+            },
+            60_000,
+            5_000,
+            300_000);
+    }
+
+    private static TestExecutionContext CreateContext()
+    {
+        var issue = new Issue(
+            id: "21",
+            identifier: "#21",
+            title: "Implement Codex agent runner",
+            description: "Runner story",
+            state: "Todo");
+        var logger = new RecordingLogger<ActiveSessionRegistry>();
+        var registry = new ActiveSessionRegistry(TimeProvider.System, logger);
+        var trackedSession = registry.BeginSession(issue, attempt: null, CancellationToken.None);
+
+        return new TestExecutionContext(
+            trackedSession,
+            trackedSession.CreateExecutionContext(),
+            logger);
+    }
+
+    private sealed class TestExecutionContext : IDisposable
+    {
+        private readonly ActiveSessionRegistry.TrackedActiveSession _trackedSession;
+
+        public TestExecutionContext(
+            ActiveSessionRegistry.TrackedActiveSession trackedSession,
+            QueuedIssueExecutionContext context,
+            RecordingLogger<ActiveSessionRegistry> logger)
+        {
+            _trackedSession = trackedSession;
+            Context = context;
+            Logger = logger;
+        }
+
+        public QueuedIssueExecutionContext Context { get; }
+
+        public RecordingLogger<ActiveSessionRegistry> Logger { get; }
+
+        public void Dispose()
+        {
+            _trackedSession.Dispose();
+        }
+    }
+
+    private sealed class RecordingLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var structuredState = state as IEnumerable<KeyValuePair<string, object?>>;
+            var values = structuredState?.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+                ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+
+            Entries.Add(new LogEntry(formatter(state, exception), values));
+        }
+    }
+
+    private sealed record LogEntry(string Message, IReadOnlyDictionary<string, object?> State);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/TestCodexProcessSessionFactory.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/TestCodexProcessSessionFactory.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using Symphony.Infrastructure.Codex;
+
+namespace Symphony.Infrastructure.Tests.Codex;
+
+internal sealed class TestCodexProcessSessionFactory(Func<string, TestCodexProcessSession, Task>? onSendAsync = null)
+    : ICodexProcessSessionFactory
+{
+    public List<CodexProcessStartRequest> Requests { get; } = [];
+
+    public TestCodexProcessSession? Session { get; private set; }
+
+    public Task<ICodexProcessSession> StartAsync(CodexProcessStartRequest request, CancellationToken cancellationToken)
+    {
+        Requests.Add(request);
+        Session = new TestCodexProcessSession(onSendAsync);
+        return Task.FromResult<ICodexProcessSession>(Session);
+    }
+}
+
+internal sealed class TestCodexProcessSession(Func<string, TestCodexProcessSession, Task>? onSendAsync) : ICodexProcessSession
+{
+    private readonly Channel<string?> _stdout = Channel.CreateUnbounded<string?>();
+    private readonly Channel<string?> _stderr = Channel.CreateUnbounded<string?>();
+    private readonly TaskCompletionSource _exitCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public List<string> SentLines { get; } = [];
+
+    public int? ProcessId { get; init; } = 42_123;
+
+    public int? ExitCode { get; private set; }
+
+    public bool HasExited { get; private set; }
+
+    public bool WasKilled { get; private set; }
+
+    public async Task SendAsync(string line, CancellationToken cancellationToken)
+    {
+        SentLines.Add(line);
+
+        if (onSendAsync is not null)
+        {
+            await onSendAsync(line, this).ConfigureAwait(false);
+        }
+    }
+
+    public Task<string?> ReadStandardOutputLineAsync(TimeSpan? timeout, CancellationToken cancellationToken)
+    {
+        return ReadAsync(_stdout.Reader, timeout, cancellationToken);
+    }
+
+    public Task<string?> ReadStandardErrorLineAsync(TimeSpan? timeout, CancellationToken cancellationToken)
+    {
+        return ReadAsync(_stderr.Reader, timeout, cancellationToken);
+    }
+
+    public Task WaitForExitAsync(CancellationToken cancellationToken)
+    {
+        return _exitCompletionSource.Task.WaitAsync(cancellationToken);
+    }
+
+    public void Kill()
+    {
+        Exit(0);
+        WasKilled = true;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Exit(ExitCode ?? 0);
+        return ValueTask.CompletedTask;
+    }
+
+    public void EnqueueStdout(object payload)
+    {
+        _stdout.Writer.TryWrite(JsonSerializer.Serialize(payload));
+    }
+
+    public void EnqueueStdoutRaw(string line)
+    {
+        _stdout.Writer.TryWrite(line);
+    }
+
+    public void EnqueueStderr(string line)
+    {
+        _stderr.Writer.TryWrite(line);
+    }
+
+    public void CompleteStdout()
+    {
+        _stdout.Writer.TryComplete();
+    }
+
+    public void CompleteStderr()
+    {
+        _stderr.Writer.TryComplete();
+    }
+
+    public void Exit(int exitCode)
+    {
+        if (HasExited)
+        {
+            return;
+        }
+
+        HasExited = true;
+        ExitCode = exitCode;
+        CompleteStdout();
+        CompleteStderr();
+        _exitCompletionSource.TrySetResult();
+    }
+
+    private static async Task<string?> ReadAsync(
+        ChannelReader<string?> reader,
+        TimeSpan? timeout,
+        CancellationToken cancellationToken)
+    {
+        if (timeout is null)
+        {
+            return await ReadCoreAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+
+        using var timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCancellationTokenSource.CancelAfter(timeout.Value);
+        return await ReadCoreAsync(reader, timeoutCancellationTokenSource.Token).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ReadCoreAsync(ChannelReader<string?> reader, CancellationToken cancellationToken)
+    {
+        if (!await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsResolverTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsResolverTests.cs
@@ -81,7 +81,11 @@ public sealed class WorkflowOptionsResolverTests
             {
                 ["approval_policy"] = "on-request",
                 ["thread_sandbox"] = "workspace-write",
-                ["turn_sandbox_policy"] = "read-only",
+                ["turn_sandbox_policy"] = new Dictionary<string, object?>
+                {
+                    ["type"] = "workspaceWrite",
+                    ["writableRoots"] = new object[] { "." }
+                },
                 ["stall_timeout_ms"] = 0
             }
         });
@@ -97,7 +101,9 @@ public sealed class WorkflowOptionsResolverTests
         Assert.DoesNotContain("broken", options.Agent.MaxConcurrentAgentsByState.Keys);
         Assert.Equal("on-request", options.Codex.ApprovalPolicy);
         Assert.Equal("workspace-write", options.Codex.ThreadSandbox);
-        Assert.Equal("read-only", options.Codex.TurnSandboxPolicy);
+        Assert.NotNull(options.Codex.TurnSandboxPolicy);
+        Assert.Equal("workspaceWrite", options.Codex.TurnSandboxPolicy!["type"]);
+        Assert.Equal(["."], Assert.IsType<object[]>(options.Codex.TurnSandboxPolicy["writableRoots"]));
         Assert.Equal(0, options.Codex.StallTimeoutMs);
     }
 

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -7,7 +7,9 @@ using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Trackers;
 using Symphony.Abstractions.Workflows;
 using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Orchestration;
 using Symphony.Infrastructure.Configuration;
+using Symphony.Infrastructure.Orchestration;
 using Symphony.Infrastructure.DependencyInjection;
 using Symphony.Infrastructure.Processes;
 using Symphony.Infrastructure.Workflows;
@@ -35,6 +37,7 @@ public class InfrastructureServiceCollectionExtensionsTests
         Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
         Assert.IsType<ProcessRunner>(serviceProvider.GetRequiredService<IProcessRunner>());
         Assert.IsType<WorkspaceManager>(serviceProvider.GetRequiredService<IWorkspaceManager>());
+        Assert.IsType<CodexQueuedIssueWorker>(serviceProvider.GetRequiredService<IQueuedIssueWorker>());
         var hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
 
         Assert.Contains(hostedServices, service => service is WorkflowStartupValidationHostedService);

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
@@ -1,0 +1,316 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Abstractions.Processes;
+using Symphony.Abstractions.Workflows;
+using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Sessions;
+using Symphony.Domain.Workflows;
+using Symphony.Domain.Workspaces;
+using Symphony.Infrastructure.Codex;
+using Symphony.Infrastructure.Orchestration;
+using Symphony.Infrastructure.Tests.Codex;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Infrastructure.Tests.Orchestration;
+
+public sealed class CodexQueuedIssueWorkerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_builds_prompt_runs_hooks_and_updates_statuses()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "symphony-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspacePath);
+
+        try
+        {
+            var workflowDefinition = new WorkflowDefinition(
+                config: null,
+                promptTemplate: """
+                    Issue {{ issue.identifier }}
+                    {% if attempt %}
+                    Attempt {{ attempt }}
+                    {% endif %}
+                    """);
+            var sessionFactory = new TestCodexProcessSessionFactory(
+                async (line, session) =>
+                {
+                    using var document = JsonDocument.Parse(line);
+                    var root = document.RootElement;
+                    var method = root.TryGetProperty("method", out var methodElement)
+                        ? methodElement.GetString()
+                        : null;
+
+                    if (method == "initialize")
+                    {
+                        session.EnqueueStdout(new { id = 1, result = new { } });
+                    }
+                    else if (method == "thread/start")
+                    {
+                        session.EnqueueStdout(new { id = 2, result = new { thread = new { id = "thread-abc" } } });
+                    }
+                    else if (method == "turn/start")
+                    {
+                        session.EnqueueStdout(new { id = 3, result = new { turn = new { id = "turn-xyz" } } });
+                        session.EnqueueStdout(new { method = "turn/completed", @params = new { message = "done" } });
+                    }
+
+                    await Task.CompletedTask;
+                });
+            var client = new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance);
+            var processRunner = new RecordingProcessRunner();
+            var worker = new CodexQueuedIssueWorker(
+                new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
+                new StaticWorkflowLoader(workflowDefinition),
+                new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
+                processRunner,
+                new WorkflowPromptRenderer(),
+                client,
+                NullLogger<CodexQueuedIssueWorker>.Instance);
+            using var testContext = CreateContext(attempt: 3);
+
+            await worker.ExecuteAsync(testContext.Context);
+
+            Assert.Equal(
+                [
+                    RunAttemptStatus.PreparingWorkspace,
+                    RunAttemptStatus.BuildingPrompt,
+                    RunAttemptStatus.LaunchingAgentProcess,
+                    RunAttemptStatus.InitializingSession,
+                    RunAttemptStatus.StreamingTurn,
+                    RunAttemptStatus.Finishing
+                ],
+                testContext.Logger.Entries
+                    .Where(entry => entry.Message.Contains("session_status completed", StringComparison.Ordinal))
+                    .Select(entry => Assert.IsType<RunAttemptStatus>(entry.State["status"]))
+                    .ToArray());
+            Assert.Equal(2, processRunner.Requests.Count);
+            Assert.All(processRunner.Requests, request => Assert.Equal(workspacePath, request.WorkingDirectory));
+
+            var startRequest = Assert.Single(sessionFactory.Requests);
+            Assert.Equal("codex app-server", startRequest.Command);
+            Assert.Equal(workspacePath, startRequest.WorkingDirectory);
+
+            Assert.NotNull(sessionFactory.Session);
+            var turnStartLine = sessionFactory.Session!.SentLines.Single(line => line.Contains("\"method\":\"turn/start\"", StringComparison.Ordinal));
+            using var turnStartDocument = JsonDocument.Parse(turnStartLine);
+            var turnStartParams = turnStartDocument.RootElement.GetProperty("params");
+
+            Assert.Equal(workspacePath, turnStartParams.GetProperty("cwd").GetString());
+            Assert.Equal("#21: Implement Codex agent runner", turnStartParams.GetProperty("title").GetString());
+            Assert.Contains("Issue #21", turnStartParams.GetProperty("input")[0].GetProperty("text").GetString(), StringComparison.Ordinal);
+            Assert.Contains("Attempt 3", turnStartParams.GetProperty("input")[0].GetProperty("text").GetString(), StringComparison.Ordinal);
+
+            var latestSession = Assert.IsType<LiveSessionMetadata>(testContext.Context.Session);
+            Assert.Equal("thread-abc-turn-xyz", latestSession.SessionId);
+            Assert.Equal("turn_completed", latestSession.LastCodexEvent);
+        }
+        finally
+        {
+            Directory.Delete(workspacePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_fails_fast_when_before_run_hook_fails()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "symphony-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspacePath);
+
+        try
+        {
+            var sessionFactory = new TestCodexProcessSessionFactory();
+            var worker = new CodexQueuedIssueWorker(
+                new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
+                new StaticWorkflowLoader(new WorkflowDefinition(null, "Prompt")),
+                new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
+                new RecordingProcessRunner(exitCodes: [1]),
+                new WorkflowPromptRenderer(),
+                new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance),
+                NullLogger<CodexQueuedIssueWorker>.Instance);
+
+            using var testContext = CreateContext(attempt: null);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => worker.ExecuteAsync(testContext.Context));
+
+            Assert.Empty(sessionFactory.Requests);
+        }
+        finally
+        {
+            Directory.Delete(workspacePath, recursive: true);
+        }
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions()
+    {
+        return new WorkflowServiceOptions(
+            new WorkflowTrackerOptions(
+                "github",
+                "https://api.github.com",
+                "token",
+                null,
+                "AGiorgetti/my-symphony",
+                null,
+                null,
+                ["open"],
+                ["closed"]),
+            new WorkflowPollingOptions(5_000),
+            new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-runner-tests")),
+            new WorkflowHookOptions(
+                null,
+                "Write-Host before",
+                "Write-Host after",
+                null,
+                5_000),
+            new WorkflowAgentOptions(1, 20, 300_000, new Dictionary<string, int>(StringComparer.Ordinal)),
+            new WorkflowCodexOptions(
+                "codex app-server",
+                "never",
+                "workspace-write",
+                new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "workspaceWrite"
+                },
+                60_000,
+                5_000,
+                300_000));
+    }
+
+    private static TestExecutionContext CreateContext(int? attempt)
+    {
+        var issue = new Issue(
+            id: "21",
+            identifier: "#21",
+            title: "Implement Codex agent runner",
+            description: "Implement the runner",
+            state: "Todo");
+        var logger = new RecordingLogger<ActiveSessionRegistry>();
+        var registry = new ActiveSessionRegistry(TimeProvider.System, logger);
+        var trackedSession = registry.BeginSession(issue, attempt, CancellationToken.None);
+
+        return new TestExecutionContext(
+            trackedSession,
+            trackedSession.CreateExecutionContext(),
+            logger);
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions options) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(options);
+        }
+    }
+
+    private sealed class StaticWorkflowLoader(WorkflowDefinition definition) : IWorkflowLoader
+    {
+        public Task<WorkflowDefinition> LoadAsync(string workflowPath, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(definition);
+        }
+    }
+
+    private sealed class StaticWorkspaceManager(Workspace workspace) : IWorkspaceManager
+    {
+        public Task<Workspace> CreateForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workspace);
+        }
+
+        public Task DeleteForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingProcessRunner(IReadOnlyList<int>? exitCodes = null) : IProcessRunner
+    {
+        private readonly Queue<int> _exitCodes = new((exitCodes ?? [0, 0]).ToArray());
+
+        public List<ProcessRunRequest> Requests { get; } = [];
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            var exitCode = _exitCodes.Count > 0
+                ? _exitCodes.Dequeue()
+                : 0;
+
+            return Task.FromResult(
+                new ProcessRunResult(
+                    exitCode,
+                    standardOutput: string.Empty,
+                    standardError: string.Empty,
+                    startedAt: DateTimeOffset.UtcNow,
+                    finishedAt: DateTimeOffset.UtcNow));
+        }
+    }
+
+    private sealed class TestExecutionContext : IDisposable
+    {
+        private readonly ActiveSessionRegistry.TrackedActiveSession _trackedSession;
+
+        public TestExecutionContext(
+            ActiveSessionRegistry.TrackedActiveSession trackedSession,
+            QueuedIssueExecutionContext context,
+            RecordingLogger<ActiveSessionRegistry> logger)
+        {
+            _trackedSession = trackedSession;
+            Context = context;
+            Logger = logger;
+        }
+
+        public QueuedIssueExecutionContext Context { get; }
+
+        public RecordingLogger<ActiveSessionRegistry> Logger { get; }
+
+        public void Dispose()
+        {
+            _trackedSession.Dispose();
+        }
+    }
+
+    private sealed class RecordingLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var structuredState = state as IEnumerable<KeyValuePair<string, object?>>;
+            var values = structuredState?.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+                ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+
+            Entries.Add(new LogEntry(formatter(state, exception), values));
+        }
+    }
+
+    private sealed record LogEntry(string Message, IReadOnlyDictionary<string, object?> State);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowPromptRendererTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowPromptRendererTests.cs
@@ -1,0 +1,81 @@
+using Symphony.Domain.Issues;
+using Symphony.Domain.Workflows;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Infrastructure.Tests.Workflows;
+
+public sealed class WorkflowPromptRendererTests
+{
+    private readonly WorkflowPromptRenderer _renderer = new();
+
+    [Fact]
+    public void Render_supports_strict_interpolation_and_if_else_blocks()
+    {
+        var definition = new WorkflowDefinition(
+            config: null,
+            promptTemplate: """
+                Issue {{ issue.identifier }}
+                {% if attempt %}
+                Attempt {{ attempt }}
+                {% endif %}
+                {% if issue.description %}
+                {{ issue.description }}
+                {% else %}
+                No description provided.
+                {% endif %}
+                Labels: {{ issue.labels }}
+                """);
+
+        var result = _renderer.Render(
+            definition,
+            new Issue(
+                id: "1",
+                identifier: "#42",
+                title: "Runner test",
+                description: "Implement the agent runner",
+                state: "Todo",
+                labels: ["priority:p0", "status:in-progress"]),
+            attempt: 2);
+
+        Assert.Contains("Issue #42", result, StringComparison.Ordinal);
+        Assert.Contains("Attempt 2", result, StringComparison.Ordinal);
+        Assert.Contains("Implement the agent runner", result, StringComparison.Ordinal);
+        Assert.Contains("priority:p0, status:in-progress", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_throws_for_unknown_variables()
+    {
+        var definition = new WorkflowDefinition(
+            config: null,
+            promptTemplate: "Hello {{ issue.unknown_field }}");
+
+        var exception = Assert.Throws<WorkflowPromptRenderer.WorkflowPromptException>(
+            () => _renderer.Render(definition, CreateIssue(), attempt: null));
+
+        Assert.Equal("template_render_error", exception.Code);
+    }
+
+    [Fact]
+    public void Render_throws_for_unterminated_if_block()
+    {
+        var definition = new WorkflowDefinition(
+            config: null,
+            promptTemplate: "{% if issue.description %}broken");
+
+        var exception = Assert.Throws<WorkflowPromptRenderer.WorkflowPromptException>(
+            () => _renderer.Render(definition, CreateIssue(), attempt: null));
+
+        Assert.Equal("template_parse_error", exception.Code);
+    }
+
+    private static Issue CreateIssue()
+    {
+        return new Issue(
+            id: "1",
+            identifier: "#1",
+            title: "Title",
+            description: "Description",
+            state: "Todo");
+    }
+}


### PR DESCRIPTION
Closes #21

#### Context

Issue `#21` needs the first real Codex execution path in the .NET runtime so dispatches stop ending in a placeholder worker and instead follow the `SPEC.md` runner contract.

#### TL;DR

Implement the Codex-backed queued worker, app-server client, and prompt rendering foundation.

#### Summary

- Replace the no-op queued worker with a Codex-backed infrastructure worker
- Add workspace hook execution, strict workflow prompt rendering, and session handshake handling
- Treat `codex.turn_sandbox_policy` as a structured object and expand infrastructure coverage

#### Alternatives

- Keep the placeholder worker and defer the runner to `#23`; rejected because `#21` is the execution seam that `#23` depends on
- Add a general-purpose template engine package now; rejected in favor of a strict renderer that covers the shipped workflow syntax already used in this repo

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added infrastructure tests for the Codex app-server client, queued worker flow, and prompt renderer