### PR TITLE
E7-S2: add dashboard operational panels

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -266,6 +266,8 @@ When enabled via service configuration (for example `server.port`), Symphony exp
 
 The dashboard shell is implemented as an interactive-server Blazor page. It is an operator-facing
 surface only: if dashboard rendering fails, the orchestrator and JSON API continue running.
+- The dashboard now includes active-session, retry-queue, and recent-attempt panels so operators
+  can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
 - `GET /api/v1/state` for the current running/retrying snapshot, live token totals, and runtime counts
 - `GET /api/v1/{issueIdentifier}` for issue-specific runtime details with a `404` JSON error envelope when the issue is not tracked
 - `POST /api/v1/refresh` to queue an immediate poll-and-reconcile cycle; repeated requests coalesce while one is already pending

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ApplicationServiceCollectionExtensions
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<PollingRefreshTrigger>();
         services.TryAddSingleton<PollingStatusTracker>();
+        services.TryAddSingleton<AttemptHistoryTracker>();
         services.TryAddSingleton<RetryDelayPlanner>();
         services.TryAddSingleton<OrchestratorDispatchQueue>();
         services.TryAddSingleton<IOrchestratorDispatchQueue>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorDispatchQueue>());

--- a/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Symphony.Application.Runtime;
 using Symphony.Domain.Runs;
 
 namespace Symphony.Application.Orchestration;
