### PR TITLE
E8-S4: harden health and timeout diagnostics

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -241,11 +241,15 @@ Notes:
 - Successful worker exits schedule a one-second continuation retry. Failed worker exits are retried
   with exponential backoff starting at 10 seconds, capped by `agent.max_retry_backoff_ms`, and are
   surfaced through the in-memory retry snapshot.
+- Operator-facing health now degrades when the last successful poll becomes stale or when
+  `WORKFLOW.md` reload fails and Symphony falls back to the last-known-good workflow snapshot.
 - Active sessions are tracked in-memory by normalized issue id, can expose live session metadata,
   and support targeted reconciliation cancellation without affecting unrelated executions.
 - Worker attempts now create a validated workspace, optionally run `hooks.before_run`, launch Codex
   through `bash -lc <codex.command>`, send the `initialize` / `thread/start` / `turn/start`
   handshake, then run `hooks.after_run` as a best-effort cleanup step after the attempt ends.
+- Hook/process timeouts and Codex read/turn timeouts are recorded separately from ordinary
+  cancellations, surface as `TimedOut` run attempts, and still enter the standard retry backoff.
 - `codex.turn_sandbox_policy` is treated as a structured object and is forwarded to Codex in the
   `turn/start` payload instead of being flattened into a string.
 - Per-issue workspaces live under `workspace.root` using a sanitized issue identifier that keeps
@@ -272,7 +276,10 @@ The dashboard shell is implemented as an interactive-server Blazor page. It is a
 surface only: if dashboard rendering fails, the orchestrator and JSON API continue running.
 - The dashboard now includes active-session, retry-queue, and recent-attempt panels so operators
   can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
-- `GET /api/v1/state` for the current running/retrying snapshot, live token totals, and runtime counts
+- The dashboard health cards now expose last poll tick, last successful poll age, and workflow load
+  status so degraded polling or workflow-reload fallback is visible without reading logs.
+- `GET /api/v1/state` for the current running/retrying snapshot, live token totals, runtime counts,
+  and operator health fields such as poll staleness and workflow reload status
 - `GET /api/v1/{issueIdentifier}` for issue-specific runtime details with a `404` JSON error envelope when the issue is not tracked
 - `POST /api/v1/refresh` to queue an immediate poll-and-reconcile cycle; repeated requests coalesce while one is already pending
 

--- a/dotnet/src/Symphony.Abstractions/Processes/ProcessRunTimedOutException.cs
+++ b/dotnet/src/Symphony.Abstractions/Processes/ProcessRunTimedOutException.cs
@@ -1,0 +1,24 @@
+namespace Symphony.Abstractions.Processes;
+
+public sealed class ProcessRunTimedOutException : TimeoutException
+{
+    public ProcessRunTimedOutException(
+        string fileName,
+        string workingDirectory,
+        TimeSpan timeout,
+        Exception? innerException = null)
+        : base(
+            $"Process '{fileName}' timed out after {timeout.TotalMilliseconds:0} ms in '{workingDirectory}'.",
+            innerException)
+    {
+        FileName = fileName;
+        WorkingDirectory = workingDirectory;
+        Timeout = timeout;
+    }
+
+    public string FileName { get; }
+
+    public string WorkingDirectory { get; }
+
+    public TimeSpan Timeout { get; }
+}

--- a/dotnet/src/Symphony.Application/Configuration/IWorkflowLoadStatusReader.cs
+++ b/dotnet/src/Symphony.Application/Configuration/IWorkflowLoadStatusReader.cs
@@ -1,0 +1,15 @@
+namespace Symphony.Application.Configuration;
+
+public interface IWorkflowLoadStatusReader
+{
+    WorkflowLoadStatusSnapshot GetSnapshot();
+}
+
+public sealed record WorkflowLoadStatusSnapshot(
+    string Status,
+    string? WorkflowPath,
+    DateTimeOffset? LastSuccessfulLoadAt,
+    DateTimeOffset? LastFailedAt,
+    string? LastErrorCode,
+    string? LastError,
+    int? PollingIntervalMs);

--- a/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
@@ -133,6 +133,27 @@ public sealed class DispatchWorkerBackgroundService(
                 workItem.Issue.Identifier,
                 executionContext.SessionId);
         }
