### PR TITLE
E2-S3: add workflow reload fallback cache

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -244,8 +244,9 @@ Notes:
 - `tracker.active_states` and `tracker.terminal_states` should be explicitly set for your tracker
   workflow.
 - If `WORKFLOW.md` is missing or has invalid YAML at startup, Symphony does not boot.
-- If a later reload fails, Symphony keeps running with the last known good workflow settings,
-  including the last valid poll interval, and logs the reload error until the file is fixed.
+- If a later reload fails, Symphony keeps running with the last known good workflow settings and
+  prompt template for future runs, including the last valid poll interval, and logs the reload
+  error until the file is fixed.
 
 ## Web dashboard
 

--- a/dotnet/src/Symphony.Application/Configuration/IWorkflowDefinitionProvider.cs
+++ b/dotnet/src/Symphony.Application/Configuration/IWorkflowDefinitionProvider.cs
@@ -1,0 +1,8 @@
+using Symphony.Domain.Workflows;
+
+namespace Symphony.Application.Configuration;
+
+public interface IWorkflowDefinitionProvider
+{
+    Task<WorkflowDefinition> GetCurrentDefinitionAsync(CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsProvider.cs
+++ b/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsProvider.cs
@@ -1,26 +1,213 @@
+using Microsoft.Extensions.Logging;
 using Symphony.Abstractions.Workflows;
 using Symphony.Application.Configuration;
+using Symphony.Domain.Workflows;
 
 namespace Symphony.Infrastructure.Configuration;
 
-public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider
+public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider, IWorkflowDefinitionProvider, IDisposable
 {
     private readonly IWorkflowLoader _workflowLoader;
     private readonly IWorkflowOptionsResolver _workflowOptionsResolver;
+    private readonly ILogger<WorkflowOptionsProvider> _logger;
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
+    private WorkflowSnapshot? _currentSnapshot;
+    private FileSystemWatcher? _watcher;
+    private string? _watchedWorkflowPath;
+    private int _reloadRequested;
+    private bool _disposed;
 
     public WorkflowOptionsProvider(
         IWorkflowLoader workflowLoader,
-        IWorkflowOptionsResolver workflowOptionsResolver)
+        IWorkflowOptionsResolver workflowOptionsResolver,
+        ILogger<WorkflowOptionsProvider> logger)
     {
         _workflowLoader = workflowLoader;
         _workflowOptionsResolver = workflowOptionsResolver;
+        _logger = logger;
     }
 
     public async Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
-        var workflowPath = Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md");
-        var workflowDefinition = await _workflowLoader.LoadAsync(workflowPath, cancellationToken).ConfigureAwait(false);
-
-        return _workflowOptionsResolver.Resolve(workflowDefinition);
+        var snapshot = await GetCurrentSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return snapshot.Options;
     }
+
+    public async Task<WorkflowDefinition> GetCurrentDefinitionAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await GetCurrentSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return snapshot.Definition;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _watcher?.Dispose();
+        _reloadGate.Dispose();
+    }
+
+    private async Task<WorkflowSnapshot> GetCurrentSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var workflowPath = GetWorkflowPath();
+
+        await _reloadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            EnsureWatcher(workflowPath);
+
+            var currentSnapshot = _currentSnapshot;
+            if (currentSnapshot is null)
+            {
+                currentSnapshot = await LoadSnapshotAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+                _currentSnapshot = currentSnapshot;
+                Volatile.Write(ref _reloadRequested, 0);
+                return currentSnapshot;
+            }
+
+            if (!StringComparer.Ordinal.Equals(currentSnapshot.WorkflowPath, workflowPath)
+                || Volatile.Read(ref _reloadRequested) == 1
+                || HasWorkflowFileChanged(currentSnapshot.FileState, workflowPath))
+            {
+                currentSnapshot = await TryReloadSnapshotAsync(currentSnapshot, workflowPath, cancellationToken).ConfigureAwait(false);
+            }
+
+            return currentSnapshot;
+        }
+        finally
+        {
+            _reloadGate.Release();
+        }
+    }
+
+    private async Task<WorkflowSnapshot> TryReloadSnapshotAsync(
+        WorkflowSnapshot currentSnapshot,
+        string workflowPath,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var reloadedSnapshot = await LoadSnapshotAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+            _currentSnapshot = reloadedSnapshot;
+
+            _logger.LogInformation(
+                "workflow_reload completed workflow_path={workflow_path} outcome=completed",
+                workflowPath);
+
+            return reloadedSnapshot;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "workflow_reload failed workflow_path={workflow_path} error_code={error_code} outcome=failed",
+                workflowPath,
+                GetErrorCode(exception));
+
+            return currentSnapshot;
+        }
+        finally
+        {
+            Volatile.Write(ref _reloadRequested, 0);
+        }
+    }
+
+    private async Task<WorkflowSnapshot> LoadSnapshotAsync(string workflowPath, CancellationToken cancellationToken)
+    {
+        var workflowDefinition = await _workflowLoader.LoadAsync(workflowPath, cancellationToken).ConfigureAwait(false);
+        var workflowOptions = _workflowOptionsResolver.Resolve(workflowDefinition);
+
+        return new WorkflowSnapshot(
+            workflowPath,
+            GetWorkflowFileState(workflowPath),
+            workflowDefinition,
+            workflowOptions);
+    }
+
+    private void EnsureWatcher(string workflowPath)
+    {
+        if (StringComparer.Ordinal.Equals(_watchedWorkflowPath, workflowPath))
+        {
+            return;
+        }
+
+        _watcher?.Dispose();
+
+        var directoryPath = Path.GetDirectoryName(workflowPath);
+        if (string.IsNullOrWhiteSpace(directoryPath))
+        {
+            directoryPath = Directory.GetCurrentDirectory();
+        }
+
+        var fileName = Path.GetFileName(workflowPath);
+        var watcher = new FileSystemWatcher(directoryPath, fileName)
+        {
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.CreationTime,
+            IncludeSubdirectories = false,
+            EnableRaisingEvents = true
+        };
+
+        watcher.Changed += OnWorkflowFileChanged;
+        watcher.Created += OnWorkflowFileChanged;
+        watcher.Deleted += OnWorkflowFileChanged;
+        watcher.Renamed += OnWorkflowFileChanged;
+
+        _watcher = watcher;
+        _watchedWorkflowPath = workflowPath;
+    }
+
+    private void OnWorkflowFileChanged(object sender, FileSystemEventArgs args)
+    {
+        Volatile.Write(ref _reloadRequested, 1);
+    }
+
+    private static string GetWorkflowPath()
+    {
+        return Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md");
+    }
+
+    private static bool HasWorkflowFileChanged(WorkflowFileState fileState, string workflowPath)
+    {
+        return fileState != GetWorkflowFileState(workflowPath);
+    }
+
+    private static WorkflowFileState GetWorkflowFileState(string workflowPath)
+    {
+        if (!File.Exists(workflowPath))
+        {
+            return new WorkflowFileState(false, DateTime.MinValue, 0);
+        }
+
+        var fileInfo = new FileInfo(workflowPath);
+        return new WorkflowFileState(true, fileInfo.LastWriteTimeUtc, fileInfo.Length);
+    }
+
+    private static string GetErrorCode(Exception exception)
+    {
+        return exception switch
+        {
+            WorkflowLoadException workflowLoadException => workflowLoadException.Code,
+            WorkflowConfigurationException workflowConfigurationException => workflowConfigurationException.Code,
+            _ => "workflow_reload_error"
+        };
+    }
+
+    private sealed record WorkflowSnapshot(
+        string WorkflowPath,
+        WorkflowFileState FileState,
+        WorkflowDefinition Definition,
+        WorkflowServiceOptions Options);
+
+    private readonly record struct WorkflowFileState(bool Exists, DateTime LastWriteTimeUtc, long Length);
 }

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -23,7 +23,9 @@ public static class InfrastructureServiceCollectionExtensions
 
         services.AddSingleton<InfrastructureServiceMarker>();
         services.AddSingleton<IWorkflowOptionsResolver, WorkflowOptionsResolver>();
