### PR TITLE
E8-S2: add host integration and smoke tests

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -188,6 +188,10 @@ dotnet build -c Release
 dotnet test -c Release
 ```
 
+The PR workflow in [`.github/workflows/make-all.yml`](../.github/workflows/make-all.yml) runs the
+same solution-wide `dotnet test` suite, including the host integration checks for startup
+validation, API contracts, and the smoke orchestration path.
+
 ## Configuration
 
 The `WORKFLOW.md` file uses YAML front matter for configuration and a Markdown body for the Codex

--- a/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
+++ b/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
@@ -1,0 +1,42 @@
+using Symphony.Application.DependencyInjection;
+using Symphony.Host.Api;
+using Symphony.Host.Components;
+using Symphony.Host.Dashboard;
+using Symphony.Infrastructure.DependencyInjection;
+
+namespace Symphony.Host.Composition;
+
+public static class SymphonyHostCompositionExtensions
+{
+    public static WebApplicationBuilder AddSymphonyHost(this WebApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Logging.AddSymphonyLogging(builder.Configuration);
+
+        builder.Services
+            .AddRazorComponents()
+            .AddInteractiveServerComponents();
+
+        builder.Services
+            .AddSymphonyApplication()
+            .AddSymphonyInfrastructure()
+            .AddConfiguredTrackerAdapter(builder.Configuration);
+        builder.Services.AddSingleton<IDashboardStateService, DashboardStateService>();
+
+        return builder;
+    }
+
+    public static WebApplication MapSymphonyHost(this WebApplication app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.UseStaticFiles();
+        app.UseAntiforgery();
+        app.MapSymphonyApi();
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        return app;
+    }
+}

--- a/dotnet/src/Symphony.Host/Program.cs
+++ b/dotnet/src/Symphony.Host/Program.cs
@@ -1,30 +1,9 @@
-using Symphony.Application.DependencyInjection;
-using Symphony.Host.Api;
 using Symphony.Host.Composition;
-using Symphony.Host.Components;
-using Symphony.Host.Dashboard;
-using Symphony.Infrastructure.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Logging.AddSymphonyLogging(builder.Configuration);
-
-builder.Services
-    .AddRazorComponents()
-    .AddInteractiveServerComponents();
-
-builder.Services
-    .AddSymphonyApplication()
-    .AddSymphonyInfrastructure()
-    .AddConfiguredTrackerAdapter(builder.Configuration);
-builder.Services.AddSingleton<IDashboardStateService, DashboardStateService>();
+builder.AddSymphonyHost();
 
 var app = builder.Build();
-
-app.UseStaticFiles();
-app.UseAntiforgery();
-app.MapSymphonyApi();
-app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode();
+app.MapSymphonyHost();
 
 app.Run();

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyHostLifecycleIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyHostLifecycleIntegrationTests.cs
@@ -1,0 +1,289 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Symphony.Abstractions.Trackers;
+using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Runs;
+using Symphony.Domain.Workspaces;
+using Symphony.Host.Composition;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SymphonyHostLifecycleIntegrationTests
+{
+    private static readonly SemaphoreSlim CurrentDirectoryGate = new(1, 1);
+
+    [Fact]
+    public async Task StartAsync_missing_default_workflow_fails_cleanly()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => StartedSymphonyHost.StartAsync(_ => null));
+
+        Assert.Contains("missing_workflow_file", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("WORKFLOW.md", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartAsync_runs_smoke_flow_from_workflow_load_to_workspace_create_and_worker_attempt()
+    {
+        var issue = new Issue(
+            id: "42",
+            identifier: "ABC-42",
+            title: "Smoke flow",
+            description: "Validate the orchestration path",
+            priority: 1,
+            state: "Todo",
+            createdAt: new DateTimeOffset(2026, 3, 18, 9, 0, 0, TimeSpan.Zero));
+        var trackerClient = new SmokeIssueTrackerClient(issue);
+        var probe = new SmokeRunProbe();
+
+        await using var host = await StartedSymphonyHost.StartAsync(
+            tempDirectory => CreateWorkflowContents(Path.Combine(tempDirectory, "workspaces")),
+            services =>
+            {
+                services.RemoveAll<IIssueTrackerClient>();
+                services.AddSingleton<IIssueTrackerClient>(trackerClient);
+
+                services.RemoveAll<IQueuedIssueWorker>();
+                services.AddSingleton(probe);
+                services.AddSingleton<IQueuedIssueWorker, SmokeQueuedIssueWorker>();
+
+                RemoveHostedService<RetryDispatchBackgroundService>(services);
+            });
+
+        var observation = await probe.AttemptObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var expectedWorkspacePath = Path.GetFullPath(Path.Combine(host.TempDirectory, "workspaces", "ABC-42"));
+
+        Assert.True(trackerClient.FetchCandidateIssuesCallCount >= 1);
+        Assert.Equal("ABC-42", observation.IssueIdentifier);
+        Assert.Null(observation.Attempt);
+        Assert.Equal("Smoke prompt for {{ issue.identifier }} on attempt {{ attempt }}.", observation.PromptTemplate);
+        Assert.Equal(expectedWorkspacePath, observation.Workspace.Path);
+        Assert.Equal("ABC-42", observation.Workspace.WorkspaceKey);
+        Assert.True(observation.Workspace.CreatedNow);
+        Assert.True(Directory.Exists(expectedWorkspacePath));
+    }
+
+    private static string CreateWorkflowContents(string workspaceRoot)
+    {
+        var normalizedWorkspaceRoot = workspaceRoot.Replace('\\', '/');
+
+        return
+            $$"""
+            ---
+            tracker:
+              kind: github
+              api_key: test-token
+              repository: AGiorgetti/my-symphony
+              active_states:
+                - Todo
+              terminal_states:
+                - Done
+            polling:
+              interval_ms: 60000
+            workspace:
+              root: "{{normalizedWorkspaceRoot}}"
+            agent:
+              max_concurrent_agents: 1
+              max_turns: 5
+            codex:
+              command: codex app-server
+            ---
+            """
+            + Environment.NewLine
+            + "Smoke prompt for {{ issue.identifier }} on attempt {{ attempt }}.";
+    }
+
+    private static void RemoveHostedService<TImplementation>(IServiceCollection services)
+        where TImplementation : class, IHostedService
+    {
+        for (var index = services.Count - 1; index >= 0; index--)
+        {
+            var descriptor = services[index];
+            if (descriptor.ServiceType == typeof(IHostedService)
+                && descriptor.ImplementationType == typeof(TImplementation))
+            {
+                services.RemoveAt(index);
+            }
+        }
+    }
+
+    private sealed class StartedSymphonyHost : IAsyncDisposable
+    {
+        private readonly string _previousDirectory;
+        private int _disposed;
+
+        private StartedSymphonyHost(WebApplication app, string tempDirectory, string previousDirectory)
+        {
+            App = app;
+            TempDirectory = tempDirectory;
+            _previousDirectory = previousDirectory;
+        }
+
+        public WebApplication App { get; }
+
+        public string TempDirectory { get; }
+
+        public static async Task<StartedSymphonyHost> StartAsync(
+            Func<string, string?> workflowFactory,
+            Action<IServiceCollection>? configureServices = null)
+        {
+            ArgumentNullException.ThrowIfNull(workflowFactory);
+
+            var tempDirectory = Path.Combine(Path.GetTempPath(), $"symphony-host-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDirectory);
+
+            var workflowContents = workflowFactory(tempDirectory);
+            if (workflowContents is not null)
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(tempDirectory, "WORKFLOW.md"),
+                    workflowContents).ConfigureAwait(false);
+            }
+
+            await CurrentDirectoryGate.WaitAsync().ConfigureAwait(false);
+            var previousDirectory = Directory.GetCurrentDirectory();
+            WebApplication? app = null;
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDirectory);
+
+                var builder = WebApplication.CreateBuilder();
+                builder.WebHost.UseUrls("http://127.0.0.1:0");
+                builder.AddSymphonyHost();
+                configureServices?.Invoke(builder.Services);
+
+                app = builder.Build();
+                app.MapSymphonyHost();
+                await app.StartAsync().ConfigureAwait(false);
+
+                return new StartedSymphonyHost(app, tempDirectory, previousDirectory);
+            }
+            catch
+            {
+                if (app is not null)
+                {
+                    await app.DisposeAsync().ConfigureAwait(false);
+                }
+
+                Directory.SetCurrentDirectory(previousDirectory);
+                CurrentDirectoryGate.Release();
+                TryDeleteDirectory(tempDirectory);
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await App.StopAsync().ConfigureAwait(false);
+                await App.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(_previousDirectory);
+                CurrentDirectoryGate.Release();
+                TryDeleteDirectory(TempDirectory);
+            }
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private sealed class SmokeQueuedIssueWorker(
+        SmokeRunProbe probe,
+        IWorkflowDefinitionProvider workflowDefinitionProvider,
+        IWorkspaceManager workspaceManager) : IQueuedIssueWorker
+    {
+        public async Task ExecuteAsync(QueuedIssueExecutionContext context)
+        {
+            context.UpdateStatus(RunAttemptStatus.PreparingWorkspace);
+            var workspace = await workspaceManager.CreateForIssueAsync(context.Issue.Identifier, context.CancellationToken).ConfigureAwait(false);
+
+            context.UpdateStatus(RunAttemptStatus.BuildingPrompt);
+            var workflowDefinition = await workflowDefinitionProvider.GetCurrentDefinitionAsync(context.CancellationToken).ConfigureAwait(false);
+
+            context.UpdateStatus(RunAttemptStatus.LaunchingAgentProcess);
+            probe.Record(
+                new SmokeRunObservation(
+                    context.Issue.Identifier,
+                    context.Attempt,
+                    workflowDefinition.PromptTemplate,
+                    workspace));
+
+            context.UpdateStatus(RunAttemptStatus.Finishing);
+        }
+    }
+
+    private sealed class SmokeIssueTrackerClient(Issue issue) : IIssueTrackerClient
+    {
+        private readonly IReadOnlyList<Issue> _issues = [issue];
+        private int _fetchCandidateIssuesCallCount;
+
+        public int FetchCandidateIssuesCallCount => Volatile.Read(ref _fetchCandidateIssuesCallCount);
+
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _fetchCandidateIssuesCallCount);
+            return Task.FromResult(_issues);
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+    }
+
+    private sealed class SmokeRunProbe
+    {
+        public TaskCompletionSource<SmokeRunObservation> AttemptObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Record(SmokeRunObservation observation)
+        {
+            AttemptObserved.TrySetResult(observation);
+        }
+    }
+
+    private sealed record SmokeRunObservation(
+        string IssueIdentifier,
+        int? Attempt,
+        string PromptTemplate,
+        Workspace Workspace);
+}


### PR DESCRIPTION
Closes #28

#### Context

E8-S2 needs host-level proof that the ASP.NET Core host fails cleanly on invalid startup config and can drive one `WORKFLOW.md`-backed smoke path through polling, workspace creation, and worker execution.

#### TL;DR

Adds reusable host composition plus startup and smoke integration tests.

#### Summary

- Extract host service and endpoint composition from `Program.cs` into reusable extensions.
- Add full-host integration coverage for missing `WORKFLOW.md` startup failure.
- Add a smoke test covering workflow load, issue poll, workspace create, and worker attempt.
- Document that PR CI already runs the solution-wide host integration checks.

#### Alternatives

- Keep duplicating `Program.cs` setup inside tests, but that would drift from production host wiring.
- Test only the hosted services in isolation, but that would miss the actual host startup path required by `SPEC.md`.

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Verified `SymphonyHostLifecycleIntegrationTests` covers startup failure and the host smoke flow