+        catch (IssueExecutionTimedOutException exception)
+        {
+            executionContext.UpdateStatus(RunAttemptStatus.TimedOut, exception.Message);
+            attemptHistoryTracker.Record(
+                workItem.Issue.Id,
+                workItem.Issue.Identifier,
+                workItem.Attempt,
+                "TimedOut",
+                attemptStartedAt,
+                timeProvider.GetUtcNow(),
+                exception.Message,
+                executionContext.SessionId);
+            logger.LogWarning(
+                exception,
+                "dispatch_execution timed_out issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=timeout outcome=timed_out",
+                workItem.Issue.Id,
+                workItem.Issue.Identifier,
+                executionContext.SessionId);
+            await dispatchQueue.ScheduleFailureRetryAsync(workItem, exception, cancellationToken).ConfigureAwait(false);
+            executionLease.PreserveClaimForRetry();
+        }
         catch (Exception exception)
         {
             executionContext.UpdateStatus(RunAttemptStatus.Failed, exception.Message);

--- a/dotnet/src/Symphony.Application/Orchestration/IssueExecutionTimedOutException.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/IssueExecutionTimedOutException.cs
@@ -1,0 +1,9 @@
+namespace Symphony.Application.Orchestration;
+
+public sealed class IssueExecutionTimedOutException : TimeoutException
+{
+    public IssueExecutionTimedOutException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/dotnet/src/Symphony.Host/Api/SymphonyApiContracts.cs
+++ b/dotnet/src/Symphony.Host/Api/SymphonyApiContracts.cs
@@ -5,6 +5,7 @@ namespace Symphony.Host.Api;
 public sealed record StateResponseDto(
     [property: JsonPropertyName("generated_at")] DateTimeOffset GeneratedAt,
     [property: JsonPropertyName("counts")] StateCountsDto Counts,
+    [property: JsonPropertyName("health")] HealthStatusDto Health,
     [property: JsonPropertyName("running")] IReadOnlyList<RunningIssueDto> Running,
     [property: JsonPropertyName("retrying")] IReadOnlyList<RetryingIssueDto> Retrying,
     [property: JsonPropertyName("codex_totals")] CodexTotalsDto CodexTotals,
@@ -13,6 +14,18 @@ public sealed record StateResponseDto(
 public sealed record StateCountsDto(
     [property: JsonPropertyName("running")] int Running,
     [property: JsonPropertyName("retrying")] int Retrying);
+
+public sealed record HealthStatusDto(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("last_poll_tick_at")] DateTimeOffset? LastPollTickAt,
+    [property: JsonPropertyName("last_successful_poll_at")] DateTimeOffset? LastSuccessfulPollAt,
+    [property: JsonPropertyName("last_successful_poll_age_seconds")] double? LastSuccessfulPollAgeSeconds,
+    [property: JsonPropertyName("poll_is_stale")] bool PollIsStale,
+    [property: JsonPropertyName("workflow_load_status")] string WorkflowLoadStatus,
+    [property: JsonPropertyName("workflow_last_loaded_at")] DateTimeOffset? WorkflowLastLoadedAt,
+    [property: JsonPropertyName("workflow_path")] string? WorkflowPath,
+    [property: JsonPropertyName("poll_last_error")] string? PollLastError,
+    [property: JsonPropertyName("workflow_last_error")] string? WorkflowLastError);
 
 public sealed record RunningIssueDto(
     [property: JsonPropertyName("issue_id")] string IssueId,

--- a/dotnet/src/Symphony.Host/Api/SymphonyApiEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Symphony.Host/Api/SymphonyApiEndpointRouteBuilderExtensions.cs
@@ -1,7 +1,9 @@
 using System.Text;
+using Microsoft.AspNetCore.Mvc;
 using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
 using Symphony.Application.Runtime;
+using Symphony.Host.Health;
 
 namespace Symphony.Host.Api;
 
@@ -15,15 +17,22 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
 
         group.MapGet(
             "/state",
-            async Task<IResult> (IOrchestratorRuntimeService runtimeService, CancellationToken cancellationToken) =>
+            async Task<IResult> (
+                [FromServices] IOrchestratorRuntimeService runtimeService,
+                [FromServices] ServiceHealthSnapshotProvider serviceHealthSnapshotProvider,
+                CancellationToken cancellationToken) =>
             {
                 var snapshot = await runtimeService.GetStateSnapshotAsync(cancellationToken).ConfigureAwait(false);
-                return Results.Ok(ToStateResponse(snapshot));
+                return Results.Ok(ToStateResponse(snapshot, serviceHealthSnapshotProvider.GetSnapshot()));
             });
 
         group.MapGet(
             "/{issueIdentifier}",
-            async Task<IResult> (string issueIdentifier, IOrchestratorRuntimeService runtimeService, IWorkflowOptionsProvider workflowOptionsProvider, CancellationToken cancellationToken) =>
+            async Task<IResult> (
+                string issueIdentifier,
+                [FromServices] IOrchestratorRuntimeService runtimeService,
+                [FromServices] IWorkflowOptionsProvider workflowOptionsProvider,
+                CancellationToken cancellationToken) =>
             {
                 var snapshot = await runtimeService.GetIssueSnapshotAsync(issueIdentifier, cancellationToken).ConfigureAwait(false);
                 if (snapshot is null)
@@ -45,7 +54,7 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
 
         group.MapPost(
             "/refresh",
-            IResult (IOrchestratorRuntimeService runtimeService) =>
+            IResult ([FromServices] IOrchestratorRuntimeService runtimeService) =>
             {
                 var receipt = runtimeService.RequestRefresh();
                 return Results.Accepted(
@@ -60,7 +69,7 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
         return endpoints;
     }
 
-    private static StateResponseDto ToStateResponse(OrchestratorStateSnapshot snapshot)
+    private static StateResponseDto ToStateResponse(OrchestratorStateSnapshot snapshot, ServiceHealthSnapshot healthSnapshot)
     {
         var running = snapshot.Running
             .Select(
@@ -92,6 +101,17 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
         return new StateResponseDto(
             snapshot.GeneratedAt,
             new StateCountsDto(running.Length, retrying.Length),
+            new HealthStatusDto(
+                healthSnapshot.Status,
+                healthSnapshot.LastPollTickAt,
+                healthSnapshot.LastSuccessfulPollAt,
+                healthSnapshot.LastSuccessfulPollAgeSeconds,
+                healthSnapshot.PollIsStale,
+                healthSnapshot.WorkflowLoadStatus,
+                healthSnapshot.WorkflowLastLoadedAt,
+                healthSnapshot.WorkflowPath,
+                healthSnapshot.PollLastError,
+                healthSnapshot.WorkflowLastError),
             running,
             retrying,
             new CodexTotalsDto(

--- a/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
@@ -24,7 +24,12 @@
         <article class="metric-card">
             <span class="metric-label">Last Poll Tick</span>
             <strong class="metric-value">@FormatTimestamp(snapshot.LastPollTickAt)</strong>
-            <span class="metric-meta">Most recent started or completed orchestrator poll tick.</span>
+            <span class="metric-meta">@GetPollMessage(snapshot)</span>
+        </article>
+        <article class="metric-card">
+            <span class="metric-label">Workflow Config</span>
+            <strong class="metric-value">@snapshot.WorkflowLoadStatus</strong>
+            <span class="metric-meta">@GetWorkflowMessage(snapshot)</span>
         </article>
     </section>
 
@@ -190,6 +195,10 @@
         ServiceHealth: "Starting",
         OrchestratorMode: "Single-process in-memory",
         LastPollTickAt: null,
+        LastSuccessfulPollAt: null,
+        LastSuccessfulPollAgeSeconds: null,
+        WorkflowLoadStatus: "Starting",
+        WorkflowLastLoadedAt: null,
         RunningCount: 0,
         RetryingCount: 0,
         InputTokens: 0,
@@ -199,7 +208,8 @@
         ActiveSessions: [],
         RetryQueue: [],
         RecentAttempts: [],
-        LastError: null);
+        LastError: null,
+        WorkflowLastError: null);
 
     protected override async Task OnInitializedAsync()
     {
@@ -259,6 +269,8 @@
             "succeeded" => "pill--success",
             "retrying" => "pill--warning",
             "failed" => "pill--danger",
+            "timedout" => "pill--danger",
+            "stalled" => "pill--danger",
             "canceled" => "pill--neutral",
             _ => "pill--neutral"
         };
@@ -266,16 +278,54 @@
 
     private static string GetHealthMessage(DashboardSnapshot snapshot)
     {
+        if (string.Equals(snapshot.WorkflowLoadStatus, "ReloadFailedUsingLastKnownGood", StringComparison.Ordinal))
+        {
+            return "Workflow reload failed; the service is using the last-known-good configuration.";
+        }
+
         if (!string.IsNullOrWhiteSpace(snapshot.LastError))
         {
             return "Latest poll attempt failed; the orchestrator is still running.";
         }
 
+        if (string.Equals(snapshot.ServiceHealth, "Degraded", StringComparison.Ordinal)
+            && snapshot.LastSuccessfulPollAgeSeconds is double ageSeconds)
+        {
+            return $"Last successful poll is {FormatDuration(ageSeconds)} old.";
+        }
+
         return snapshot.ServiceHealth switch
         {
-            "Healthy" => "Recent poll ticks completed successfully.",
-            "Degraded" => "Recent poll tick failed; inspect logs for details.",
-            _ => "No successful poll tick has completed yet."
+            "Healthy" => "Workflow loaded and recent poll ticks are healthy.",
+            "Degraded" => "Health indicators are degraded; inspect logs for details.",
+            _ => "Waiting for the first successful workflow load and poll tick."
         };
+    }
+
+    private static string GetPollMessage(DashboardSnapshot snapshot)
+    {
+        if (snapshot.LastSuccessfulPollAt is null)
+        {
+            return "Waiting for the first successful orchestrator poll.";
+        }
+
+        var age = snapshot.LastSuccessfulPollAgeSeconds is double ageSeconds
+            ? FormatDuration(ageSeconds)
+            : "unknown age";
+        return $"Last success {FormatTimestamp(snapshot.LastSuccessfulPollAt)} ({age} ago).";
+    }
+
+    private static string GetWorkflowMessage(DashboardSnapshot snapshot)
+    {
+        if (string.Equals(snapshot.WorkflowLoadStatus, "ReloadFailedUsingLastKnownGood", StringComparison.Ordinal))
+        {
+            return string.IsNullOrWhiteSpace(snapshot.WorkflowLastError)
+                ? "Last workflow reload failed; continuing with the cached definition."
+                : $"Reload failed: {snapshot.WorkflowLastError}";
+        }
+
+        return snapshot.WorkflowLastLoadedAt is null
+            ? "Waiting for the initial workflow load."
+            : $"Last loaded {FormatTimestamp(snapshot.WorkflowLastLoadedAt)}.";
     }
 }

--- a/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
+++ b/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
@@ -2,6 +2,7 @@ using Symphony.Application.DependencyInjection;
 using Symphony.Host.Api;
 using Symphony.Host.Components;
 using Symphony.Host.Dashboard;
+using Symphony.Host.Health;
 using Symphony.Infrastructure.DependencyInjection;
 
 namespace Symphony.Host.Composition;
@@ -22,6 +23,7 @@ public static class SymphonyHostCompositionExtensions
             .AddSymphonyApplication()
             .AddSymphonyInfrastructure()
             .AddConfiguredTrackerAdapter(builder.Configuration);
+        builder.Services.AddSingleton<ServiceHealthSnapshotProvider>();
         builder.Services.AddSingleton<IDashboardStateService, DashboardStateService>();
 
         return builder;

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
@@ -5,6 +5,10 @@ public sealed record DashboardSnapshot(
     string ServiceHealth,
     string OrchestratorMode,
     DateTimeOffset? LastPollTickAt,
+    DateTimeOffset? LastSuccessfulPollAt,
+    double? LastSuccessfulPollAgeSeconds,
+    string WorkflowLoadStatus,
+    DateTimeOffset? WorkflowLastLoadedAt,
     int RunningCount,
     int RetryingCount,
     long InputTokens,
@@ -14,7 +18,8 @@ public sealed record DashboardSnapshot(
     IReadOnlyList<DashboardActiveSessionSnapshot> ActiveSessions,
     IReadOnlyList<DashboardRetrySnapshot> RetryQueue,
     IReadOnlyList<DashboardRecentAttemptSnapshot> RecentAttempts,
-    string? LastError);
+    string? LastError,
+    string? WorkflowLastError);
 
 public sealed record DashboardActiveSessionSnapshot(
     string IssueIdentifier,

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
@@ -1,19 +1,20 @@
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
+using Symphony.Host.Health;
 
 namespace Symphony.Host.Dashboard;
 
 public sealed class DashboardStateService(
     IOrchestratorRuntimeService orchestratorRuntimeService,
     AttemptHistoryTracker attemptHistoryTracker,
-    PollingStatusTracker pollingStatusTracker) : IDashboardStateService
+    ServiceHealthSnapshotProvider serviceHealthSnapshotProvider) : IDashboardStateService
 {
     private const string InMemoryMode = "Single-process in-memory";
 
     public async Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
     {
         var runtimeSnapshot = await orchestratorRuntimeService.GetStateSnapshotAsync(cancellationToken).ConfigureAwait(false);
-        var pollingSnapshot = pollingStatusTracker.GetSnapshot();
+        var healthSnapshot = serviceHealthSnapshotProvider.GetSnapshot();
         var activeSessions = runtimeSnapshot.Running
             .Select(
                 session => new DashboardActiveSessionSnapshot(
@@ -49,9 +50,13 @@ public sealed class DashboardStateService(
 
         return new DashboardSnapshot(
             runtimeSnapshot.GeneratedAt,
-            DetermineServiceHealth(pollingSnapshot),
+            healthSnapshot.Status,
             InMemoryMode,
-            pollingSnapshot.LastSuccessfulTickAt ?? pollingSnapshot.LastCompletedAt ?? pollingSnapshot.LastStartedAt,
+            healthSnapshot.LastPollTickAt,
+            healthSnapshot.LastSuccessfulPollAt,
+            healthSnapshot.LastSuccessfulPollAgeSeconds,
+            healthSnapshot.WorkflowLoadStatus,
+            healthSnapshot.WorkflowLastLoadedAt,
             runtimeSnapshot.Running.Count,
             runtimeSnapshot.Retrying.Count,
             runtimeSnapshot.CodexTotals.InputTokens,
@@ -61,22 +66,7 @@ public sealed class DashboardStateService(
             activeSessions,
             retryQueue,
             recentAttempts,
-            pollingSnapshot.LastError);
-    }
-
-    private static string DetermineServiceHealth(PollingStatusSnapshot pollingSnapshot)
-    {
-        if (pollingSnapshot.LastFailedAt is not null
-            && (pollingSnapshot.LastSuccessfulTickAt is null || pollingSnapshot.LastFailedAt > pollingSnapshot.LastSuccessfulTickAt))
-        {
-            return "Degraded";
-        }
-
-        if (pollingSnapshot.LastSuccessfulTickAt is not null)
-        {
-            return "Healthy";
-        }
-
-        return "Starting";
+            healthSnapshot.PollLastError,
+            healthSnapshot.WorkflowLastError);
     }
 }

--- a/dotnet/src/Symphony.Host/Health/ServiceHealthSnapshotProvider.cs
+++ b/dotnet/src/Symphony.Host/Health/ServiceHealthSnapshotProvider.cs
@@ -1,0 +1,74 @@
+using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
+
+namespace Symphony.Host.Health;
+
+public sealed class ServiceHealthSnapshotProvider(
+    PollingStatusTracker pollingStatusTracker,
+    IWorkflowLoadStatusReader workflowLoadStatusReader,
+    TimeProvider timeProvider)
+{
+    private const string Healthy = "Healthy";
+    private const string Degraded = "Degraded";
+    private const string Starting = "Starting";
+    private static readonly TimeSpan MinimumStaleThreshold = TimeSpan.FromSeconds(30);
+
+    public ServiceHealthSnapshot GetSnapshot()
+    {
+        var pollingSnapshot = pollingStatusTracker.GetSnapshot();
+        var workflowSnapshot = workflowLoadStatusReader.GetSnapshot();
+        var now = timeProvider.GetUtcNow();
+        var lastPollTickAt = pollingSnapshot.LastCompletedAt ?? pollingSnapshot.LastStartedAt;
+        TimeSpan? lastSuccessfulPollAge = pollingSnapshot.LastSuccessfulTickAt is null
+            ? null
+            : now - pollingSnapshot.LastSuccessfulTickAt.Value;
+        var pollStaleThreshold = GetPollStaleThreshold(workflowSnapshot.PollingIntervalMs);
+        var pollIsStale = lastSuccessfulPollAge is not null && lastSuccessfulPollAge > pollStaleThreshold;
+        var pollFailed = pollingSnapshot.LastFailedAt is not null
+            && (pollingSnapshot.LastSuccessfulTickAt is null || pollingSnapshot.LastFailedAt > pollingSnapshot.LastSuccessfulTickAt);
+        var workflowFailed = string.Equals(
+            workflowSnapshot.Status,
+            "ReloadFailedUsingLastKnownGood",
+            StringComparison.Ordinal);
+
+        var status = workflowFailed || pollFailed || pollIsStale
+            ? Degraded
+            : pollingSnapshot.LastSuccessfulTickAt is not null
+                ? Healthy
+                : Starting;
+
+        return new ServiceHealthSnapshot(
+            status,
+            lastPollTickAt,
+            pollingSnapshot.LastSuccessfulTickAt,
+            lastSuccessfulPollAge?.TotalSeconds,
+            pollIsStale,
+            workflowSnapshot.Status,
+            workflowSnapshot.LastSuccessfulLoadAt,
+            workflowSnapshot.WorkflowPath,
+            pollingSnapshot.LastError,
+            workflowSnapshot.LastError);
+    }
+
+    private static TimeSpan GetPollStaleThreshold(int? pollingIntervalMs)
+    {
+        if (pollingIntervalMs is null || pollingIntervalMs <= 0)
+        {
+            return MinimumStaleThreshold;
+        }
+
+        return TimeSpan.FromMilliseconds(Math.Max(pollingIntervalMs.Value * 2L, (long)MinimumStaleThreshold.TotalMilliseconds));
+    }
+}
+
+public sealed record ServiceHealthSnapshot(
+    string Status,
+    DateTimeOffset? LastPollTickAt,
+    DateTimeOffset? LastSuccessfulPollAt,
+    double? LastSuccessfulPollAgeSeconds,
+    bool PollIsStale,
+    string WorkflowLoadStatus,
+    DateTimeOffset? WorkflowLastLoadedAt,
+    string? WorkflowPath,
+    string? PollLastError,
+    string? WorkflowLastError);

--- a/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
+++ b/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
@@ -187,6 +187,10 @@ internal sealed class CodexAppServerClient(
             {
                 throw new CodexAgentException("response_timeout", "Timed out waiting for Codex app-server response.", exception);
             }
+            catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new CodexAgentException("response_timeout", "Timed out waiting for Codex app-server response.", exception);
+            }
 
             if (line is null)
             {

--- a/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowLoadStatusTracker.cs
+++ b/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowLoadStatusTracker.cs
@@ -1,0 +1,62 @@
+using Symphony.Application.Configuration;
+
+namespace Symphony.Infrastructure.Configuration;
+
+public sealed class WorkflowLoadStatusTracker : IWorkflowLoadStatusReader
+{
+    private readonly Lock _stateLock = new();
+    private WorkflowLoadStatusSnapshot _snapshot = new(
+        Status: "Starting",
+        WorkflowPath: null,
+        LastSuccessfulLoadAt: null,
+        LastFailedAt: null,
+        LastErrorCode: null,
+        LastError: null,
+        PollingIntervalMs: null);
+
+    public void RecordLoaded(string workflowPath, WorkflowServiceOptions workflowOptions, DateTimeOffset loadedAt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowPath);
+        ArgumentNullException.ThrowIfNull(workflowOptions);
+
+        lock (_stateLock)
+        {
+            _snapshot = _snapshot with
+            {
+                Status = "Loaded",
+                WorkflowPath = workflowPath,
+                LastSuccessfulLoadAt = loadedAt,
+                LastErrorCode = null,
+                LastError = null,
+                PollingIntervalMs = workflowOptions.Polling.IntervalMs
+            };
+        }
+    }
+
+    public void RecordFailed(string workflowPath, string errorCode, string error, DateTimeOffset failedAt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(error);
+
+        lock (_stateLock)
+        {
+            _snapshot = _snapshot with
+            {
+                Status = "ReloadFailedUsingLastKnownGood",
+                WorkflowPath = workflowPath,
+                LastFailedAt = failedAt,
+                LastErrorCode = errorCode,
+                LastError = error.Trim()
+            };
+        }
+    }
+
+    public WorkflowLoadStatusSnapshot GetSnapshot()
+    {
+        lock (_stateLock)
+        {
+            return _snapshot;
+        }
+    }
+}

--- a/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsProvider.cs
+++ b/dotnet/src/Symphony.Infrastructure/Configuration/WorkflowOptionsProvider.cs
@@ -9,6 +9,8 @@ public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider, IWorkflo
 {
     private readonly IWorkflowLoader _workflowLoader;
     private readonly IWorkflowOptionsResolver _workflowOptionsResolver;
+    private readonly WorkflowLoadStatusTracker _workflowLoadStatusTracker;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<WorkflowOptionsProvider> _logger;
     private readonly SemaphoreSlim _reloadGate = new(1, 1);
     private WorkflowSnapshot? _currentSnapshot;
@@ -20,10 +22,14 @@ public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider, IWorkflo
     public WorkflowOptionsProvider(
         IWorkflowLoader workflowLoader,
         IWorkflowOptionsResolver workflowOptionsResolver,
+        WorkflowLoadStatusTracker workflowLoadStatusTracker,
+        TimeProvider timeProvider,
         ILogger<WorkflowOptionsProvider> logger)
     {
         _workflowLoader = workflowLoader;
         _workflowOptionsResolver = workflowOptionsResolver;
+        _workflowLoadStatusTracker = workflowLoadStatusTracker;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -109,6 +115,11 @@ public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider, IWorkflo
         }
         catch (Exception exception)
         {
+            _workflowLoadStatusTracker.RecordFailed(
+                workflowPath,
+                GetErrorCode(exception),
+                exception.Message,
+                _timeProvider.GetUtcNow());
             _logger.LogError(
                 exception,
                 "workflow_reload failed workflow_path={workflow_path} error_code={error_code} outcome=failed",
@@ -127,6 +138,7 @@ public sealed class WorkflowOptionsProvider : IWorkflowOptionsProvider, IWorkflo
     {
         var workflowDefinition = await _workflowLoader.LoadAsync(workflowPath, cancellationToken).ConfigureAwait(false);
         var workflowOptions = _workflowOptionsResolver.Resolve(workflowDefinition);
+        _workflowLoadStatusTracker.RecordLoaded(workflowPath, workflowOptions, _timeProvider.GetUtcNow());
 
         return new WorkflowSnapshot(
             workflowPath,

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -23,6 +23,8 @@ public static class InfrastructureServiceCollectionExtensions
 
         services.AddSingleton<InfrastructureServiceMarker>();
         services.AddSingleton<IWorkflowOptionsResolver, WorkflowOptionsResolver>();
+        services.AddSingleton<WorkflowLoadStatusTracker>();
+        services.AddSingleton<IWorkflowLoadStatusReader>(serviceProvider => serviceProvider.GetRequiredService<WorkflowLoadStatusTracker>());
         services.AddSingleton<WorkflowOptionsProvider>();
         services.AddSingleton<IWorkflowOptionsProvider>(serviceProvider => serviceProvider.GetRequiredService<WorkflowOptionsProvider>());
         services.AddSingleton<IWorkflowDefinitionProvider>(serviceProvider => serviceProvider.GetRequiredService<WorkflowOptionsProvider>());

--- a/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
@@ -4,6 +4,7 @@ using Symphony.Abstractions.Workspaces;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
 using Symphony.Domain.Runs;
+using Symphony.Domain.Workspaces;
 using Symphony.Infrastructure.Codex;
 using Symphony.Infrastructure.Processes;
 using Symphony.Infrastructure.Workflows;
@@ -24,20 +25,23 @@ internal sealed class CodexQueuedIssueWorker(
         ArgumentNullException.ThrowIfNull(context);
 
         var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(context.CancellationToken).ConfigureAwait(false);
+        Workspace? workspace = null;
 
         context.UpdateStatus(RunAttemptStatus.PreparingWorkspace);
-        var workspace = await workspaceManager.CreateForIssueAsync(context.Issue.Identifier, context.CancellationToken).ConfigureAwait(false);
         var shouldRunAfterRunHook = false;
 
         try
         {
+            workspace = await workspaceManager.CreateForIssueAsync(context.Issue.Identifier, context.CancellationToken).ConfigureAwait(false);
+            var issueWorkspace = workspace ?? throw new InvalidOperationException("Workspace manager returned null.");
+
             if (workflowOptions.Hooks.BeforeRun is not null)
             {
                 await RunRequiredHookAsync(
                         "before_run",
                         workflowOptions.Hooks.BeforeRun,
                         context.Issue.Identifier,
-                        workspace.Path,
+                        issueWorkspace.Path,
                         workflowOptions.Hooks.TimeoutMs,
                         context.CancellationToken)
                     .ConfigureAwait(false);
@@ -50,8 +54,20 @@ internal sealed class CodexQueuedIssueWorker(
             var prompt = workflowPromptRenderer.Render(workflowDefinition, context.Issue, context.Attempt);
 
             context.UpdateStatus(RunAttemptStatus.LaunchingAgentProcess);
-            await codexAppServerClient.RunAsync(context, workspace.Path, prompt, workflowOptions.Codex).ConfigureAwait(false);
+            await codexAppServerClient.RunAsync(context, issueWorkspace.Path, prompt, workflowOptions.Codex).ConfigureAwait(false);
             context.UpdateStatus(RunAttemptStatus.Finishing);
+        }
+        catch (ProcessRunTimedOutException exception)
+        {
+            throw new IssueExecutionTimedOutException(
+                $"Issue '{context.Issue.Identifier}' timed out while running a workflow hook.",
+                exception);
+        }
+        catch (CodexAgentException exception) when (IsTimeout(exception))
+        {
+            throw new IssueExecutionTimedOutException(
+                $"Issue '{context.Issue.Identifier}' timed out while waiting for Codex.",
+                exception);
         }
         catch (WorkflowPromptRenderer.WorkflowPromptException exception)
         {
@@ -64,7 +80,7 @@ internal sealed class CodexQueuedIssueWorker(
         }
         finally
         {
-            if (shouldRunAfterRunHook && workflowOptions.Hooks.AfterRun is not null)
+            if (workspace is not null && shouldRunAfterRunHook && workflowOptions.Hooks.AfterRun is not null)
             {
                 await RunBestEffortHookAsync(
                         "after_run",
@@ -115,6 +131,15 @@ internal sealed class CodexQueuedIssueWorker(
                     result.ExitCode);
             }
         }
+        catch (ProcessRunTimedOutException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "workflow_hook timed_out issue_identifier={issue_identifier} hook_name={hook_name} workspace_path={workspace_path} outcome=timed_out",
+                issueIdentifier,
+                hookName,
+                workspacePath);
+        }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
@@ -143,11 +168,16 @@ internal sealed class CodexQueuedIssueWorker(
             issueIdentifier,
             hookName,
             workspacePath,
-            timeoutMs);
+                timeoutMs);
 
         return await processRunner.RunAsync(
                 ShellCommandRequestFactory.Create(command, workspacePath, timeoutMs),
                 cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private static bool IsTimeout(CodexAgentException exception)
+    {
+        return exception.Code is "response_timeout" or "turn_timeout";
     }
 }

--- a/dotnet/src/Symphony.Infrastructure/Processes/ProcessRunner.cs
+++ b/dotnet/src/Symphony.Infrastructure/Processes/ProcessRunner.cs
@@ -74,7 +74,7 @@ public sealed class ProcessRunner(ILogger<ProcessRunner> logger) : IProcessRunne
 
             return result;
         }
-        catch (OperationCanceledException) when (effectiveCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (effectiveCancellationToken.IsCancellationRequested)
         {
             TryKill(process);
 
@@ -86,11 +86,25 @@ public sealed class ProcessRunner(ILogger<ProcessRunner> logger) : IProcessRunne
             {
             }
 
-            logger.LogInformation(
-                "process_run canceled file_name={file_name} working_directory={working_directory} outcome=canceled",
+            if (cancellationToken.IsCancellationRequested)
+            {
+                logger.LogInformation(
+                    "process_run canceled file_name={file_name} working_directory={working_directory} outcome=canceled",
+                    request.FileName,
+                    request.WorkingDirectory);
+                throw;
+            }
+
+            logger.LogWarning(
+                "process_run timed_out file_name={file_name} working_directory={working_directory} timeout_ms={timeout_ms} outcome=timed_out",
                 request.FileName,
-                request.WorkingDirectory);
-            throw;
+                request.WorkingDirectory,
+                request.Timeout?.TotalMilliseconds);
+            throw new ProcessRunTimedOutException(
+                request.FileName,
+                request.WorkingDirectory,
+                request.Timeout ?? Timeout.InfiniteTimeSpan,
+                exception);
         }
     }
 

--- a/dotnet/src/Symphony.Infrastructure/Workspaces/WorkspaceManager.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workspaces/WorkspaceManager.cs
@@ -141,6 +141,15 @@ public sealed class WorkspaceManager(
                     result.ExitCode);
             }
         }
+        catch (ProcessRunTimedOutException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "workspace_hook timed_out issue_identifier={issue_identifier} hook_name={hook_name} workspace_path={workspace_path} outcome=timed_out",
+                issueIdentifier,
+                hookName,
+                workspacePath);
+        }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
@@ -317,6 +317,32 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal("transient failure", attempt.Error);
     }
 
+    [Fact]
+    public async Task DispatchWorker_records_timeout_attempts_and_schedules_retry()
+    {
+        var timeProvider = TimeProvider.System;
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var registry = CreateRegistry(timeProvider);
+        var attemptHistoryTracker = new AttemptHistoryTracker();
+        var worker = new ThrowingQueuedIssueWorker(
+            new IssueExecutionTimedOutException("worker timed out", new TimeoutException("timed out")));
+        var hostedService = CreateHostedService(queue, registry, attemptHistoryTracker, worker, timeProvider);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.ExecutionAttempted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => queue.GetSnapshot().Retrying.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => attemptHistoryTracker.GetRecentAttempts().Count == 1, TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var attempt = Assert.Single(attemptHistoryTracker.GetRecentAttempts());
+        var retry = Assert.Single(queue.GetSnapshot().Retrying);
+
+        Assert.Equal("TimedOut", attempt.Outcome);
+        Assert.Equal("worker timed out", attempt.Error);
+        Assert.Equal("worker timed out", retry.Error);
+    }
+
     private static OrchestratorDispatchQueue CreateQueue(int maxConcurrentAgents)
     {
         return CreateQueue(new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents)));

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -27,6 +27,10 @@ public sealed class DashboardPageIntegrationTests
                     "Healthy",
                     "Single-process in-memory",
                     new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 16, 14, 59, 30, TimeSpan.Zero),
+                    30d,
+                    "Loaded",
+                    new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
                     RunningCount: 2,
                     RetryingCount: 1,
                     InputTokens: 100,
@@ -65,7 +69,8 @@ public sealed class DashboardPageIntegrationTests
                             "Tracker request failed",
                             "thread-3-turn-2")
                     ],
-                    LastError: null)));
+                    LastError: null,
+                    WorkflowLastError: null)));
         var client = CreateHttpClient(app);
 
         var response = await client.GetAsync("/");
@@ -74,8 +79,10 @@ public sealed class DashboardPageIntegrationTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains("Runtime Control Surface", html, StringComparison.Ordinal);
         Assert.Contains("Service Health", html, StringComparison.Ordinal);
+        Assert.Contains("Workflow Config", html, StringComparison.Ordinal);
         Assert.Contains("Single-process in-memory", html, StringComparison.Ordinal);
         Assert.Contains("2026-03-16 15:00:00 UTC", html, StringComparison.Ordinal);
+        Assert.Contains("Loaded", html, StringComparison.Ordinal);
         Assert.Contains("Active Sessions", html, StringComparison.Ordinal);
         Assert.Contains("Retry Queue", html, StringComparison.Ordinal);
         Assert.Contains("Recent Attempts", html, StringComparison.Ordinal);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
@@ -1,6 +1,8 @@
+using Symphony.Application.Configuration;
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Dashboard;
+using Symphony.Host.Health;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -52,13 +54,30 @@ public sealed class DashboardStateServiceTests
         var pollingStatusTracker = new PollingStatusTracker();
         pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero));
         pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero));
-        var service = new DashboardStateService(runtimeService, attemptHistoryTracker, pollingStatusTracker);
+        var service = new DashboardStateService(
+            runtimeService,
+            attemptHistoryTracker,
+            new ServiceHealthSnapshotProvider(
+                pollingStatusTracker,
+                new StaticWorkflowLoadStatusReader(
+                    new WorkflowLoadStatusSnapshot(
+                        "Loaded",
+                        "C:\\repo\\WORKFLOW.md",
+                        new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
+                        null,
+                        null,
+                        null,
+                        30_000)),
+                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 0, 5, TimeSpan.Zero))));
 
         var snapshot = await service.GetSnapshotAsync();
 
         Assert.Equal("Healthy", snapshot.ServiceHealth);
         Assert.Equal("Single-process in-memory", snapshot.OrchestratorMode);
         Assert.Equal(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero), snapshot.LastPollTickAt);