-        services.AddSingleton<IWorkflowOptionsProvider, WorkflowOptionsProvider>();
+        services.AddSingleton<WorkflowOptionsProvider>();
+        services.AddSingleton<IWorkflowOptionsProvider>(serviceProvider => serviceProvider.GetRequiredService<WorkflowOptionsProvider>());
+        services.AddSingleton<IWorkflowDefinitionProvider>(serviceProvider => serviceProvider.GetRequiredService<WorkflowOptionsProvider>());
         services.AddSingleton<ITrackerClientOptionsProvider, TrackerClientOptionsProvider>();
         services.AddSingleton<IWorkflowLoader, YamlWorkflowLoader>();
         services.AddHostedService<WorkflowStartupValidationHostedService>();

--- a/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Symphony.Abstractions.Processes;
-using Symphony.Abstractions.Workflows;
 using Symphony.Abstractions.Workspaces;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
@@ -13,7 +12,7 @@ namespace Symphony.Infrastructure.Orchestration;
 
 internal sealed class CodexQueuedIssueWorker(
     IWorkflowOptionsProvider workflowOptionsProvider,
-    IWorkflowLoader workflowLoader,
+    IWorkflowDefinitionProvider workflowDefinitionProvider,
     IWorkspaceManager workspaceManager,
     IProcessRunner processRunner,
     WorkflowPromptRenderer workflowPromptRenderer,
@@ -47,7 +46,7 @@ internal sealed class CodexQueuedIssueWorker(
             shouldRunAfterRunHook = true;
 
             context.UpdateStatus(RunAttemptStatus.BuildingPrompt);
-            var workflowDefinition = await workflowLoader.LoadAsync(GetWorkflowPath(), context.CancellationToken).ConfigureAwait(false);
+            var workflowDefinition = await workflowDefinitionProvider.GetCurrentDefinitionAsync(context.CancellationToken).ConfigureAwait(false);
             var prompt = workflowPromptRenderer.Render(workflowDefinition, context.Issue, context.Attempt);
 
             context.UpdateStatus(RunAttemptStatus.LaunchingAgentProcess);
@@ -150,10 +149,5 @@ internal sealed class CodexQueuedIssueWorker(
                 ShellCommandRequestFactory.Create(command, workspacePath, timeoutMs),
                 cancellationToken)
             .ConfigureAwait(false);
-    }
-
-    private static string GetWorkflowPath()
-    {
-        return Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md");
     }
 }

