### PR TITLE
E7-S1: add dashboard shell at root

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -260,6 +260,9 @@ When enabled via service configuration (for example `server.port`), Symphony exp
 
 - Dashboard at `/`
 - JSON APIs under `/api/v1/*`
+
+The dashboard shell is implemented as an interactive-server Blazor page. It is an operator-facing
+surface only: if dashboard rendering fails, the orchestrator and JSON API continue running.
 - `GET /api/v1/state` for the current running/retrying snapshot, live token totals, and runtime counts
 - `GET /api/v1/{issueIdentifier}` for issue-specific runtime details with a `404` JSON error envelope when the issue is not tracked
 - `POST /api/v1/refresh` to queue an immediate poll-and-reconcile cycle; repeated requests coalesce while one is already pending

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<ApplicationServiceMarker>();
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<PollingRefreshTrigger>();
+        services.TryAddSingleton<PollingStatusTracker>();
         services.TryAddSingleton<RetryDelayPlanner>();
         services.TryAddSingleton<OrchestratorDispatchQueue>();
         services.TryAddSingleton<IOrchestratorDispatchQueue>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());

--- a/dotnet/src/Symphony.Application/Polling/PollingBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Polling/PollingBackgroundService.cs
@@ -8,6 +8,7 @@ public sealed class PollingBackgroundService : BackgroundService
 {
     private readonly IPollingIterationHandler _pollingIterationHandler;
     private readonly PollingRefreshTrigger _pollingRefreshTrigger;
+    private readonly PollingStatusTracker _pollingStatusTracker;
     private readonly ILogger<PollingBackgroundService> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly IWorkflowOptionsProvider _workflowOptionsProvider;
@@ -16,12 +17,14 @@ public sealed class PollingBackgroundService : BackgroundService
         IWorkflowOptionsProvider workflowOptionsProvider,
         IPollingIterationHandler pollingIterationHandler,
         PollingRefreshTrigger pollingRefreshTrigger,
+        PollingStatusTracker pollingStatusTracker,
         TimeProvider timeProvider,
         ILogger<PollingBackgroundService> logger)
     {
         _workflowOptionsProvider = workflowOptionsProvider;
         _pollingIterationHandler = pollingIterationHandler;
         _pollingRefreshTrigger = pollingRefreshTrigger;
+        _pollingStatusTracker = pollingStatusTracker;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -37,6 +40,8 @@ public sealed class PollingBackgroundService : BackgroundService
         {
             while (!stoppingToken.IsCancellationRequested)
             {
+                var tickStartedAt = _timeProvider.GetUtcNow();
+                _pollingStatusTracker.RecordStarted(tickStartedAt);
                 _logger.LogInformation(
                     "poll_tick started poll_interval_ms={poll_interval_ms} outcome=started",
                     currentOptions.Polling.IntervalMs);
@@ -44,6 +49,7 @@ public sealed class PollingBackgroundService : BackgroundService
                 try
                 {
                     await _pollingIterationHandler.ExecuteAsync(currentOptions, stoppingToken).ConfigureAwait(false);
+                    _pollingStatusTracker.RecordCompleted(_timeProvider.GetUtcNow());
                     _logger.LogInformation(
                         "poll_tick completed poll_interval_ms={poll_interval_ms} outcome=completed",
                         currentOptions.Polling.IntervalMs);
@@ -54,6 +60,7 @@ public sealed class PollingBackgroundService : BackgroundService
                 }
                 catch (Exception exception)
                 {
+                    _pollingStatusTracker.RecordFailed(_timeProvider.GetUtcNow(), exception.Message);
                     _logger.LogError(
                         exception,
                         "poll_tick failed poll_interval_ms={poll_interval_ms} outcome=failed",

--- a/dotnet/src/Symphony.Application/Polling/PollingStatusTracker.cs
+++ b/dotnet/src/Symphony.Application/Polling/PollingStatusTracker.cs
@@ -1,0 +1,64 @@
+namespace Symphony.Application.Polling;
+
+public sealed class PollingStatusTracker
+{
+    private readonly Lock stateLock = new();
+    private PollingStatusSnapshot snapshot = new(
+        LastStartedAt: null,
+        LastCompletedAt: null,
+        LastSuccessfulTickAt: null,
+        LastFailedAt: null,
+        LastError: null);
+
+    public void RecordStarted(DateTimeOffset startedAt)
+    {
+        lock (stateLock)
+        {
+            snapshot = snapshot with
+            {
+                LastStartedAt = startedAt
+            };
+        }
+    }
+
+    public void RecordCompleted(DateTimeOffset completedAt)
+    {
+        lock (stateLock)
+        {
+            snapshot = snapshot with
+            {
+                LastCompletedAt = completedAt,
+                LastSuccessfulTickAt = completedAt,
+                LastError = null
+            };
+        }
+    }
+
+    public void RecordFailed(DateTimeOffset failedAt, string? error)
+    {
+        lock (stateLock)
+        {
+            snapshot = snapshot with
+            {
+                LastCompletedAt = failedAt,
+                LastFailedAt = failedAt,
+                LastError = string.IsNullOrWhiteSpace(error) ? null : error.Trim()
+            };
+        }
+    }
+
+    public PollingStatusSnapshot GetSnapshot()
+    {
+        lock (stateLock)
+        {
+            return snapshot;
+        }
+    }
+}
+
+public sealed record PollingStatusSnapshot(
+    DateTimeOffset? LastStartedAt,
+    DateTimeOffset? LastCompletedAt,
+    DateTimeOffset? LastSuccessfulTickAt,
+    DateTimeOffset? LastFailedAt,
+    string? LastError);

--- a/dotnet/src/Symphony.Host/Components/App.razor
+++ b/dotnet/src/Symphony.Host/Components/App.razor
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <title>Symphony Dashboard</title>
+    <link rel="stylesheet" href="app.css" />
+    <HeadOutlet @rendermode="InteractiveServer" />
+</head>
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
+++ b/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
@@ -1,0 +1,5 @@
+@inherits LayoutComponentBase
+
+<div class="shell">
+    @Body
+</div>

--- a/dotnet/src/Symphony.Host/Components/Pages/DashboardPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/DashboardPage.razor
@@ -1,0 +1,18 @@
+@page "/"
+
+<ErrorBoundary>
+    <ChildContent>
+        <DashboardShellContent />
+    </ChildContent>
+    <ErrorContent>
+        <main class="dashboard-page">
+            <section class="hero">
+                <p class="eyebrow">Symphony</p>
+                <h1>Dashboard temporarily unavailable</h1>
+                <p class="lede">
+                    The UI hit an error while rendering. Orchestrator background work keeps running.
+                </p>
+            </section>
+        </main>
+    </ErrorContent>
+</ErrorBoundary>

--- a/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
@@ -1,0 +1,127 @@
+@inject IDashboardStateService DashboardStateService
+
+<main class="dashboard-page">
+    <section class="hero">
+        <p class="eyebrow">Symphony</p>
+        <h1>Runtime Control Surface</h1>
+        <p class="lede">
+            Operator-facing dashboard for the in-memory orchestrator. The UI reflects runtime state but
+            is not required for orchestration correctness.
+        </p>
+    </section>
+
+    <section class="summary-grid" aria-label="System summary">
+        <article class="metric-card @(GetHealthClass(snapshot.ServiceHealth))">
+            <span class="metric-label">Service Health</span>
+            <strong class="metric-value">@snapshot.ServiceHealth</strong>
+            <span class="metric-meta">@GetHealthMessage(snapshot)</span>
+        </article>
+        <article class="metric-card">
+            <span class="metric-label">Orchestrator Mode</span>
+            <strong class="metric-value">@snapshot.OrchestratorMode</strong>
+            <span class="metric-meta">State is tracked in-process and served live.</span>
+        </article>
+        <article class="metric-card">
+            <span class="metric-label">Last Poll Tick</span>
+            <strong class="metric-value">@FormatTimestamp(snapshot.LastPollTickAt)</strong>
+            <span class="metric-meta">Most recent started or completed orchestrator poll tick.</span>
+        </article>
+    </section>
+
+    <section class="detail-grid" aria-label="Runtime details">
+        <article class="detail-card">
+            <h2>Workload</h2>
+            <dl class="detail-list">
+                <div>
+                    <dt>Running Sessions</dt>
+                    <dd>@snapshot.RunningCount</dd>
+                </div>
+                <div>
+                    <dt>Retry Queue</dt>
+                    <dd>@snapshot.RetryingCount</dd>
+                </div>
+            </dl>
+        </article>
+        <article class="detail-card">
+            <h2>Codex Totals</h2>
+            <dl class="detail-list">
+                <div>
+                    <dt>Input Tokens</dt>
+                    <dd>@snapshot.InputTokens</dd>
+                </div>
+                <div>
+                    <dt>Output Tokens</dt>
+                    <dd>@snapshot.OutputTokens</dd>
+                </div>
+                <div>
+                    <dt>Total Tokens</dt>
+                    <dd>@snapshot.TotalTokens</dd>
+                </div>
+                <div>
+                    <dt>Seconds Running</dt>
+                    <dd>@snapshot.SecondsRunning.ToString("0.0")</dd>
+                </div>
+            </dl>
+        </article>
+        <article class="detail-card">
+            <h2>Operational Notes</h2>
+            <p>
+                API observers can use <code>/api/v1/state</code> and <code>/api/v1/refresh</code>. The
+                richer panels for sessions and retries land separately.
+            </p>
+            @if (!string.IsNullOrWhiteSpace(snapshot.LastError))
+            {
+                <p class="detail-alert">Last poll error: @snapshot.LastError</p>
+            }
+        </article>
+    </section>
+</main>
+
+@code {
+    private DashboardSnapshot snapshot = new(
+        ServiceHealth: "Starting",
+        OrchestratorMode: "Single-process in-memory",
+        LastPollTickAt: null,
+        RunningCount: 0,
+        RetryingCount: 0,
+        InputTokens: 0,
+        OutputTokens: 0,
+        TotalTokens: 0,
+        SecondsRunning: 0d,
+        LastError: null);
+
+    protected override async Task OnInitializedAsync()
+    {
+        snapshot = await DashboardStateService.GetSnapshotAsync();
+    }
+
+    private static string FormatTimestamp(DateTimeOffset? timestamp)
+    {
+        return timestamp?.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Waiting for first tick";
+    }
+
+    private static string GetHealthClass(string serviceHealth)
+    {
+        return serviceHealth.ToLowerInvariant() switch
+        {
+            "healthy" => "metric-card--healthy",
+            "degraded" => "metric-card--degraded",
+            _ => "metric-card--starting"
+        };
+    }
+
+    private static string GetHealthMessage(DashboardSnapshot snapshot)
+    {
+        if (!string.IsNullOrWhiteSpace(snapshot.LastError))
+        {
+            return "Latest poll attempt failed; the orchestrator is still running.";
+        }
+
+        return snapshot.ServiceHealth switch
+        {
+            "Healthy" => "Recent poll ticks completed successfully.",
+            "Degraded" => "Recent poll tick failed; inspect logs for details.",
+            _ => "No successful poll tick has completed yet."
+        };
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/Routes.razor
+++ b/dotnet/src/Symphony.Host/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/dotnet/src/Symphony.Host/Components/_Imports.razor
+++ b/dotnet/src/Symphony.Host/Components/_Imports.razor
@@ -1,0 +1,6 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Symphony.Host.Dashboard
+@using Symphony.Host.Components.Layout
+@using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
@@ -1,0 +1,13 @@
+namespace Symphony.Host.Dashboard;
+
+public sealed record DashboardSnapshot(
+    string ServiceHealth,
+    string OrchestratorMode,
+    DateTimeOffset? LastPollTickAt,
+    int RunningCount,
+    int RetryingCount,
+    long InputTokens,
+    long OutputTokens,
+    long TotalTokens,
+    double SecondsRunning,
+    string? LastError);

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
@@ -1,0 +1,45 @@
+using Symphony.Application.Polling;
+using Symphony.Application.Runtime;
+
+namespace Symphony.Host.Dashboard;
+
+public sealed class DashboardStateService(
+    IOrchestratorRuntimeService orchestratorRuntimeService,
+    PollingStatusTracker pollingStatusTracker) : IDashboardStateService
+{
+    private const string InMemoryMode = "Single-process in-memory";
+
+    public async Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var runtimeSnapshot = await orchestratorRuntimeService.GetStateSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        var pollingSnapshot = pollingStatusTracker.GetSnapshot();
+
+        return new DashboardSnapshot(
+            DetermineServiceHealth(pollingSnapshot),
+            InMemoryMode,
+            pollingSnapshot.LastSuccessfulTickAt ?? pollingSnapshot.LastCompletedAt ?? pollingSnapshot.LastStartedAt,
+            runtimeSnapshot.Running.Count,
+            runtimeSnapshot.Retrying.Count,
+            runtimeSnapshot.CodexTotals.InputTokens,
+            runtimeSnapshot.CodexTotals.OutputTokens,
+            runtimeSnapshot.CodexTotals.TotalTokens,
+            runtimeSnapshot.CodexTotals.SecondsRunning,
+            pollingSnapshot.LastError);
+    }
+
+    private static string DetermineServiceHealth(PollingStatusSnapshot pollingSnapshot)
+    {
+        if (pollingSnapshot.LastFailedAt is not null
+            && (pollingSnapshot.LastSuccessfulTickAt is null || pollingSnapshot.LastFailedAt > pollingSnapshot.LastSuccessfulTickAt))
+        {
+            return "Degraded";
+        }
+
+        if (pollingSnapshot.LastSuccessfulTickAt is not null)
+        {
+            return "Healthy";
+        }
+
+        return "Starting";
+    }
+}

--- a/dotnet/src/Symphony.Host/Dashboard/IDashboardStateService.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/IDashboardStateService.cs
@@ -1,0 +1,6 @@
+namespace Symphony.Host.Dashboard;
+
+public interface IDashboardStateService
+{
+    Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/Symphony.Host/Program.cs
+++ b/dotnet/src/Symphony.Host/Program.cs
@@ -1,6 +1,8 @@
 using Symphony.Application.DependencyInjection;
 using Symphony.Host.Api;
 using Symphony.Host.Composition;
+using Symphony.Host.Components;
+using Symphony.Host.Dashboard;
 using Symphony.Infrastructure.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,13 +10,21 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Logging.AddSymphonyLogging(builder.Configuration);
 
 builder.Services
+    .AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services
     .AddSymphonyApplication()
     .AddSymphonyInfrastructure()
     .AddConfiguredTrackerAdapter(builder.Configuration);
+builder.Services.AddSingleton<IDashboardStateService, DashboardStateService>();
 
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.UseStaticFiles();
+app.UseAntiforgery();
 app.MapSymphonyApi();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
 
 app.Run();

--- a/dotnet/src/Symphony.Host/Symphony.Host.csproj
+++ b/dotnet/src/Symphony.Host/Symphony.Host.csproj
@@ -14,4 +14,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Update="wwwroot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/dotnet/src/Symphony.Host/wwwroot/app.css
+++ b/dotnet/src/Symphony.Host/wwwroot/app.css
@@ -1,0 +1,213 @@
+:root {
+    --bg: #f3efe5;
+    --panel: rgba(255, 252, 245, 0.92);
+    --panel-strong: #fffaf0;
+    --ink: #1f2933;
+    --muted: #5f6c7b;
+    --accent: #146356;
+    --accent-soft: rgba(20, 99, 86, 0.14);
+    --warn: #a64b2a;
+    --warn-soft: rgba(166, 75, 42, 0.14);
+    --pending: #7a5b16;
+    --pending-soft: rgba(122, 91, 22, 0.14);
+    --border: rgba(31, 41, 51, 0.12);
+    --shadow: 0 18px 60px rgba(31, 41, 51, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    min-height: 100%;
+    background:
+        radial-gradient(circle at top left, rgba(20, 99, 86, 0.16), transparent 38%),
+        linear-gradient(180deg, #f7f2e8 0%, var(--bg) 100%);
+    color: var(--ink);
+    font-family: "Bahnschrift", "Segoe UI Variable Text", "Trebuchet MS", sans-serif;
+}
+
+body {
+    min-height: 100vh;
+}
+
+.shell {
+    min-height: 100vh;
+}
+
+.dashboard-page {
+    width: min(1120px, calc(100vw - 2rem));
+    margin: 0 auto;
+    padding: 2.5rem 0 3rem;
+}
+
+.hero {
+    padding: 2rem;
+    border: 1px solid var(--border);
+    border-radius: 28px;
+    background: linear-gradient(160deg, rgba(255, 250, 240, 0.96), rgba(239, 246, 240, 0.9));
+    box-shadow: var(--shadow);
+}
+
+.eyebrow {
+    margin: 0 0 0.75rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.hero h1 {
+    margin: 0;
+    font-family: Cambria, "Times New Roman", serif;
+    font-size: clamp(2.3rem, 5vw, 4rem);
+    line-height: 0.95;
+}
+
+.lede {
+    max-width: 60ch;
+    margin: 1rem 0 0;
+    color: var(--muted);
+    font-size: 1.02rem;
+    line-height: 1.6;
+}
+
+.summary-grid,
+.detail-grid {
+    display: grid;
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.summary-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.detail-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.metric-card,
+.detail-card {
+    border: 1px solid var(--border);
+    border-radius: 22px;
+    background: var(--panel);
+    box-shadow: var(--shadow);
+}
+
+.metric-card {
+    padding: 1.25rem 1.25rem 1.4rem;
+}
+
+.detail-card {
+    padding: 1.4rem;
+}
+
+.metric-card--healthy {
+    background: linear-gradient(180deg, var(--panel-strong), rgba(237, 250, 246, 0.96));
+}
+
+.metric-card--degraded {
+    background: linear-gradient(180deg, var(--panel-strong), rgba(255, 241, 236, 0.96));
+}
+
+.metric-card--starting {
+    background: linear-gradient(180deg, var(--panel-strong), rgba(255, 247, 224, 0.96));
+}
+
+.metric-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--muted);
+    font-size: 0.84rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.metric-value {
+    display: block;
+    font-size: 1.35rem;
+    line-height: 1.2;
+}
+
+.metric-meta {
+    display: block;
+    margin-top: 0.75rem;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.detail-card h2 {
+    margin: 0 0 1rem;
+    font-family: Cambria, "Times New Roman", serif;
+    font-size: 1.2rem;
+}
+
+.detail-card p {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.55;
+}
+
+.detail-list {
+    margin: 0;
+}
+
+.detail-list div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.7rem 0;
+    border-top: 1px solid rgba(31, 41, 51, 0.08);
+}
+
+.detail-list div:first-child {
+    border-top: none;
+    padding-top: 0;
+}
+
+.detail-list dt {
+    color: var(--muted);
+}
+
+.detail-list dd {
+    margin: 0;
+    font-weight: 700;
+}
+
+.detail-alert {
+    margin-top: 1rem !important;
+    padding: 0.85rem 1rem;
+    border-radius: 16px;
+    background: var(--warn-soft);
+    color: var(--warn) !important;
+}
+
+code {
+    padding: 0.15rem 0.35rem;
+    border-radius: 6px;
+    background: rgba(31, 41, 51, 0.08);
+    font-size: 0.92em;
+}
+
+@media (max-width: 900px) {
+    .summary-grid,
+    .detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard-page {
+        width: min(100vw - 1.25rem, 1120px);
+        padding-top: 1.25rem;
+    }
+
+    .hero,
+    .metric-card,
+    .detail-card {
+        border-radius: 20px;
+    }
+}

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -63,6 +63,7 @@ public class ApplicationServiceCollectionExtensionsTests
 
         Assert.NotNull(serviceProvider.GetService<ApplicationServiceMarker>());
         Assert.NotNull(serviceProvider.GetService<PollingRefreshTrigger>());
+        Assert.NotNull(serviceProvider.GetService<PollingStatusTracker>());
         Assert.NotNull(serviceProvider.GetService<RetryDelayPlanner>());
         Assert.IsType<ActiveSessionRegistry>(serviceProvider.GetRequiredService<IActiveSessionRegistry>());
         Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchQueue>());

--- a/dotnet/tests/Symphony.Application.Tests/Polling/PollingBackgroundServiceTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Polling/PollingBackgroundServiceTests.cs
@@ -33,6 +33,7 @@ public sealed class PollingBackgroundServiceTests
                     return Task.CompletedTask;
                 }),
             new PollingRefreshTrigger(TimeProvider.System),
+            new PollingStatusTracker(),
             TimeProvider.System,
             NullLogger<PollingBackgroundService>.Instance);
 
@@ -73,6 +74,7 @@ public sealed class PollingBackgroundServiceTests
                     }
                 }),
             new PollingRefreshTrigger(TimeProvider.System),
+            new PollingStatusTracker(),
             TimeProvider.System,
             NullLogger<PollingBackgroundService>.Instance);
 
@@ -91,6 +93,7 @@ public sealed class PollingBackgroundServiceTests
     {
         var firstInvocation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var logger = new TestLogger<PollingBackgroundService>();
+        var pollingStatusTracker = new PollingStatusTracker();
         var service = new PollingBackgroundService(
             new StaticWorkflowOptionsProvider(CreateWorkflowOptions(intervalMs: 75)),
             new DelegatePollingIterationHandler(
@@ -100,6 +103,7 @@ public sealed class PollingBackgroundServiceTests
                     return Task.CompletedTask;
                 }),
             new PollingRefreshTrigger(TimeProvider.System),
+            pollingStatusTracker,
             TimeProvider.System,
             logger);
 
@@ -119,6 +123,69 @@ public sealed class PollingBackgroundServiceTests
         Assert.Contains(
             logger.Entries,
             entry => entry.Message.Contains("polling_service completed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StartAsync_records_completed_tick_in_polling_status_tracker()
+    {
+        var firstInvocation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero));
+        var pollingStatusTracker = new PollingStatusTracker();
+        var service = new PollingBackgroundService(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions(intervalMs: 1_000)),
+            new DelegatePollingIterationHandler(
+                (_, _) =>
+                {
+                    firstInvocation.TrySetResult();
+                    return Task.CompletedTask;
+                }),
+            new PollingRefreshTrigger(timeProvider),
+            pollingStatusTracker,
+            timeProvider,
+            NullLogger<PollingBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await firstInvocation.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await service.StopAsync(CancellationToken.None);
+
+        var snapshot = pollingStatusTracker.GetSnapshot();
+
+        Assert.Equal(timeProvider.GetUtcNow(), snapshot.LastStartedAt);
+        Assert.Equal(timeProvider.GetUtcNow(), snapshot.LastCompletedAt);
+        Assert.Equal(timeProvider.GetUtcNow(), snapshot.LastSuccessfulTickAt);
+        Assert.Null(snapshot.LastError);
+    }
+
+    [Fact]
+    public async Task StartAsync_records_failed_tick_in_polling_status_tracker()
+    {
+        var firstInvocation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 30, 0, TimeSpan.Zero));
+        var pollingStatusTracker = new PollingStatusTracker();
+        var service = new PollingBackgroundService(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions(intervalMs: 1_000)),
+            new DelegatePollingIterationHandler(
+                (_, _) =>
+                {
+                    firstInvocation.TrySetResult();
+                    throw new InvalidOperationException("poll failed");
+                }),
+            new PollingRefreshTrigger(timeProvider),
+            pollingStatusTracker,
+            timeProvider,
+            NullLogger<PollingBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await firstInvocation.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await service.StopAsync(CancellationToken.None);
+
+        var snapshot = pollingStatusTracker.GetSnapshot();
+
+        Assert.Equal(timeProvider.GetUtcNow(), snapshot.LastStartedAt);
+        Assert.Equal(timeProvider.GetUtcNow(), snapshot.LastCompletedAt);
+        Assert.Null(snapshot.LastSuccessfulTickAt);
+        Assert.Equal(timeProvider.GetUtcNow(), snapshot.LastFailedAt);
+        Assert.Equal("poll failed", snapshot.LastError);
     }
 
     [Fact]