+        Assert.Equal(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero), snapshot.LastSuccessfulPollAt);
+        Assert.Equal(5d, snapshot.LastSuccessfulPollAgeSeconds);
+        Assert.Equal("Loaded", snapshot.WorkflowLoadStatus);
         Assert.Single(snapshot.ActiveSessions);
         Assert.Single(snapshot.RetryQueue);
         Assert.Single(snapshot.RecentAttempts);
@@ -77,13 +96,29 @@ public sealed class DashboardStateServiceTests
         var pollingStatusTracker = new PollingStatusTracker();
         pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 15, 10, 0, TimeSpan.Zero));
         pollingStatusTracker.RecordFailed(new DateTimeOffset(2026, 3, 16, 15, 11, 0, TimeSpan.Zero), "Tracker request failed");
-        var service = new DashboardStateService(runtimeService, attemptHistoryTracker, pollingStatusTracker);
+        var service = new DashboardStateService(
+            runtimeService,
+            attemptHistoryTracker,
+            new ServiceHealthSnapshotProvider(
+                pollingStatusTracker,
+                new StaticWorkflowLoadStatusReader(
+                    new WorkflowLoadStatusSnapshot(
+                        "ReloadFailedUsingLastKnownGood",
+                        "C:\\repo\\WORKFLOW.md",
+                        new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 3, 16, 15, 10, 30, TimeSpan.Zero),
+                        "workflow_parse_error",
+                        "Tracker config is invalid.",
+                        30_000)),
+                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 11, 5, TimeSpan.Zero))));
 
         var snapshot = await service.GetSnapshotAsync();
 
         Assert.Equal("Degraded", snapshot.ServiceHealth);
         Assert.Equal(new DateTimeOffset(2026, 3, 16, 15, 11, 0, TimeSpan.Zero), snapshot.LastPollTickAt);
         Assert.Equal("Tracker request failed", snapshot.LastError);