@@ -7,6 +8,8 @@ namespace Symphony.Application.Orchestration;
 public sealed class DispatchWorkerBackgroundService(
     OrchestratorDispatchQueue dispatchQueue,
     ActiveSessionRegistry activeSessionRegistry,
+    AttemptHistoryTracker attemptHistoryTracker,
+    TimeProvider timeProvider,
     IQueuedIssueWorker queuedIssueWorker,
     ILogger<DispatchWorkerBackgroundService> logger) : BackgroundService
 {
@@ -55,6 +58,8 @@ public sealed class DispatchWorkerBackgroundService(
         OrchestratorDispatchQueue.DispatchQueueWorkItem workItem,
         CancellationToken cancellationToken)
     {
+        var attemptStartedAt = timeProvider.GetUtcNow();
+
         logger.LogInformation(
             "dispatch_worker started issue_id={issue_id} issue_identifier={issue_identifier} attempt={attempt} outcome=started",
             workItem.Issue.Id,
@@ -69,14 +74,32 @@ public sealed class DispatchWorkerBackgroundService(
         {
             await queuedIssueWorker.ExecuteAsync(executionContext).ConfigureAwait(false);
             executionContext.UpdateStatus(RunAttemptStatus.Succeeded);
+            attemptHistoryTracker.Record(
+                workItem.Issue.Id,
+                workItem.Issue.Identifier,
+                workItem.Attempt,
+                "Succeeded",
+                attemptStartedAt,
+                timeProvider.GetUtcNow(),
+                sessionId: executionContext.SessionId);
             await dispatchQueue.ScheduleContinuationRetryAsync(workItem, cancellationToken).ConfigureAwait(false);
             executionLease.PreserveClaimForRetry();
         }
         catch (OperationCanceledException) when (activeSession.WasCanceledByReconciliation)
         {
+            const string cancellationError = "Execution canceled after reconciliation marked the issue ineligible.";
             executionContext.UpdateStatus(
                 RunAttemptStatus.CanceledByReconciliation,
-                "Execution canceled after reconciliation marked the issue ineligible.");
+                cancellationError);
+            attemptHistoryTracker.Record(
+                workItem.Issue.Id,
+                workItem.Issue.Identifier,
+                workItem.Attempt,
+                "Canceled",
+                attemptStartedAt,
+                timeProvider.GetUtcNow(),
+                cancellationError,
+                executionContext.SessionId);
             logger.LogInformation(
                 "dispatch_execution canceled issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=reconciliation outcome=canceled",
                 workItem.Issue.Id,
@@ -94,6 +117,15 @@ public sealed class DispatchWorkerBackgroundService(
         catch (NonTransientIssueExecutionException exception)
         {
             executionContext.UpdateStatus(RunAttemptStatus.Failed, exception.Message);
+            attemptHistoryTracker.Record(
+                workItem.Issue.Id,
+                workItem.Issue.Identifier,
+                workItem.Attempt,
+                "Failed",
+                attemptStartedAt,
+                timeProvider.GetUtcNow(),
+                exception.Message,
+                executionContext.SessionId);
             logger.LogWarning(
                 exception,
                 "dispatch_execution failed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=non_transient outcome=failed_no_retry",
@@ -104,6 +136,15 @@ public sealed class DispatchWorkerBackgroundService(
         catch (Exception exception)
         {
             executionContext.UpdateStatus(RunAttemptStatus.Failed, exception.Message);
+            attemptHistoryTracker.Record(
+                workItem.Issue.Id,
+                workItem.Issue.Identifier,
+                workItem.Attempt,
+                "Retrying",
+                attemptStartedAt,
+                timeProvider.GetUtcNow(),
+                exception.Message,
+                executionContext.SessionId);
             logger.LogError(
                 exception,
                 "dispatch_execution failed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=worker_exception outcome=failed",

--- a/dotnet/src/Symphony.Application/Runtime/AttemptHistoryTracker.cs
+++ b/dotnet/src/Symphony.Application/Runtime/AttemptHistoryTracker.cs
@@ -1,0 +1,65 @@
+namespace Symphony.Application.Runtime;
+
+public sealed class AttemptHistoryTracker
+{
+    private const int MaxEntries = 20;
+
+    private readonly Lock _stateLock = new();
+    private readonly LinkedList<RecentAttemptSnapshot> _attempts = [];
+
+    public void Record(
+        string issueId,
+        string issueIdentifier,
+        int? attempt,
+        string outcome,
+        DateTimeOffset startedAt,
+        DateTimeOffset completedAt,
+        string? error = null,
+        string? sessionId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outcome);
+
+        var durationSeconds = Math.Max((completedAt - startedAt).TotalSeconds, 0d);
+        var snapshot = new RecentAttemptSnapshot(
+            issueId.Trim(),
+            issueIdentifier.Trim(),
+            attempt,
+            outcome.Trim(),
+            startedAt,
+            completedAt,
+            durationSeconds,
+            string.IsNullOrWhiteSpace(error) ? null : error.Trim(),
+            string.IsNullOrWhiteSpace(sessionId) ? null : sessionId.Trim());
+
+        lock (_stateLock)
+        {
+            _attempts.AddFirst(snapshot);
+
+            while (_attempts.Count > MaxEntries)
+            {
+                _attempts.RemoveLast();
+            }
+        }
+    }
+
+    public IReadOnlyList<RecentAttemptSnapshot> GetRecentAttempts()
+    {
+        lock (_stateLock)
+        {
+            return _attempts.ToArray();
+        }
+    }
+}
+
+public sealed record RecentAttemptSnapshot(
+    string IssueId,
+    string IssueIdentifier,
+    int? Attempt,
+    string Outcome,
+    DateTimeOffset StartedAt,
+    DateTimeOffset CompletedAt,
+    double DurationSeconds,
+    string? Error,
+    string? SessionId);

--- a/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
@@ -28,46 +28,153 @@
         </article>
     </section>
 
-    <section class="detail-grid" aria-label="Runtime details">
-        <article class="detail-card">
-            <h2>Workload</h2>
-            <dl class="detail-list">
+    <section class="ops-strip" aria-label="Orchestrator totals">
+        <div class="ops-stat">
+            <span class="metric-label">Running Sessions</span>
+            <strong class="ops-value">@snapshot.RunningCount</strong>
+        </div>
+        <div class="ops-stat">
+            <span class="metric-label">Retry Queue</span>
+            <strong class="ops-value">@snapshot.RetryingCount</strong>
+        </div>
+        <div class="ops-stat">
+            <span class="metric-label">Token Totals</span>
+            <strong class="ops-value">@snapshot.TotalTokens</strong>
+            <span class="ops-meta">input @snapshot.InputTokens / output @snapshot.OutputTokens</span>
+        </div>
+        <div class="ops-stat">
+            <span class="metric-label">Runtime Seconds</span>
+            <strong class="ops-value">@snapshot.SecondsRunning.ToString("0.0")</strong>
+            <span class="ops-meta">Aggregate active-session runtime</span>
+        </div>
+    </section>
+
+    <section class="detail-grid" aria-label="Operational panels">
+        <article class="detail-card panel-card">
+            <div class="panel-heading">
                 <div>
-                    <dt>Running Sessions</dt>
-                    <dd>@snapshot.RunningCount</dd>
+                    <h2>Active Sessions</h2>
+                    <p>Live runs with current tracker state, session metadata, and token usage.</p>
                 </div>
-                <div>
-                    <dt>Retry Queue</dt>
-                    <dd>@snapshot.RetryingCount</dd>
-                </div>
-            </dl>
+            </div>
+
+            @if (snapshot.ActiveSessions.Count == 0)
+            {
+                <p class="empty-state">No active sessions are running right now.</p>
+            }
+            else
+            {
+                <ul class="panel-list">
+                    @foreach (var session in snapshot.ActiveSessions)
+                    {
+                        <li class="panel-item">
+                            <div class="panel-item-top">
+                                <strong>@session.IssueIdentifier</strong>
+                                <span class="pill pill--neutral">@session.State</span>
+                            </div>
+                            <p class="panel-meta">
+                                started @FormatTimestamp(session.StartedAt) · @FormatElapsed(session.StartedAt) live
+                            </p>
+                            <p class="panel-meta">
+                                session @(session.SessionId ?? "pending") · turns @session.TurnCount · tokens @session.TotalTokens
+                            </p>
+                            @if (!string.IsNullOrWhiteSpace(session.LastEvent) || !string.IsNullOrWhiteSpace(session.LastMessage))
+                            {
+                                <p class="panel-note">
+                                    Latest: @session.LastEvent
+                                    @if (!string.IsNullOrWhiteSpace(session.LastMessage))
+                                    {
+                                        <span> · @session.LastMessage</span>
+                                    }
+                                </p>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
         </article>
-        <article class="detail-card">
-            <h2>Codex Totals</h2>
-            <dl class="detail-list">
+
+        <article class="detail-card panel-card">
+            <div class="panel-heading">
                 <div>
-                    <dt>Input Tokens</dt>
-                    <dd>@snapshot.InputTokens</dd>
+                    <h2>Retry Queue</h2>
+                    <p>Scheduled continuation and failure retries with their next retry ETA.</p>
                 </div>
-                <div>
-                    <dt>Output Tokens</dt>
-                    <dd>@snapshot.OutputTokens</dd>
-                </div>
-                <div>
-                    <dt>Total Tokens</dt>
-                    <dd>@snapshot.TotalTokens</dd>
-                </div>
-                <div>
-                    <dt>Seconds Running</dt>
-                    <dd>@snapshot.SecondsRunning.ToString("0.0")</dd>
-                </div>
-            </dl>
+            </div>
+
+            @if (snapshot.RetryQueue.Count == 0)
+            {
+                <p class="empty-state">No retries are queued at the moment.</p>
+            }
+            else
+            {
+                <ul class="panel-list">
+                    @foreach (var retry in snapshot.RetryQueue)
+                    {
+                        <li class="panel-item">
+                            <div class="panel-item-top">
+                                <strong>@retry.IssueIdentifier</strong>
+                                <span class="pill pill--warning">Retry @retry.Attempt</span>
+                            </div>
+                            <p class="panel-meta">
+                                ETA @FormatRetryEta(retry.DueAt) · due @FormatTimestamp(retry.DueAt)
+                            </p>
+                            @if (!string.IsNullOrWhiteSpace(retry.Error))
+                            {
+                                <p class="panel-note panel-note--warning">@retry.Error</p>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
         </article>
+
+        <article class="detail-card panel-card">
+            <div class="panel-heading">
+                <div>
+                    <h2>Recent Attempts</h2>
+                    <p>Most recent run outcomes with concise error summaries for operator triage.</p>
+                </div>
+            </div>
+
+            @if (snapshot.RecentAttempts.Count == 0)
+            {
+                <p class="empty-state">Recent run attempts will appear here after the first worker completes.</p>
+            }
+            else
+            {
+                <ul class="panel-list">
+                    @foreach (var attempt in snapshot.RecentAttempts)
+                    {
+                        <li class="panel-item">
+                            <div class="panel-item-top">
+                                <strong>@attempt.IssueIdentifier</strong>
+                                <span class="pill @GetOutcomeClass(attempt.Outcome)">@attempt.Outcome</span>
+                            </div>
+                            <p class="panel-meta">
+                                @GetAttemptLabel(attempt.Attempt) · finished @FormatTimestamp(attempt.CompletedAt) · @FormatDuration(attempt.DurationSeconds)
+                            </p>
+                            @if (!string.IsNullOrWhiteSpace(attempt.SessionId))
+                            {
+                                <p class="panel-meta">session @attempt.SessionId</p>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(attempt.Error))
+                            {
+                                <p class="panel-note panel-note--warning">@attempt.Error</p>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+        </article>
+    </section>
+
+    <section class="detail-grid detail-grid--notes" aria-label="Operational notes">
         <article class="detail-card">
-            <h2>Operational Notes</h2>
+            <h2>Operator Notes</h2>
             <p>
-                API observers can use <code>/api/v1/state</code> and <code>/api/v1/refresh</code>. The
-                richer panels for sessions and retries land separately.
+                API observers can use <code>/api/v1/state</code> and <code>/api/v1/refresh</code>. Dashboard
+                failures must not stop orchestration or the API surface.
             </p>
             @if (!string.IsNullOrWhiteSpace(snapshot.LastError))
             {
@@ -79,6 +186,7 @@
 
 @code {
     private DashboardSnapshot snapshot = new(
+        GeneratedAt: DateTimeOffset.UnixEpoch,
         ServiceHealth: "Starting",
         OrchestratorMode: "Single-process in-memory",
         LastPollTickAt: null,
@@ -88,6 +196,9 @@
         OutputTokens: 0,
         TotalTokens: 0,
         SecondsRunning: 0d,
+        ActiveSessions: [],
+        RetryQueue: [],
+        RecentAttempts: [],
         LastError: null);
 
     protected override async Task OnInitializedAsync()
@@ -97,7 +208,7 @@
 
     private static string FormatTimestamp(DateTimeOffset? timestamp)
     {
-        return timestamp?.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Waiting for first tick";
+        return timestamp?.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Waiting for first tick";
     }
 
     private static string GetHealthClass(string serviceHealth)
@@ -107,6 +218,49 @@
             "healthy" => "metric-card--healthy",
             "degraded" => "metric-card--degraded",
             _ => "metric-card--starting"
+        };
+    }
+
+    private string FormatRetryEta(DateTimeOffset dueAt)
+    {
+        var remaining = dueAt - snapshot.GeneratedAt;
+        if (remaining <= TimeSpan.Zero)
+        {
+            return "due now";
+        }
+
+        return remaining.TotalMinutes >= 1d
+            ? $"in {remaining.TotalMinutes:0.#} min"
+            : $"in {remaining.TotalSeconds:0}s";
+    }
+
+    private string FormatElapsed(DateTimeOffset startedAt)
+    {
+        var elapsed = snapshot.GeneratedAt - startedAt;
+        return FormatDuration(Math.Max(elapsed.TotalSeconds, 0d));
+    }
+
+    private static string FormatDuration(double durationSeconds)
+    {
+        return durationSeconds >= 60d
+            ? $"{durationSeconds / 60d:0.#} min"
+            : $"{durationSeconds:0.#} s";
+    }
+
+    private static string GetAttemptLabel(int? attempt)
+    {
+        return attempt is null ? "Initial run" : $"Attempt {attempt}";
+    }
+
+    private static string GetOutcomeClass(string outcome)
+    {
+        return outcome.ToLowerInvariant() switch
+        {
+            "succeeded" => "pill--success",
+            "retrying" => "pill--warning",
+            "failed" => "pill--danger",
+            "canceled" => "pill--neutral",
+            _ => "pill--neutral"
         };
     }
 

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
@@ -1,6 +1,7 @@
 namespace Symphony.Host.Dashboard;
 
 public sealed record DashboardSnapshot(
+    DateTimeOffset GeneratedAt,
     string ServiceHealth,
     string OrchestratorMode,
     DateTimeOffset? LastPollTickAt,
@@ -10,4 +11,33 @@ public sealed record DashboardSnapshot(
     long OutputTokens,
     long TotalTokens,
     double SecondsRunning,
+    IReadOnlyList<DashboardActiveSessionSnapshot> ActiveSessions,
+    IReadOnlyList<DashboardRetrySnapshot> RetryQueue,
+    IReadOnlyList<DashboardRecentAttemptSnapshot> RecentAttempts,
     string? LastError);
+
+public sealed record DashboardActiveSessionSnapshot(
+    string IssueIdentifier,
+    string State,
+    string? SessionId,
+    int TurnCount,
+    string? LastEvent,
+    string? LastMessage,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? LastEventAt,
+    long TotalTokens);
+
+public sealed record DashboardRetrySnapshot(
+    string IssueIdentifier,
+    int Attempt,
+    DateTimeOffset DueAt,
+    string? Error);
+
+public sealed record DashboardRecentAttemptSnapshot(
+    string IssueIdentifier,
+    int? Attempt,
+    string Outcome,
+    DateTimeOffset CompletedAt,
+    double DurationSeconds,
+    string? Error,
+    string? SessionId);

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
@@ -5,6 +5,7 @@ namespace Symphony.Host.Dashboard;
 
 public sealed class DashboardStateService(
     IOrchestratorRuntimeService orchestratorRuntimeService,
+    AttemptHistoryTracker attemptHistoryTracker,
     PollingStatusTracker pollingStatusTracker) : IDashboardStateService
 {
     private const string InMemoryMode = "Single-process in-memory";
@@ -13,8 +14,41 @@ public sealed class DashboardStateService(
     {
         var runtimeSnapshot = await orchestratorRuntimeService.GetStateSnapshotAsync(cancellationToken).ConfigureAwait(false);
         var pollingSnapshot = pollingStatusTracker.GetSnapshot();
+        var activeSessions = runtimeSnapshot.Running
+            .Select(
+                session => new DashboardActiveSessionSnapshot(
+                    session.IssueIdentifier,
+                    session.State,
+                    session.SessionId,
+                    session.TurnCount,
+                    session.LastEvent,
+                    session.LastMessage,
+                    session.StartedAt,
+                    session.LastEventAt,
+                    session.TotalTokens))
+            .ToArray();
+        var retryQueue = runtimeSnapshot.Retrying
+            .Select(
+                retry => new DashboardRetrySnapshot(
+                    retry.IssueIdentifier,
+                    retry.Attempt,
+                    retry.DueAt,
+                    retry.Error))
+            .ToArray();
+        var recentAttempts = attemptHistoryTracker.GetRecentAttempts()
+            .Select(
+                attempt => new DashboardRecentAttemptSnapshot(
+                    attempt.IssueIdentifier,
+                    attempt.Attempt,
+                    attempt.Outcome,
+                    attempt.CompletedAt,
+                    attempt.DurationSeconds,
+                    attempt.Error,
+                    attempt.SessionId))
+            .ToArray();
 
         return new DashboardSnapshot(
+            runtimeSnapshot.GeneratedAt,
             DetermineServiceHealth(pollingSnapshot),
             InMemoryMode,
             pollingSnapshot.LastSuccessfulTickAt ?? pollingSnapshot.LastCompletedAt ?? pollingSnapshot.LastStartedAt,
@@ -24,6 +58,9 @@ public sealed class DashboardStateService(
             runtimeSnapshot.CodexTotals.OutputTokens,
             runtimeSnapshot.CodexTotals.TotalTokens,
             runtimeSnapshot.CodexTotals.SecondsRunning,
+            activeSessions,
+            retryQueue,
+            recentAttempts,
             pollingSnapshot.LastError);
     }
 

--- a/dotnet/src/Symphony.Host/wwwroot/app.css
+++ b/dotnet/src/Symphony.Host/wwwroot/app.css
@@ -90,6 +90,10 @@ body {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.detail-grid--notes {
+    grid-template-columns: 1fr;
+}
+
 .metric-card,
 .detail-card {
     border: 1px solid var(--border);
@@ -153,6 +157,123 @@ body {
     line-height: 1.55;
 }
 
+.ops-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.ops-stat {
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    background: rgba(255, 252, 245, 0.8);
+    box-shadow: var(--shadow);
+}
+
+.ops-value {
+    display: block;
+    font-size: 1.2rem;
+    line-height: 1.2;
+}
+
+.ops-meta {
+    display: block;
+    margin-top: 0.45rem;
+    color: var(--muted);
+    font-size: 0.92rem;
+    line-height: 1.45;
+}
+
+.panel-heading {
+    margin-bottom: 1rem;
+}
+
+.panel-heading h2 {
+    margin-bottom: 0.35rem;
+}
+
+.panel-heading p {
+    font-size: 0.96rem;
+}
+
+.empty-state {
+    padding: 1rem;
+    border-radius: 16px;
+    background: rgba(31, 41, 51, 0.04);
+}
+
+.panel-list {
+    display: grid;
+    gap: 0.85rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.panel-item {
+    padding: 1rem;
+    border: 1px solid rgba(31, 41, 51, 0.08);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.4);
+}
+
+.panel-item-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.panel-meta,
+.panel-note {
+    margin-top: 0.45rem !important;
+    font-size: 0.94rem;
+}
+
+.panel-note {
+    color: var(--ink) !important;
+}
+
+.panel-note--warning {
+    padding: 0.65rem 0.75rem;
+    border-radius: 14px;
+    background: var(--warn-soft);
+    color: var(--warn) !important;
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.pill--success {
+    background: var(--accent-soft);
+    color: var(--accent);
+}
+
+.pill--warning {
+    background: var(--pending-soft);
+    color: var(--pending);
+}
+
+.pill--danger {
+    background: var(--warn-soft);
+    color: var(--warn);
+}
+
+.pill--neutral {
+    background: rgba(31, 41, 51, 0.08);
+    color: var(--ink);
+}
+
 .detail-list {
     margin: 0;
 }
@@ -195,6 +316,7 @@ code {
 }
 
 @media (max-width: 900px) {
+    .ops-strip,
     .summary-grid,
     .detail-grid {
         grid-template-columns: 1fr;

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -64,6 +64,7 @@ public class ApplicationServiceCollectionExtensionsTests
         Assert.NotNull(serviceProvider.GetService<ApplicationServiceMarker>());
         Assert.NotNull(serviceProvider.GetService<PollingRefreshTrigger>());
         Assert.NotNull(serviceProvider.GetService<PollingStatusTracker>());
+        Assert.NotNull(serviceProvider.GetService<AttemptHistoryTracker>());
         Assert.NotNull(serviceProvider.GetService<RetryDelayPlanner>());
         Assert.IsType<ActiveSessionRegistry>(serviceProvider.GetRequiredService<IActiveSessionRegistry>());
         Assert.IsType<OrchestratorDispatchQueue>(serviceProvider.GetRequiredService<IOrchestratorDispatchQueue>());

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
+using Symphony.Application.Runtime;
 using Symphony.Application.Tests.Logging;
 using Symphony.Domain.Issues;
 using Symphony.Domain.Runs;
@@ -119,8 +120,9 @@ public sealed class OrchestratorDispatchQueueTests
     {
         var queue = CreateQueue(maxConcurrentAgents: 2);
         var registry = CreateRegistry();
+        var attemptHistoryTracker = new AttemptHistoryTracker();
         var worker = new BlockingQueuedIssueWorker();
-        var hostedService = CreateHostedService(queue, registry, worker);
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker);
 
         await hostedService.StartAsync(CancellationToken.None);
         await queue.QueueAsync(CreateIssue("ABC-1", "ABC-1"));
@@ -149,8 +151,9 @@ public sealed class OrchestratorDispatchQueueTests
         var logger = new TestLogger<OrchestratorDispatchQueue>();
         var queue = CreateQueue(new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents: 1)), logger: logger);
         var registry = CreateRegistry();
+        var attemptHistoryTracker = new AttemptHistoryTracker();
         var worker = new BlockingQueuedIssueWorker();
-        var hostedService = CreateHostedService(queue, registry, worker);
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker);
         var issue = CreateIssue("123", "ABC-123");
 
         await hostedService.StartAsync(CancellationToken.None);
@@ -198,8 +201,9 @@ public sealed class OrchestratorDispatchQueueTests
             new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents: 1)),
             logger: logger);
         var registry = CreateRegistry();
+        var attemptHistoryTracker = new AttemptHistoryTracker();
         var worker = new ThrowingQueuedIssueWorker(new InvalidOperationException("transient failure"));
-        var hostedService = CreateHostedService(queue, registry, worker);
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker);
 
         await hostedService.StartAsync(CancellationToken.None);
         await queue.QueueAsync(CreateIssue("1", "ABC-1"));
@@ -227,8 +231,9 @@ public sealed class OrchestratorDispatchQueueTests
     {
         var queue = CreateQueue(maxConcurrentAgents: 1);
         var registry = CreateRegistry();
+        var attemptHistoryTracker = new AttemptHistoryTracker();
         var worker = new ThrowingQueuedIssueWorker(new NonTransientIssueExecutionException("do not retry"));
-        var hostedService = CreateHostedService(queue, registry, worker);
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker);
         var issue = CreateIssue("1", "ABC-1");
 
         await hostedService.StartAsync(CancellationToken.None);
@@ -251,8 +256,9 @@ public sealed class OrchestratorDispatchQueueTests
             new RetryDelayPlanner(() => 1d),
             timeProvider);
         var registry = CreateRegistry(timeProvider);
+        var attemptHistoryTracker = new AttemptHistoryTracker();
         var worker = new FailOnceQueuedIssueWorker();
-        var dispatchHostedService = CreateHostedService(queue, registry, worker);
+        var dispatchHostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker, timeProvider);
         var retryHostedService = CreateRetryHostedService(queue, timeProvider);
 
         await dispatchHostedService.StartAsync(CancellationToken.None);
@@ -263,6 +269,52 @@ public sealed class OrchestratorDispatchQueueTests
         await dispatchHostedService.StopAsync(CancellationToken.None);
 
         Assert.Equal(new int?[] { null, 1 }, worker.Attempts.ToArray());
+    }
+
+    [Fact]
+    public async Task DispatchWorker_records_successful_attempts_for_dashboard_history()
+    {
+        var timeProvider = TimeProvider.System;
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var registry = CreateRegistry(timeProvider);
+        var attemptHistoryTracker = new AttemptHistoryTracker();
+        var worker = new BlockingQueuedIssueWorker();
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker, timeProvider);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.ExecutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        worker.AllowCompletion("ABC-1");
+        await worker.WaitForCompletionAsync("ABC-1", TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => attemptHistoryTracker.GetRecentAttempts().Count == 1, TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var attempt = Assert.Single(attemptHistoryTracker.GetRecentAttempts());
+        Assert.Equal("ABC-1", attempt.IssueIdentifier);
+        Assert.Equal("Succeeded", attempt.Outcome);
+        Assert.Null(attempt.Error);
+    }
+
+    [Fact]
+    public async Task DispatchWorker_records_retrying_attempts_for_dashboard_history()
+    {
+        var timeProvider = TimeProvider.System;
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var registry = CreateRegistry(timeProvider);
+        var attemptHistoryTracker = new AttemptHistoryTracker();
+        var worker = new ThrowingQueuedIssueWorker(new InvalidOperationException("transient failure"));
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker, timeProvider);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.ExecutionAttempted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => attemptHistoryTracker.GetRecentAttempts().Count == 1, TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var attempt = Assert.Single(attemptHistoryTracker.GetRecentAttempts());
+        Assert.Equal("Retrying", attempt.Outcome);
+        Assert.Equal("transient failure", attempt.Error);
     }
 
     private static OrchestratorDispatchQueue CreateQueue(int maxConcurrentAgents)
@@ -300,9 +352,21 @@ public sealed class OrchestratorDispatchQueueTests
         ActiveSessionRegistry registry,
         IQueuedIssueWorker queuedIssueWorker)
     {
+        return CreateHostedService(queue, registry, new AttemptHistoryTracker(), queuedIssueWorker, timeProvider: null);
+    }
+
+    private static DispatchWorkerBackgroundService CreateHostedService(
+        OrchestratorDispatchQueue queue,
+        ActiveSessionRegistry registry,
+        AttemptHistoryTracker attemptHistoryTracker,
+        IQueuedIssueWorker queuedIssueWorker,
+        TimeProvider? timeProvider = null)
+    {
         return new DispatchWorkerBackgroundService(
             queue,
             registry,
+            attemptHistoryTracker,
+            timeProvider ?? TimeProvider.System,
             queuedIssueWorker,
             NullLogger<DispatchWorkerBackgroundService>.Instance);
     }

--- a/dotnet/tests/Symphony.Application.Tests/Runtime/AttemptHistoryTrackerTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Runtime/AttemptHistoryTrackerTests.cs
@@ -1,0 +1,32 @@
+using Symphony.Application.Runtime;
+
+namespace Symphony.Application.Tests.Runtime;
+
+public sealed class AttemptHistoryTrackerTests
+{
+    [Fact]
+    public void Record_keeps_most_recent_entries_first_and_trims_history()
+    {
+        var tracker = new AttemptHistoryTracker();
+        var startedAt = new DateTimeOffset(2026, 3, 18, 9, 0, 0, TimeSpan.Zero);
+
+        for (var index = 0; index < 25; index++)
+        {
+            tracker.Record(
+                $"issue-{index}",
+                $"ABC-{index}",
+                attempt: index == 0 ? null : index,
+                outcome: index % 2 == 0 ? "Succeeded" : "Retrying",
+                startedAt.AddMinutes(index),
+                startedAt.AddMinutes(index).AddSeconds(15),
+                error: index % 2 == 0 ? null : "retry later");
+        }
+
+        var history = tracker.GetRecentAttempts();
+
+        Assert.Equal(20, history.Count);
+        Assert.Equal("ABC-24", history[0].IssueIdentifier);
+        Assert.Equal("ABC-5", history[^1].IssueIdentifier);
+        Assert.Equal(15d, history[0].DurationSeconds);
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -23,6 +23,7 @@ public sealed class DashboardPageIntegrationTests
             new StubRuntimeService(),
             new StaticDashboardStateService(
                 new DashboardSnapshot(
+                    new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
                     "Healthy",
                     "Single-process in-memory",
                     new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
@@ -32,6 +33,38 @@ public sealed class DashboardPageIntegrationTests
                     OutputTokens: 40,
                     TotalTokens: 140,
                     SecondsRunning: 300d,
+                    ActiveSessions:
+                    [
+                        new DashboardActiveSessionSnapshot(
+                            "ABC-1",
+                            "In Progress",
+                            "thread-1-turn-1",
+                            3,
+                            "turn_completed",
+                            "Applied changes",
+                            new DateTimeOffset(2026, 3, 16, 14, 55, 0, TimeSpan.Zero),
+                            new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero),
+                            140)
+                    ],
+                    RetryQueue:
+                    [
+                        new DashboardRetrySnapshot(
+                            "ABC-2",
+                            2,
+                            new DateTimeOffset(2026, 3, 16, 15, 1, 0, TimeSpan.Zero),
+                            "retry later")
+                    ],
+                    RecentAttempts:
+                    [
+                        new DashboardRecentAttemptSnapshot(
+                            "ABC-3",
+                            1,
+                            "Retrying",
+                            new DateTimeOffset(2026, 3, 16, 14, 58, 30, TimeSpan.Zero),
+                            22.5d,
+                            "Tracker request failed",
+                            "thread-3-turn-2")
+                    ],
                     LastError: null)));
         var client = CreateHttpClient(app);
 
@@ -43,6 +76,12 @@ public sealed class DashboardPageIntegrationTests
         Assert.Contains("Service Health", html, StringComparison.Ordinal);
         Assert.Contains("Single-process in-memory", html, StringComparison.Ordinal);
         Assert.Contains("2026-03-16 15:00:00 UTC", html, StringComparison.Ordinal);
+        Assert.Contains("Active Sessions", html, StringComparison.Ordinal);
+        Assert.Contains("Retry Queue", html, StringComparison.Ordinal);
+        Assert.Contains("Recent Attempts", html, StringComparison.Ordinal);
+        Assert.Contains("ABC-1", html, StringComparison.Ordinal);
+        Assert.Contains("ABC-2", html, StringComparison.Ordinal);
+        Assert.Contains("ABC-3", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
@@ -13,21 +13,58 @@ public sealed class DashboardStateServiceTests
         {
             StateSnapshot = new OrchestratorStateSnapshot(
                 new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
-                [],
-                [],
+                [
+                    new RunningIssueSnapshot(
+                        "1",
+                        "ABC-1",
+                        "In Progress",
+                        "thread-1-turn-1",
+                        4,
+                        "turn_completed",
+                        "Applied changes",
+                        new DateTimeOffset(2026, 3, 16, 14, 55, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 3, 16, 14, 59, 30, TimeSpan.Zero),
+                        120,
+                        45,
+                        165)
+                ],
+                [
+                    new Symphony.Abstractions.Orchestration.RetryDispatchSnapshot(
+                        "2",
+                        "ABC-2",
+                        2,
+                        new DateTimeOffset(2026, 3, 16, 15, 2, 0, TimeSpan.Zero),
+                        "retry later")
+                ],
                 new CodexTotalsSnapshot(120, 45, 165, 90d),
                 RateLimits: null)
         };
+        var attemptHistoryTracker = new AttemptHistoryTracker();
+        attemptHistoryTracker.Record(
+            "3",
+            "ABC-3",
+            1,
+            "Retrying",
+            new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero),
+            "Tracker request failed",
+            "thread-3-turn-2");
         var pollingStatusTracker = new PollingStatusTracker();
         pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero));
         pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero));
-        var service = new DashboardStateService(runtimeService, pollingStatusTracker);
+        var service = new DashboardStateService(runtimeService, attemptHistoryTracker, pollingStatusTracker);
 
         var snapshot = await service.GetSnapshotAsync();
 
         Assert.Equal("Healthy", snapshot.ServiceHealth);
         Assert.Equal("Single-process in-memory", snapshot.OrchestratorMode);
         Assert.Equal(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero), snapshot.LastPollTickAt);
+        Assert.Single(snapshot.ActiveSessions);
+        Assert.Single(snapshot.RetryQueue);
+        Assert.Single(snapshot.RecentAttempts);
+        Assert.Equal("ABC-1", snapshot.ActiveSessions[0].IssueIdentifier);
+        Assert.Equal("ABC-2", snapshot.RetryQueue[0].IssueIdentifier);
+        Assert.Equal("Retrying", snapshot.RecentAttempts[0].Outcome);
         Assert.Equal(165, snapshot.TotalTokens);
         Assert.Null(snapshot.LastError);
     }
@@ -36,10 +73,11 @@ public sealed class DashboardStateServiceTests
     public async Task GetSnapshotAsync_returns_degraded_dashboard_summary_after_failed_poll()
     {
         var runtimeService = new StubRuntimeService();
+        var attemptHistoryTracker = new AttemptHistoryTracker();
         var pollingStatusTracker = new PollingStatusTracker();
         pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 15, 10, 0, TimeSpan.Zero));
         pollingStatusTracker.RecordFailed(new DateTimeOffset(2026, 3, 16, 15, 11, 0, TimeSpan.Zero), "Tracker request failed");
-        var service = new DashboardStateService(runtimeService, pollingStatusTracker);
+        var service = new DashboardStateService(runtimeService, attemptHistoryTracker, pollingStatusTracker);
 
         var snapshot = await service.GetSnapshotAsync();
 


### PR DESCRIPTION
#### Context

Implement story #26 from `dotnet/IMPLEMENTATIONPLAN.github.md` against `SPEC.md` by extending the dashboard with operator-facing runtime panels. Closes #26.

#### TL;DR

Add active-session, retry-queue, and recent-attempt panels to the dashboard with real runtime state behind them.

#### Summary

- add dashboard panels for active sessions, retry ETA, and recent attempts with outcome/error summaries
- track recent worker outcomes in application state so the dashboard can render them without parsing logs
- cover the new runtime tracker and dashboard rendering with application and host integration tests

#### Alternatives

- Driving the recent-attempt panel from raw logs was rejected because `SPEC.md` frames the dashboard as a view over orchestrator state, not log scraping

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Added application tests for attempt history tracking and dispatch recording plus host integration tests for the new dashboard panels