@@ -146,6 +213,7 @@ public sealed class PollingBackgroundServiceTests
                     return Task.CompletedTask;
                 }),
             refreshTrigger,
+            new PollingStatusTracker(),
             TimeProvider.System,
             NullLogger<PollingBackgroundService>.Instance);
 
@@ -186,6 +254,7 @@ public sealed class PollingBackgroundServiceTests
                     return Task.CompletedTask;
                 }),
             new PollingRefreshTrigger(TimeProvider.System),
+            new PollingStatusTracker(),
             TimeProvider.System,
             NullLogger<PollingBackgroundService>.Instance);
 
@@ -259,6 +328,14 @@ public sealed class PollingBackgroundServiceTests
         public Task ExecuteAsync(WorkflowServiceOptions workflowOptions, CancellationToken cancellationToken)
         {
             return onExecuteAsync(workflowOptions, cancellationToken);
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset currentTime) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return currentTime;
         }
     }
 }

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
+using Symphony.Application.Runtime;
+using Symphony.Host.Api;
+using Symphony.Host.Components;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class DashboardPageIntegrationTests
+{
+    [Fact]
+    public async Task Root_page_renders_dashboard_shell()
+    {
+        using var app = await StartDashboardApplicationAsync(
+            new StubRuntimeService(),
+            new StaticDashboardStateService(
+                new DashboardSnapshot(
+                    "Healthy",
+                    "Single-process in-memory",
+                    new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                    RunningCount: 2,
+                    RetryingCount: 1,
+                    InputTokens: 100,
+                    OutputTokens: 40,
+                    TotalTokens: 140,
+                    SecondsRunning: 300d,
+                    LastError: null)));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Runtime Control Surface", html, StringComparison.Ordinal);
+        Assert.Contains("Service Health", html, StringComparison.Ordinal);
+        Assert.Contains("Single-process in-memory", html, StringComparison.Ordinal);
+        Assert.Contains("2026-03-16 15:00:00 UTC", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Root_page_uses_error_boundary_without_blocking_api_routes()
+    {
+        using var app = await StartDashboardApplicationAsync(
+            new StubRuntimeService(),
+            new ThrowingDashboardStateService());
+        var client = CreateHttpClient(app);
+
+        var rootResponse = await client.GetAsync("/");
+        var rootHtml = await rootResponse.Content.ReadAsStringAsync();
+        var apiResponse = await client.PostAsJsonAsync("/api/v1/refresh", new { });
+
+        Assert.Equal(HttpStatusCode.OK, rootResponse.StatusCode);
+        Assert.Contains("Dashboard temporarily unavailable", rootHtml, StringComparison.Ordinal);
+        Assert.Equal(HttpStatusCode.Accepted, apiResponse.StatusCode);
+    }
+
+    private static HttpClient CreateHttpClient(WebApplication app)
+    {
+        var server = app.Services.GetRequiredService<IServer>();
+        var addresses = server.Features.Get<IServerAddressesFeature>()
+            ?? throw new InvalidOperationException("Test server addresses are unavailable.");
+        var address = Assert.Single(addresses.Addresses);
+
+        return new HttpClient
+        {
+            BaseAddress = new Uri(address)
+        };
+    }
+
+    private static async Task<WebApplication> StartDashboardApplicationAsync(
+        IOrchestratorRuntimeService runtimeService,
+        IDashboardStateService dashboardStateService)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+        builder.Services.AddSingleton<IOrchestratorRuntimeService>(runtimeService);
+        builder.Services.AddSingleton<IDashboardStateService>(dashboardStateService);
+        builder.Services.AddSingleton<IWorkflowOptionsProvider>(
+            new StaticWorkflowOptionsProvider(
+                new WorkflowServiceOptions(
+                    new WorkflowTrackerOptions(
+                        "github",
+                        "https://api.github.com",
+                        "token",
+                        null,
+                        "owner/repo",
+                        null,
+                        null,
+                        ["Todo"],
+                        ["Done"]),
+                    new WorkflowPollingOptions(1_000),
+                    new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                    new WorkflowHookOptions(
+                        null,
+                        null,
+                        null,
+                        null,
+                        60_000),
+                    new WorkflowAgentOptions(
+                        1,
+                        20,
+                        300_000,
+                        new Dictionary<string, int>(StringComparer.Ordinal)),
+                    new WorkflowCodexOptions(
+                        "codex app-server",
+                        null,
+                        null,
+                        null,
+                        3_600_000,
+                        5_000,
+                        300_000))));
+
+        var app = builder.Build();
+        app.UseStaticFiles();
+        app.UseAntiforgery();
+        app.MapSymphonyApi();
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class StubRuntimeService : IOrchestratorRuntimeService
+    {
+        public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(
+                new OrchestratorStateSnapshot(
+                    DateTimeOffset.UtcNow,
+                    Array.Empty<RunningIssueSnapshot>(),
+                    Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                    new CodexTotalsSnapshot(0, 0, 0, 0d),
+                    RateLimits: null));
+        }
+
+        public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<OrchestratorIssueSnapshot?>(null);
+        }
+
+        public PollingRefreshReceipt RequestRefresh()
+        {
+            return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
+    }
+
+    private sealed class StaticDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
+    {
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class ThrowingDashboardStateService : IDashboardStateService
+    {
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("dashboard render failure");
+        }
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
@@ -1,0 +1,75 @@
+using Symphony.Application.Polling;
+using Symphony.Application.Runtime;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class DashboardStateServiceTests
+{
+    [Fact]
+    public async Task GetSnapshotAsync_returns_healthy_dashboard_summary_after_successful_poll()
+    {
+        var runtimeService = new StubRuntimeService
+        {
+            StateSnapshot = new OrchestratorStateSnapshot(
+                new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                [],
+                [],
+                new CodexTotalsSnapshot(120, 45, 165, 90d),
+                RateLimits: null)
+        };
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero));
+        pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero));
+        var service = new DashboardStateService(runtimeService, pollingStatusTracker);
+
+        var snapshot = await service.GetSnapshotAsync();
+
+        Assert.Equal("Healthy", snapshot.ServiceHealth);
+        Assert.Equal("Single-process in-memory", snapshot.OrchestratorMode);
+        Assert.Equal(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero), snapshot.LastPollTickAt);
+        Assert.Equal(165, snapshot.TotalTokens);
+        Assert.Null(snapshot.LastError);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_returns_degraded_dashboard_summary_after_failed_poll()
+    {
+        var runtimeService = new StubRuntimeService();
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 15, 10, 0, TimeSpan.Zero));
+        pollingStatusTracker.RecordFailed(new DateTimeOffset(2026, 3, 16, 15, 11, 0, TimeSpan.Zero), "Tracker request failed");
+        var service = new DashboardStateService(runtimeService, pollingStatusTracker);
+
+        var snapshot = await service.GetSnapshotAsync();
+
+        Assert.Equal("Degraded", snapshot.ServiceHealth);
+        Assert.Equal(new DateTimeOffset(2026, 3, 16, 15, 11, 0, TimeSpan.Zero), snapshot.LastPollTickAt);
+        Assert.Equal("Tracker request failed", snapshot.LastError);
+    }
+
+    private sealed class StubRuntimeService : IOrchestratorRuntimeService
+    {
+        public OrchestratorStateSnapshot StateSnapshot { get; set; } = new(
+            DateTimeOffset.UtcNow,
+            Array.Empty<RunningIssueSnapshot>(),
+            Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+            new CodexTotalsSnapshot(0, 0, 0, 0d),
+            RateLimits: null);
+
+        public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(StateSnapshot);
+        }
+
+        public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<OrchestratorIssueSnapshot?>(null);
+        }
+
+        public PollingRefreshReceipt RequestRefresh()
+        {
+            return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
+    }
+}


### PR DESCRIPTION
#### Context

Implement story #25 from `dotnet/IMPLEMENTATIONPLAN.github.md` against `SPEC.md` by adding the operator dashboard shell at `/`. Closes #25.

#### TL;DR

Add a Blazor Server dashboard at `/` that surfaces runtime health and poll state without blocking orchestration.

#### Summary

- add the host-side Blazor dashboard shell, layout, and styling for the `/` route
- track polling status and compose dashboard state from runtime and poll health data
- cover the dashboard with application and host integration tests and document the UI behavior

#### Alternatives

- Keeping `/` as a plain text or API-only endpoint was rejected because `SPEC.md` requires an operator-facing dashboard shell with runtime visibility

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added application tests for polling status tracking and host integration tests for dashboard rendering and UI-failure isolation