+        Assert.Equal("ReloadFailedUsingLastKnownGood", snapshot.WorkflowLoadStatus);
+        Assert.Equal("Tracker config is invalid.", snapshot.WorkflowLastError);
     }
 
     private sealed class StubRuntimeService : IOrchestratorRuntimeService
@@ -108,6 +143,22 @@ public sealed class DashboardStateServiceTests
         public PollingRefreshReceipt RequestRefresh()
         {
             return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
+    }
+
+    private sealed class StaticWorkflowLoadStatusReader(WorkflowLoadStatusSnapshot snapshot) : IWorkflowLoadStatusReader
+    {
+        public WorkflowLoadStatusSnapshot GetSnapshot()
+        {
+            return snapshot;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset currentTime) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return currentTime;
         }
     }
 }

--- a/dotnet/tests/Symphony.Host.IntegrationTests/ServiceHealthSnapshotProviderTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/ServiceHealthSnapshotProviderTests.cs
@@ -1,0 +1,77 @@
+using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
+using Symphony.Host.Health;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class ServiceHealthSnapshotProviderTests
+{
+    [Fact]
+    public void GetSnapshot_returns_degraded_when_last_successful_poll_is_stale()
+    {
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 18, 14, 59, 0, TimeSpan.Zero));
+        pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 18, 14, 59, 0, TimeSpan.Zero));
+        var provider = new ServiceHealthSnapshotProvider(
+            pollingStatusTracker,
+            new StaticWorkflowLoadStatusReader(
+                new WorkflowLoadStatusSnapshot(
+                    "Loaded",
+                    "C:\\repo\\WORKFLOW.md",
+                    new DateTimeOffset(2026, 3, 18, 14, 58, 0, TimeSpan.Zero),
+                    null,
+                    null,
+                    null,
+                    1_000)),
+            new FakeTimeProvider(new DateTimeOffset(2026, 3, 18, 15, 0, 0, TimeSpan.Zero)));
+
+        var snapshot = provider.GetSnapshot();
+
+        Assert.Equal("Degraded", snapshot.Status);
+        Assert.True(snapshot.PollIsStale);
+        Assert.Equal(60d, snapshot.LastSuccessfulPollAgeSeconds);
+    }
+
+    [Fact]
+    public void GetSnapshot_returns_degraded_when_workflow_reload_failed_using_last_known_good()
+    {
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 18, 14, 59, 55, TimeSpan.Zero));
+        pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 18, 14, 59, 56, TimeSpan.Zero));
+        var provider = new ServiceHealthSnapshotProvider(
+            pollingStatusTracker,
+            new StaticWorkflowLoadStatusReader(
+                new WorkflowLoadStatusSnapshot(
+                    "ReloadFailedUsingLastKnownGood",
+                    "C:\\repo\\WORKFLOW.md",
+                    new DateTimeOffset(2026, 3, 18, 14, 58, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 18, 14, 59, 57, TimeSpan.Zero),
+                    "workflow_parse_error",
+                    "Front matter is invalid.",
+                    30_000)),
+            new FakeTimeProvider(new DateTimeOffset(2026, 3, 18, 15, 0, 0, TimeSpan.Zero)));
+
+        var snapshot = provider.GetSnapshot();
+
+        Assert.Equal("Degraded", snapshot.Status);
+        Assert.False(snapshot.PollIsStale);
+        Assert.Equal("ReloadFailedUsingLastKnownGood", snapshot.WorkflowLoadStatus);
+        Assert.Equal("Front matter is invalid.", snapshot.WorkflowLastError);
+    }
+
+    private sealed class StaticWorkflowLoadStatusReader(WorkflowLoadStatusSnapshot snapshot) : IWorkflowLoadStatusReader
+    {
+        public WorkflowLoadStatusSnapshot GetSnapshot()
+        {
+            return snapshot;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset currentTime) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return currentTime;
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyApiEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyApiEndpointRouteBuilderExtensionsTests.cs
@@ -9,6 +9,7 @@ using Symphony.Application.Configuration;
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Api;
+using Symphony.Host.Health;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -17,6 +18,9 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
     [Fact]
     public async Task State_endpoint_returns_runtime_snapshot()
     {
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordStarted(new DateTimeOffset(2026, 3, 16, 14, 59, 55, TimeSpan.Zero));
+        pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 16, 14, 59, 55, TimeSpan.Zero));
         using var app = await StartApiApplicationAsync(
             new StubRuntimeService
             {
@@ -47,7 +51,18 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
                     ],
                     new CodexTotalsSnapshot(100, 40, 140, 300d),
                     RateLimits: null)