--- a/dotnet/tests/Symphony.Application.Tests/Polling/PollingBackgroundServiceTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Polling/PollingBackgroundServiceTests.cs
@@ -118,6 +118,43 @@ public sealed class PollingBackgroundServiceTests
             entry => entry.Message.Contains("polling_service completed", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task StartAsync_uses_reloaded_poll_interval_for_future_ticks()
+    {
+        var firstTick = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondTick = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationCount = 0;
+        var service = new PollingBackgroundService(
+            new SequencedWorkflowOptionsProvider(
+                CreateWorkflowOptions(intervalMs: 200),
+                CreateWorkflowOptions(intervalMs: 40)),
+            new DelegatePollingIterationHandler(
+                (workflowOptions, _) =>
+                {
+                    var currentCount = Interlocked.Increment(ref invocationCount);
+
+                    if (currentCount == 1)
+                    {
+                        firstTick.TrySetResult(workflowOptions.Polling.IntervalMs);
+                    }
+                    else if (currentCount == 2)
+                    {
+                        secondTick.TrySetResult(workflowOptions.Polling.IntervalMs);
+                    }
+
+                    return Task.CompletedTask;
+                }),
+            TimeProvider.System,
+            NullLogger<PollingBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(200, await firstTick.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.Equal(40, await secondTick.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
     private static WorkflowServiceOptions CreateWorkflowOptions(int intervalMs)
     {
         return new WorkflowServiceOptions(
@@ -159,6 +196,18 @@ public sealed class PollingBackgroundServiceTests
         public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class SequencedWorkflowOptionsProvider(params WorkflowServiceOptions[] workflowOptions) : IWorkflowOptionsProvider
+    {
+        private readonly WorkflowServiceOptions[] _workflowOptions = workflowOptions;
+        private int _nextIndex;
+
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            var index = Math.Min(Interlocked.Increment(ref _nextIndex) - 1, _workflowOptions.Length - 1);
+            return Task.FromResult(_workflowOptions[index]);
         }
     }
 

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsProviderTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsProviderTests.cs
@@ -1,0 +1,212 @@
+using Microsoft.Extensions.Logging;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Workflows;
+using Symphony.Infrastructure.Configuration;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Infrastructure.Tests.Configuration;
+
+public sealed class WorkflowOptionsProviderTests
+{
+    private static readonly SemaphoreSlim CurrentDirectoryGate = new(1, 1);
+    private static long _lastWriteSequence;
+
+    [Fact]
+    public async Task GetCurrentAsync_reloads_workflow_options_and_prompt_after_file_change()
+    {
+        var tempDirectory = CreateTemporaryDirectory();
+        var workflowPath = Path.Combine(tempDirectory, "WORKFLOW.md");
+        await WriteWorkflowFileAsync(
+            workflowPath,
+            """
+            ---
+            tracker:
+              kind: github
+              api_key: token
+              repository: AGiorgetti/my-symphony
+            polling:
+              interval_ms: 125
+            ---
+            Initial prompt for {{ issue.identifier }}
+            """);
+
+        var logger = new TestLogger<WorkflowOptionsProvider>();
+        using var provider = new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), logger);
+
+        await CurrentDirectoryGate.WaitAsync();
+
+        try
+        {
+            var previousDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDirectory);
+
+                var initialOptions = await provider.GetCurrentAsync();
+                var initialDefinition = await provider.GetCurrentDefinitionAsync();
+
+                await WriteWorkflowFileAsync(
+                    workflowPath,
+                    """
+                    ---
+                    tracker:
+                      kind: github
+                      api_key: token
+                      repository: AGiorgetti/my-symphony
+                    polling:
+                      interval_ms: 250
+                    ---
+                    Updated prompt for {{ issue.title }}
+                    """);
+
+                var reloadedOptions = await provider.GetCurrentAsync();
+                var reloadedDefinition = await provider.GetCurrentDefinitionAsync();
+
+                Assert.Equal(125, initialOptions.Polling.IntervalMs);
+                Assert.Equal("Initial prompt for {{ issue.identifier }}", initialDefinition.PromptTemplate);
+                Assert.Equal(250, reloadedOptions.Polling.IntervalMs);
+                Assert.Equal("Updated prompt for {{ issue.title }}", reloadedDefinition.PromptTemplate);
+                Assert.Contains(
+                    logger.Entries,
+                    entry => entry.Message.Contains("workflow_reload completed", StringComparison.Ordinal));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousDirectory);
+            }
+        }
+        finally
+        {
+            CurrentDirectoryGate.Release();
+        }
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_invalid_reload_keeps_last_known_good_and_logs_error()
+    {
+        var tempDirectory = CreateTemporaryDirectory();
+        var workflowPath = Path.Combine(tempDirectory, "WORKFLOW.md");
+        await WriteWorkflowFileAsync(
+            workflowPath,
+            """
+            ---
+            tracker:
+              kind: github
+              api_key: token
+              repository: AGiorgetti/my-symphony
+            polling:
+              interval_ms: 125
+            ---
+            Initial prompt for {{ issue.identifier }}
+            """);
+
+        var logger = new TestLogger<WorkflowOptionsProvider>();
+        using var provider = new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), logger);
+
+        await CurrentDirectoryGate.WaitAsync();
+
+        try
+        {
+            var previousDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDirectory);
+
+                var initialOptions = await provider.GetCurrentAsync();
+                var initialDefinition = await provider.GetCurrentDefinitionAsync();
+
+                await WriteWorkflowFileAsync(
+                    workflowPath,
+                    """
+                    ---
+                    tracker:
+                      kind: github
+                      repository: AGiorgetti/my-symphony
+                    polling:
+                      interval_ms: 500
+                    ---
+                    Broken prompt
+                    """);
+
+                var currentOptions = await provider.GetCurrentAsync();
+                var currentDefinition = await provider.GetCurrentDefinitionAsync();
+
+                Assert.Equal(initialOptions, currentOptions);
+                Assert.Equal(initialDefinition, currentDefinition);
+
+                var errorEntry = logger.Entries.Last(
+                    entry => entry.Message.Contains("workflow_reload failed", StringComparison.Ordinal));
+                Assert.Equal("missing_tracker_api_key", Assert.IsType<string>(errorEntry.State["error_code"]));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousDirectory);
+            }
+        }
+        finally
+        {
+            CurrentDirectoryGate.Release();
+        }
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"symphony-provider-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static async Task WriteWorkflowFileAsync(string workflowPath, string content)
+    {
+        await File.WriteAllTextAsync(workflowPath, content);
+        File.SetLastWriteTimeUtc(
+            workflowPath,
+            DateTime.UtcNow.AddSeconds(Interlocked.Increment(ref _lastWriteSequence)));
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<TestLogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var structuredState = state as IEnumerable<KeyValuePair<string, object?>>;
+            var values = structuredState?.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+                ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+
+            Entries.Add(new TestLogEntry(logLevel, formatter(state, exception), values, exception));
+        }
+    }
+
+    private sealed record TestLogEntry(
+        LogLevel LogLevel,
+        string Message,
+        IReadOnlyDictionary<string, object?> State,
+        Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -33,6 +33,10 @@ public class InfrastructureServiceCollectionExtensionsTests
         Assert.NotNull(serviceProvider.GetService<InfrastructureServiceMarker>());
         Assert.IsType<WorkflowOptionsResolver>(serviceProvider.GetRequiredService<IWorkflowOptionsResolver>());
         Assert.IsType<WorkflowOptionsProvider>(serviceProvider.GetRequiredService<IWorkflowOptionsProvider>());
+        Assert.IsType<WorkflowOptionsProvider>(serviceProvider.GetRequiredService<IWorkflowDefinitionProvider>());
+        Assert.Same(
+            serviceProvider.GetRequiredService<IWorkflowOptionsProvider>(),
+            serviceProvider.GetRequiredService<IWorkflowDefinitionProvider>());
         Assert.IsType<TrackerClientOptionsProvider>(serviceProvider.GetRequiredService<ITrackerClientOptionsProvider>());
         Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
         Assert.IsType<ProcessRunner>(serviceProvider.GetRequiredService<IProcessRunner>());

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Symphony.Abstractions.Processes;
-using Symphony.Abstractions.Workflows;
 using Symphony.Abstractions.Workspaces;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
@@ -65,7 +64,7 @@ public sealed class CodexQueuedIssueWorkerTests
             var processRunner = new RecordingProcessRunner();
             var worker = new CodexQueuedIssueWorker(
                 new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
-                new StaticWorkflowLoader(workflowDefinition),
+                new StaticWorkflowDefinitionProvider(workflowDefinition),
                 new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
                 processRunner,
                 new WorkflowPromptRenderer(),
@@ -126,7 +125,7 @@ public sealed class CodexQueuedIssueWorkerTests
             var sessionFactory = new TestCodexProcessSessionFactory();
             var worker = new CodexQueuedIssueWorker(
                 new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
-                new StaticWorkflowLoader(new WorkflowDefinition(null, "Prompt")),
+                new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
                 new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
                 new RecordingProcessRunner(exitCodes: [1]),
                 new WorkflowPromptRenderer(),
@@ -205,9 +204,9 @@ public sealed class CodexQueuedIssueWorkerTests
         }
     }
 
-    private sealed class StaticWorkflowLoader(WorkflowDefinition definition) : IWorkflowLoader
+    private sealed class StaticWorkflowDefinitionProvider(WorkflowDefinition definition) : IWorkflowDefinitionProvider
     {
-        public Task<WorkflowDefinition> LoadAsync(string workflowPath, CancellationToken cancellationToken = default)
+        public Task<WorkflowDefinition> GetCurrentDefinitionAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(definition);
         }

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Symphony.Application.Configuration;
 using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Workflows;
@@ -27,7 +28,7 @@ public sealed class WorkflowStartupValidationHostedServiceTests
         var loggerProvider = new TestLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
         var service = new WorkflowStartupValidationHostedService(
-            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver()),
+            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), NullLogger<WorkflowOptionsProvider>.Instance),
             loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
 
         await CurrentDirectoryGate.WaitAsync();