-            });
+            },
+            pollingStatusTracker,
+            new StaticWorkflowLoadStatusReader(
+                new WorkflowLoadStatusSnapshot(
+                    "Loaded",
+                    "C:\\repo\\WORKFLOW.md",
+                    new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
+                    null,
+                    null,
+                    null,
+                    1_000)),
+            new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero)));
         var client = CreateHttpClient(app);
 
         var response = await client.GetAsync("/api/v1/state");
@@ -57,6 +72,9 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
         Assert.NotNull(payload);
         Assert.Equal(1, payload!.Counts.Running);
         Assert.Equal(1, payload.Counts.Retrying);
+        Assert.Equal("Healthy", payload.Health.Status);
+        Assert.Equal("Loaded", payload.Health.WorkflowLoadStatus);
+        Assert.Equal(5d, payload.Health.LastSuccessfulPollAgeSeconds);
         Assert.Equal("ABC-1", payload.Running[0].IssueIdentifier);
         Assert.Equal("ABC-2", payload.Retrying[0].IssueIdentifier);
     }
@@ -112,11 +130,22 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
         };
     }
 
-    private static async Task<WebApplication> StartApiApplicationAsync(IOrchestratorRuntimeService runtimeService)
+    private static async Task<WebApplication> StartApiApplicationAsync(
+        IOrchestratorRuntimeService runtimeService,
+        PollingStatusTracker? pollingStatusTracker = null,
+        IWorkflowLoadStatusReader? workflowLoadStatusReader = null,
+        TimeProvider? timeProvider = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         builder.Services.AddSingleton<IOrchestratorRuntimeService>(runtimeService);
+        builder.Services.AddSingleton(pollingStatusTracker ?? new PollingStatusTracker());
+        builder.Services.AddSingleton<IWorkflowLoadStatusReader>(
+            workflowLoadStatusReader
+            ?? new StaticWorkflowLoadStatusReader(
+                new WorkflowLoadStatusSnapshot("Starting", null, null, null, null, null, null)));
+        builder.Services.AddSingleton(timeProvider ?? TimeProvider.System);
+        builder.Services.AddSingleton<ServiceHealthSnapshotProvider>();
         builder.Services.AddSingleton<IWorkflowOptionsProvider>(
             new StaticWorkflowOptionsProvider(
                 new WorkflowServiceOptions(
@@ -198,6 +227,22 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
         public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class StaticWorkflowLoadStatusReader(WorkflowLoadStatusSnapshot snapshot) : IWorkflowLoadStatusReader
+    {
+        public WorkflowLoadStatusSnapshot GetSnapshot()
+        {
+            return snapshot;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset currentTime) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return currentTime;
         }
     }
 }

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsProviderTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Configuration/WorkflowOptionsProviderTests.cs
@@ -31,7 +31,8 @@ public sealed class WorkflowOptionsProviderTests
             """);
 
         var logger = new TestLogger<WorkflowOptionsProvider>();
-        using var provider = new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), logger);
+        var workflowLoadStatusTracker = new WorkflowLoadStatusTracker();
+        using var provider = CreateProvider(logger, workflowLoadStatusTracker);
 
         await CurrentDirectoryGate.WaitAsync();
 
@@ -67,6 +68,8 @@ public sealed class WorkflowOptionsProviderTests
                 Assert.Equal("Initial prompt for {{ issue.identifier }}", initialDefinition.PromptTemplate);
                 Assert.Equal(250, reloadedOptions.Polling.IntervalMs);
                 Assert.Equal("Updated prompt for {{ issue.title }}", reloadedDefinition.PromptTemplate);
+                Assert.Equal("Loaded", workflowLoadStatusTracker.GetSnapshot().Status);
+                Assert.Equal(250, workflowLoadStatusTracker.GetSnapshot().PollingIntervalMs);
                 Assert.Contains(
                     logger.Entries,
                     entry => entry.Message.Contains("workflow_reload completed", StringComparison.Ordinal));
@@ -102,7 +105,8 @@ public sealed class WorkflowOptionsProviderTests
             """);
 
         var logger = new TestLogger<WorkflowOptionsProvider>();
-        using var provider = new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), logger);
+        var workflowLoadStatusTracker = new WorkflowLoadStatusTracker();
+        using var provider = CreateProvider(logger, workflowLoadStatusTracker);
 
         await CurrentDirectoryGate.WaitAsync();
 
@@ -142,6 +146,11 @@ public sealed class WorkflowOptionsProviderTests
                 Assert.True(
                     errorCode is "missing_tracker_api_key" or "workflow_parse_error",
                     $"Unexpected workflow reload error code '{errorCode}'.");
+                var snapshot = workflowLoadStatusTracker.GetSnapshot();
+                Assert.Equal("ReloadFailedUsingLastKnownGood", snapshot.Status);
+                Assert.Equal(initialOptions.Polling.IntervalMs, snapshot.PollingIntervalMs);
+                Assert.Equal(errorCode, snapshot.LastErrorCode);
+                Assert.NotNull(snapshot.LastSuccessfulLoadAt);
             }
             finally
             {
@@ -152,6 +161,18 @@ public sealed class WorkflowOptionsProviderTests
         {
             CurrentDirectoryGate.Release();
         }
+    }
+
+    private static WorkflowOptionsProvider CreateProvider(
+        TestLogger<WorkflowOptionsProvider> logger,
+        WorkflowLoadStatusTracker workflowLoadStatusTracker)
+    {
+        return new WorkflowOptionsProvider(
+            new YamlWorkflowLoader(),
+            new WorkflowOptionsResolver(),
+            workflowLoadStatusTracker,
+            TimeProvider.System,
+            logger);
     }
 
     private static string CreateTemporaryDirectory()

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -38,6 +38,10 @@ public class InfrastructureServiceCollectionExtensionsTests
         Assert.Same(
             serviceProvider.GetRequiredService<IWorkflowOptionsProvider>(),
             serviceProvider.GetRequiredService<IWorkflowDefinitionProvider>());