@@ -77,7 +78,7 @@ public sealed class WorkflowStartupValidationHostedServiceTests
         var loggerProvider = new TestLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
         var service = new WorkflowStartupValidationHostedService(
-            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver()),
+            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), NullLogger<WorkflowOptionsProvider>.Instance),
             loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
 
         await CurrentDirectoryGate.WaitAsync();


### PR DESCRIPTION
Closes #14

#### Context

Issue `#14` needs the `SPEC.md` workflow-reload contract so future runs pick up `WORKFLOW.md` config and prompt changes without crashing on broken edits.

#### TL;DR

Add a cached workflow snapshot that reloads `WORKFLOW.md` on change and keeps the last good config and prompt on reload failures.

#### Summary

- Cache the last valid `WORKFLOW.md` definition and typed options in a shared provider
- Reload on file changes for future config reads and future prompt rendering while logging failures with context
- Add polling, provider, DI, startup-validation, and worker coverage for reload and fallback behavior

#### Alternatives

- Keep reload as a polling-only re-read path; rejected because prompt rendering and other consumers would still bypass the last-known-good snapshot
- Let workers continue loading `WORKFLOW.md` directly; rejected because invalid edits would still break future runs instead of using the cached prompt

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added targeted provider and polling tests for reload success, invalid reload fallback, and future-tick reapplication