+        Assert.IsType<WorkflowLoadStatusTracker>(serviceProvider.GetRequiredService<IWorkflowLoadStatusReader>());
+        Assert.Same(
+            serviceProvider.GetRequiredService<WorkflowLoadStatusTracker>(),
+            serviceProvider.GetRequiredService<IWorkflowLoadStatusReader>());
         Assert.IsType<TrackerClientOptionsProvider>(serviceProvider.GetRequiredService<ITrackerClientOptionsProvider>());
         Assert.IsType<YamlWorkflowLoader>(serviceProvider.GetRequiredService<IWorkflowLoader>());
         Assert.IsType<ProcessRunner>(serviceProvider.GetRequiredService<IProcessRunner>());

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
@@ -143,7 +143,68 @@ public sealed class CodexQueuedIssueWorkerTests
         }
     }
 
-    private static WorkflowServiceOptions CreateWorkflowOptions()
+    [Fact]
+    public async Task ExecuteAsync_translates_hook_timeout_to_issue_timeout()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "symphony-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspacePath);
+
+        try
+        {
+            var worker = new CodexQueuedIssueWorker(
+                new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
+                new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
+                new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
+                new RecordingProcessRunner(
+                    exceptionFactory: request => new ProcessRunTimedOutException(
+                        request.FileName,
+                        request.WorkingDirectory,
+                        request.Timeout ?? TimeSpan.FromMilliseconds(1))),
+                new WorkflowPromptRenderer(),
+                new CodexAppServerClient(new TestCodexProcessSessionFactory(), TimeProvider.System, NullLogger<CodexAppServerClient>.Instance),
+                NullLogger<CodexQueuedIssueWorker>.Instance);
+
+            using var testContext = CreateContext(attempt: null);
+
+            await Assert.ThrowsAsync<IssueExecutionTimedOutException>(() => worker.ExecuteAsync(testContext.Context));
+        }
+        finally
+        {
+            Directory.Delete(workspacePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_translates_codex_response_timeout_to_issue_timeout()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "symphony-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspacePath);
+
+        try
+        {
+            var worker = new CodexQueuedIssueWorker(
+                new StaticWorkflowOptionsProvider(CreateWorkflowOptions(beforeRun: null, afterRun: null, readTimeoutMs: 50)),
+                new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
+                new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
+                new RecordingProcessRunner(),
+                new WorkflowPromptRenderer(),
+                new CodexAppServerClient(new TestCodexProcessSessionFactory(), TimeProvider.System, NullLogger<CodexAppServerClient>.Instance),
+                NullLogger<CodexQueuedIssueWorker>.Instance);
+
+            using var testContext = CreateContext(attempt: null);
+
+            await Assert.ThrowsAsync<IssueExecutionTimedOutException>(() => worker.ExecuteAsync(testContext.Context));
+        }
+        finally
+        {
+            Directory.Delete(workspacePath, recursive: true);
+        }
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions(
+        string? beforeRun = "Write-Host before",
+        string? afterRun = "Write-Host after",
+        int readTimeoutMs = 5_000)
     {
         return new WorkflowServiceOptions(
             new WorkflowTrackerOptions(
@@ -160,8 +221,8 @@ public sealed class CodexQueuedIssueWorkerTests
             new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-runner-tests")),
             new WorkflowHookOptions(
                 null,
-                "Write-Host before",
-                "Write-Host after",
+                beforeRun,
+                afterRun,
                 null,
                 5_000),
             new WorkflowAgentOptions(1, 20, 300_000, new Dictionary<string, int>(StringComparer.Ordinal)),
@@ -174,7 +235,7 @@ public sealed class CodexQueuedIssueWorkerTests
                     ["type"] = "workspaceWrite"
                 },
                 60_000,
-                5_000,
+                readTimeoutMs,
                 300_000));
     }
 
@@ -225,7 +286,9 @@ public sealed class CodexQueuedIssueWorkerTests
         }
     }
 
-    private sealed class RecordingProcessRunner(IReadOnlyList<int>? exitCodes = null) : IProcessRunner
+    private sealed class RecordingProcessRunner(
+        IReadOnlyList<int>? exitCodes = null,
+        Func<ProcessRunRequest, Exception>? exceptionFactory = null) : IProcessRunner
     {
         private readonly Queue<int> _exitCodes = new((exitCodes ?? [0, 0]).ToArray());
 
@@ -234,6 +297,11 @@ public sealed class CodexQueuedIssueWorkerTests
         public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            if (exceptionFactory is not null)
+            {
+                return Task.FromException<ProcessRunResult>(exceptionFactory(request));
+            }
+
             var exitCode = _exitCodes.Count > 0
                 ? _exitCodes.Dequeue()
                 : 0;

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Processes/ProcessRunnerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Processes/ProcessRunnerTests.cs
@@ -91,7 +91,11 @@ public sealed class ProcessRunnerTests
             ? new ProcessRunRequest("cmd", ["/c", "ping 127.0.0.1 -n 30 > nul"], CreateTemporaryDirectory(), timeout: TimeSpan.FromMilliseconds(200))
             : new ProcessRunRequest("/bin/sh", ["-c", "sleep 30"], CreateTemporaryDirectory(), timeout: TimeSpan.FromMilliseconds(200));
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _runner.RunAsync(request));
+        var exception = await Assert.ThrowsAsync<ProcessRunTimedOutException>(() => _runner.RunAsync(request));
+
+        Assert.Equal(request.FileName, exception.FileName);
+        Assert.Equal(request.WorkingDirectory, exception.WorkingDirectory);
+        Assert.Equal(request.Timeout, exception.Timeout);
     }
 
     private static ProcessRunRequest CreateShellRequest(string script, string workingDirectory)

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowStartupValidationHostedServiceTests.cs
@@ -28,7 +28,7 @@ public sealed class WorkflowStartupValidationHostedServiceTests
         var loggerProvider = new TestLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
         var service = new WorkflowStartupValidationHostedService(
-            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), NullLogger<WorkflowOptionsProvider>.Instance),
+            CreateProvider(),
             loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
 
         await CurrentDirectoryGate.WaitAsync();
@@ -78,7 +78,7 @@ public sealed class WorkflowStartupValidationHostedServiceTests
         var loggerProvider = new TestLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
         var service = new WorkflowStartupValidationHostedService(
-            new WorkflowOptionsProvider(new YamlWorkflowLoader(), new WorkflowOptionsResolver(), NullLogger<WorkflowOptionsProvider>.Instance),
+            CreateProvider(),
             loggerFactory.CreateLogger<WorkflowStartupValidationHostedService>());
 
         await CurrentDirectoryGate.WaitAsync();
@@ -107,6 +107,16 @@ public sealed class WorkflowStartupValidationHostedServiceTests
         {
             CurrentDirectoryGate.Release();
         }
+    }
+
+    private static WorkflowOptionsProvider CreateProvider()
+    {
+        return new WorkflowOptionsProvider(
+            new YamlWorkflowLoader(),
+            new WorkflowOptionsResolver(),
+            new WorkflowLoadStatusTracker(),
+            TimeProvider.System,
+            NullLogger<WorkflowOptionsProvider>.Instance);
     }
 
     private sealed class TestLoggerProvider : ILoggerProvider

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workspaces/WorkspaceManagerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workspaces/WorkspaceManagerTests.cs
@@ -138,6 +138,48 @@ public sealed class WorkspaceManagerTests
         }
     }
 
+    [Fact]
+    public async Task DeleteForIssueAsync_rejects_workspace_root_path()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner: new RecordingProcessRunner());
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => manager.DeleteForIssueAsync("."));
+
+            Assert.Contains("must stay inside the configured workspace root", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteForIssueAsync_rejects_empty_workspace_key()
+    {
+        var workspaceRoot = CreateTemporaryWorkspaceRoot();
+
+        try
+        {
+            var manager = CreateWorkspaceManager(
+                workspaceRoot,
+                processRunner: new RecordingProcessRunner());
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => manager.DeleteForIssueAsync("   "));
+
+            Assert.Contains("empty string or composed entirely of whitespace", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(workspaceRoot);
+        }
+    }
+
     private static WorkspaceManager CreateWorkspaceManager(
         string workspaceRoot,
         RecordingProcessRunner processRunner,
@@ -208,7 +250,7 @@ public sealed class WorkspaceManagerTests
 
             if (exceptionFactory is not null)
             {
-                throw exceptionFactory(request);
+                return Task.FromException<ProcessRunResult>(exceptionFactory(request));
             }
 
             return Task.FromResult(


### PR DESCRIPTION
#### Context

SPEC.md requires E8-S4 to expose degraded operator health, separate timeouts from ordinary cancellation, and harden workspace path safeguards.

#### TL;DR

Add degraded health reporting, explicit timeout outcomes, and extra safety coverage.

#### Summary

- expose workflow-load and stale-poll health through the dashboard and `/api/v1/state`
- classify process and Codex timeouts as `TimedOut` attempts with retry diagnostics
- add host and infrastructure tests for health fallback, timeout translation, and workspace delete guards

#### Alternatives

- Keep generic cancellation and failure handling, but that hides stale polling, cached workflow fallback, and timeout-specific retries from operators.

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Verified stale-poll health, workflow reload fallback, timeout translation, and workspace path safety coverage

Closes #30