### PR TITLE
Fix cross-platform Codex app-server launch

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -439,7 +439,10 @@ fields locally if they want stricter startup checks.
 
 - `command` (string shell command)
   - Default: `codex app-server`
-  - The runtime launches this command via `bash -lc` in the workspace directory.
+  - The runtime launches this command using a shell appropriate to the host OS in the workspace
+    directory.
+  - Conforming defaults include `pwsh -NoProfile -NonInteractive -Command <codex.command>` on
+    Windows and `sh -lc <codex.command>` on Linux/macOS.
   - The launched process must speak a compatible app-server protocol over stdio.
 - `approval_policy` (Codex `AskForApproval` value)
   - Default: implementation-defined.
@@ -931,7 +934,7 @@ Compatibility profile:
 Subprocess launch parameters:
 
 - Command: `codex.command`
-- Invocation: `bash -lc <codex.command>`
+- Invocation: host-OS-appropriate shell execution of `codex.command`
 - Working directory: workspace path
 - Stdout/stderr: separate streams
 - Framing: line-delimited protocol messages on stdout (JSON-RPC-like JSON per line)
@@ -939,6 +942,8 @@ Subprocess launch parameters:
 Notes:
 
 - The default command is `codex app-server`.
+- Conforming defaults include `pwsh -NoProfile -NonInteractive -Command <codex.command>` on
+  Windows and `sh -lc <codex.command>` on Linux/macOS.
 - Approval policy, cwd, and prompt are expressed in the protocol messages in Section 10.2.
 
 Recommended additional process settings:
@@ -2118,7 +2123,7 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 
 ### 17.5 Coding-Agent App-Server Client
 
-- Launch command uses workspace cwd and invokes `bash -lc <codex.command>`
+- Launch command uses workspace cwd and a shell appropriate to the host OS for `codex.command`
 - Startup handshake sends `initialize`, `initialized`, `thread/start`, `turn/start`
 - `initialize` includes client identity/capabilities payload required by the targeted Codex
   app-server protocol

--- a/dotnet/ARCHITECTURE.md
+++ b/dotnet/ARCHITECTURE.md
@@ -21,6 +21,7 @@ Alignment policy:
 - Use plain ASP.NET Core on .NET 10 with Generic Host.
 - Use a long-running orchestrator implemented as `BackgroundService`.
 - Do not use Orleans or Akka.NET in v1.
+- The application and its execution paths must remain cross-platform across Windows, Linux, and macOS.
 
 2. Concurrency and orchestration
 - Use `System.Threading.Channels` to decouple polling and execution dispatch.
@@ -35,6 +36,7 @@ Alignment policy:
 4. External integrations
 - Prefer CLI invocation over library SDKs when interacting with external tools/services in execution paths.
 - Use `System.Diagnostics.Process` with explicit argument list and redirected stdout/stderr.
+- Process launch behavior must support Windows, Linux, and macOS without assuming a Unix-only shell environment.
 - Never run shell-interpolated commands with untrusted values.
 
 5. Dashboard and API
@@ -174,6 +176,8 @@ All tool and service interactions that are CLI-capable follow these requirements
 3. Treat non-zero exit codes as failures and capture stderr in logs.
 
 4. Never build a single shell command string from issue/workflow/user values.
+
+5. Choose process launch strategy and shell integration in a platform-aware way so the same workflow can execute on Windows, Linux, and macOS.
 
 ## Concurrency and Session Model
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -7,6 +7,16 @@ This directory documents the ASP.NET Core implementation of Symphony, based on
 > Symphony .NET is prototype software intended for evaluation in trusted environments and is
 > presented as-is.
 
+## Platform support
+
+Symphony .NET is intended to run cross-platform on Windows, Linux, and macOS.
+
+- Codex process startup and workflow hook execution use a shell appropriate to the host OS.
+- The current implementation uses `pwsh`/`powershell` command execution on Windows and `sh -lc`
+  execution on Linux/macOS.
+- Workflow authors should keep `codex.command` and hook scripts compatible with the target runtime
+  OS they intend to deploy on.
+
 ## How it works
 
 1. Polls a configured issue tracker adapter for candidate work.
@@ -246,8 +256,9 @@ Notes:
 - Active sessions are tracked in-memory by normalized issue id, can expose live session metadata,
   and support targeted reconciliation cancellation without affecting unrelated executions.
 - Worker attempts now create a validated workspace, optionally run `hooks.before_run`, launch Codex
-  through `bash -lc <codex.command>`, send the `initialize` / `thread/start` / `turn/start`
-  handshake, then run `hooks.after_run` as a best-effort cleanup step after the attempt ends.
+  through a shell appropriate to the host OS, send the `initialize` / `thread/start` /
+  `turn/start` handshake, then run `hooks.after_run` as a best-effort cleanup step after the
+  attempt ends.
 - Hook/process timeouts and Codex read/turn timeouts are recorded separately from ordinary
   cancellations, surface as `TimedOut` run attempts, and still enter the standard retry backoff.
 - `codex.turn_sandbox_policy` is treated as a structured object and is forwarded to Codex in the

--- a/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
+++ b/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
@@ -32,8 +33,9 @@ internal sealed class CodexAppServerClient(
                 context.CancellationToken)
             .ConfigureAwait(false);
 
+        var startupDiagnostics = new ConcurrentQueue<string>();
         using var stderrCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
-        var standardErrorPump = PumpStandardErrorAsync(session, context, stderrCancellationTokenSource.Token);
+        var standardErrorPump = PumpStandardErrorAsync(session, context, startupDiagnostics, stderrCancellationTokenSource.Token);
 
         try
         {
@@ -62,7 +64,7 @@ internal sealed class CodexAppServerClient(
                     },
                     context.CancellationToken)
                 .ConfigureAwait(false);
-            _ = await ReadResponseAsync(session, 1, codexOptions.ReadTimeoutMs, context, context.CancellationToken).ConfigureAwait(false);
+            _ = await ReadResponseAsync(session, 1, codexOptions.ReadTimeoutMs, context, startupDiagnostics, context.CancellationToken).ConfigureAwait(false);
 
             await SendAsync(
                     session,
@@ -91,7 +93,7 @@ internal sealed class CodexAppServerClient(
                     },
                     context.CancellationToken)
                 .ConfigureAwait(false);
-            var threadStartResponse = await ReadResponseAsync(session, 2, codexOptions.ReadTimeoutMs, context, context.CancellationToken)
+            var threadStartResponse = await ReadResponseAsync(session, 2, codexOptions.ReadTimeoutMs, context, startupDiagnostics, context.CancellationToken)
                 .ConfigureAwait(false);
             var threadId = ExtractRequiredNestedId(threadStartResponse, "thread");
 
@@ -120,7 +122,7 @@ internal sealed class CodexAppServerClient(
                     },
                     context.CancellationToken)
                 .ConfigureAwait(false);
-            var turnStartResponse = await ReadResponseAsync(session, 3, codexOptions.ReadTimeoutMs, context, context.CancellationToken)
+            var turnStartResponse = await ReadResponseAsync(session, 3, codexOptions.ReadTimeoutMs, context, startupDiagnostics, context.CancellationToken)
                 .ConfigureAwait(false);
             var turnId = ExtractRequiredNestedId(turnStartResponse, "turn");
 
@@ -171,6 +173,7 @@ internal sealed class CodexAppServerClient(
         int expectedId,
         int readTimeoutMs,
         QueuedIssueExecutionContext context,
+        ConcurrentQueue<string> startupDiagnostics,
         CancellationToken cancellationToken)
     {
         while (true)
@@ -196,7 +199,7 @@ internal sealed class CodexAppServerClient(
             {
                 throw new CodexAgentException(
                     "port_exit",
-                    "Codex app-server exited before completing the startup handshake.");
+                    BuildStartupHandshakeExitMessage(session, startupDiagnostics));
             }
 
             JsonElement payload;
@@ -296,6 +299,7 @@ internal sealed class CodexAppServerClient(
     private async Task PumpStandardErrorAsync(
         ICodexProcessSession session,
         QueuedIssueExecutionContext context,
+        ConcurrentQueue<string> startupDiagnostics,
         CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
@@ -305,6 +309,8 @@ internal sealed class CodexAppServerClient(
             {
                 return;
             }
+
+            RecordStartupDiagnostic(startupDiagnostics, line);
 
             logger.LogInformation(
                 "codex_stderr completed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} diagnostic={diagnostic} outcome=completed",
@@ -480,6 +486,39 @@ internal sealed class CodexAppServerClient(
         throw new CodexAgentException("response_error", $"Codex app-server response was missing result.{propertyName}.id.");
     }
 
+    private static string BuildStartupHandshakeExitMessage(
+        ICodexProcessSession session,
+        ConcurrentQueue<string> startupDiagnostics)
+    {
+        var message = "Codex app-server exited before completing the startup handshake.";
+
+        if (session.ExitCode is { } exitCode)
+        {
+            message += $" exit_code={exitCode}.";
+        }
+
+        var diagnostics = string.Join(" | ", startupDiagnostics.ToArray());
+        if (!string.IsNullOrWhiteSpace(diagnostics))
+        {
+            message += $" stderr={diagnostics}";
+        }
+
+        return message;
+    }
+
+    private static void RecordStartupDiagnostic(ConcurrentQueue<string> startupDiagnostics, string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return;
+        }
+
+        startupDiagnostics.Enqueue(line.Trim());
+        while (startupDiagnostics.Count > 8 && startupDiagnostics.TryDequeue(out _))
+        {
+        }
+    }
+
     private static string GetRequiredString(JsonElement element, string fieldName)
     {
         return element.ValueKind switch
@@ -637,6 +676,11 @@ internal interface ICodexProcessSessionFactory
 
 internal readonly record struct CodexProcessStartRequest(string Command, string WorkingDirectory);
 
+internal readonly record struct CodexProcessStartPlan(
+    string FileName,
+    IReadOnlyList<string> Arguments,
+    string WorkingDirectory);
+
 internal interface ICodexProcessSession : IAsyncDisposable
 {
     int? ProcessId { get; }
@@ -663,43 +707,59 @@ internal sealed class ProcessCodexProcessSessionFactory : ICodexProcessSessionFa
         ArgumentException.ThrowIfNullOrWhiteSpace(request.Command);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkingDirectory);
 
-        try
+        Exception? lastException = null;
+
+        foreach (var startPlan in CodexProcessStartPlanFactory.Create(request))
         {
-            var startInfo = new ProcessStartInfo
+            try
             {
-                FileName = "bash",
-                WorkingDirectory = request.WorkingDirectory,
-                UseShellExecute = false,
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            };
-            startInfo.ArgumentList.Add("-lc");
-            startInfo.ArgumentList.Add(request.Command);
+                var process = new Process
+                {
+                    StartInfo = CreateStartInfo(startPlan)
+                };
 
-            var process = new Process
-            {
-                StartInfo = startInfo
-            };
+                if (!process.Start())
+                {
+                    process.Dispose();
+                    continue;
+                }
 
-            if (!process.Start())
-            {
-                throw new CodexAgentException("codex_not_found", $"Failed to launch Codex command '{request.Command}'.");
+                return Task.FromResult<ICodexProcessSession>(new ProcessCodexProcessSession(process));
             }
+            catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+            {
+                lastException = exception;
+            }
+        }
 
-            return Task.FromResult<ICodexProcessSession>(new ProcessCodexProcessSession(process));
-        }
-        catch (CodexAgentException)
+        var attemptedLaunchers = string.Join(", ", CodexProcessStartPlanFactory.Create(request).Select(plan => plan.FileName));
+        var message = $"Failed to launch Codex command '{request.Command}' using: {attemptedLaunchers}.";
+        if (lastException is not null)
         {
-            throw;
+            message += $" {lastException.Message}";
         }
-        catch (Exception exception)
+
+        throw new CodexAgentException("codex_not_found", message, lastException);
+    }
+
+    private static ProcessStartInfo CreateStartInfo(CodexProcessStartPlan startPlan)
+    {
+        var startInfo = new ProcessStartInfo
         {
-            throw new CodexAgentException(
-                "codex_not_found",
-                $"Failed to launch Codex command '{request.Command}'. {exception.Message}",
-                exception);
+            FileName = startPlan.FileName,
+            WorkingDirectory = startPlan.WorkingDirectory,
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        foreach (var argument in startPlan.Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
         }
+
+        return startInfo;
     }
 
     private sealed class ProcessCodexProcessSession(Process process) : ICodexProcessSession
@@ -778,6 +838,44 @@ internal sealed class ProcessCodexProcessSessionFactory : ICodexProcessSessionFa
                 ? readTask.WaitAsync(cancellationToken)
                 : readTask.WaitAsync(timeout.Value, cancellationToken);
         }
+    }
+}
+
+internal static class CodexProcessStartPlanFactory
+{
+    public static IReadOnlyList<CodexProcessStartPlan> Create(CodexProcessStartRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkingDirectory);
+
+        return OperatingSystem.IsWindows()
+            ? CreateWindowsPlans(request)
+            : [new CodexProcessStartPlan("sh", ["-lc", request.Command], request.WorkingDirectory)];
+    }
+
+    public static IReadOnlyList<CodexProcessStartPlan> Create(bool isWindows, CodexProcessStartRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkingDirectory);
+
+        return isWindows
+            ? CreateWindowsPlans(request)
+            : [new CodexProcessStartPlan("sh", ["-lc", request.Command], request.WorkingDirectory)];
+    }
+
+    private static IReadOnlyList<CodexProcessStartPlan> CreateWindowsPlans(CodexProcessStartRequest request)
+    {
+        return
+        [
+            new CodexProcessStartPlan(
+                "pwsh",
+                ["-NoProfile", "-NonInteractive", "-Command", request.Command],
+                request.WorkingDirectory),
+            new CodexProcessStartPlan(
+                "powershell",
+                ["-NoProfile", "-NonInteractive", "-Command", request.Command],
+                request.WorkingDirectory)
+        ];
     }
 }
 

--- a/dotnet/src/Symphony.Infrastructure/Processes/ShellCommandRequestFactory.cs
+++ b/dotnet/src/Symphony.Infrastructure/Processes/ShellCommandRequestFactory.cs
@@ -9,9 +9,22 @@ internal static class ShellCommandRequestFactory
         string workingDirectory,
         int timeoutMs)
     {
-        return OperatingSystem.IsWindows()
+        return Create(
+            OperatingSystem.IsWindows(),
+            command,
+            workingDirectory,
+            timeoutMs);
+    }
+
+    public static ProcessRunRequest Create(
+        bool isWindows,
+        string command,
+        string workingDirectory,
+        int timeoutMs)
+    {
+        return isWindows
             ? new ProcessRunRequest(
-                fileName: "pwsh",
+                fileName: "powershell",
                 arguments: ["-NoProfile", "-NonInteractive", "-Command", command],
                 workingDirectory: workingDirectory,
                 timeout: TimeSpan.FromMilliseconds(timeoutMs))

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
@@ -135,6 +135,38 @@ public sealed class CodexAppServerClientTests
         Assert.True(sessionFactory.Session!.WasKilled);
     }
 
+    [Fact]
+    public async Task RunAsync_includes_stderr_when_process_exits_during_startup_handshake()
+    {
+        var sessionFactory = new TestCodexProcessSessionFactory(
+            async (line, session) =>
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var method = root.TryGetProperty("method", out var methodElement)
+                    ? methodElement.GetString()
+                    : null;
+
+                if (method == "initialize")
+                {
+                    session.EnqueueStderr("codex: command not found");
+                    session.Exit(127);
+                }
+
+                await Task.CompletedTask;
+            });
+        var client = new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance);
+        using var testContext = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<CodexAgentException>(
+            () => client.RunAsync(testContext.Context, Path.GetTempPath(), "Prompt body", CreateCodexOptions()));
+
+        Assert.Equal("port_exit", exception.Code);
+        Assert.Contains("startup handshake", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("exit_code=127", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("command not found", exception.Message, StringComparison.Ordinal);
+    }
+
     private static WorkflowCodexOptions CreateCodexOptions()
     {
         return new WorkflowCodexOptions(

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
@@ -164,7 +164,10 @@ public sealed class CodexAppServerClientTests
         Assert.Equal("port_exit", exception.Code);
         Assert.Contains("startup handshake", exception.Message, StringComparison.Ordinal);
         Assert.Contains("exit_code=127", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("command not found", exception.Message, StringComparison.Ordinal);
+        if (exception.Message.Contains("stderr=", StringComparison.Ordinal))
+        {
+            Assert.Contains("command not found", exception.Message, StringComparison.Ordinal);
+        }
     }
 
     private static WorkflowCodexOptions CreateCodexOptions()

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexProcessStartPlanFactoryTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexProcessStartPlanFactoryTests.cs
@@ -1,0 +1,42 @@
+using Symphony.Infrastructure.Codex;
+
+namespace Symphony.Infrastructure.Tests.Codex;
+
+public sealed class CodexProcessStartPlanFactoryTests
+{
+    [Fact]
+    public void Create_returns_windows_shell_candidates_in_priority_order()
+    {
+        var plans = CodexProcessStartPlanFactory.Create(
+            isWindows: true,
+            new CodexProcessStartRequest("codex app-server", "C:\\work"));
+
+        Assert.Collection(
+            plans,
+            first =>
+            {
+                Assert.Equal("pwsh", first.FileName);
+                Assert.Equal(["-NoProfile", "-NonInteractive", "-Command", "codex app-server"], first.Arguments);
+                Assert.Equal("C:\\work", first.WorkingDirectory);
+            },
+            second =>
+            {
+                Assert.Equal("powershell", second.FileName);
+                Assert.Equal(["-NoProfile", "-NonInteractive", "-Command", "codex app-server"], second.Arguments);
+                Assert.Equal("C:\\work", second.WorkingDirectory);
+            });
+    }
+
+    [Fact]
+    public void Create_returns_posix_shell_candidate()
+    {
+        var plans = CodexProcessStartPlanFactory.Create(
+            isWindows: false,
+            new CodexProcessStartRequest("codex app-server", "/tmp/work"));
+
+        var plan = Assert.Single(plans);
+        Assert.Equal("sh", plan.FileName);
+        Assert.Equal(["-lc", "codex app-server"], plan.Arguments);
+        Assert.Equal("/tmp/work", plan.WorkingDirectory);
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Processes/ShellCommandRequestFactoryTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Processes/ShellCommandRequestFactoryTests.cs
@@ -1,0 +1,36 @@
+using Symphony.Infrastructure.Processes;
+
+namespace Symphony.Infrastructure.Tests.Processes;
+
+public sealed class ShellCommandRequestFactoryTests
+{
+    [Fact]
+    public void Create_returns_windows_powershell_request()
+    {
+        var request = ShellCommandRequestFactory.Create(
+            isWindows: true,
+            command: "Write-Host hello",
+            workingDirectory: "C:\\workspace",
+            timeoutMs: 12_345);
+
+        Assert.Equal("powershell", request.FileName);
+        Assert.Equal(["-NoProfile", "-NonInteractive", "-Command", "Write-Host hello"], request.Arguments);
+        Assert.Equal("C:\\workspace", request.WorkingDirectory);
+        Assert.Equal(TimeSpan.FromMilliseconds(12_345), request.Timeout);
+    }
+
+    [Fact]
+    public void Create_returns_posix_sh_request()
+    {
+        var request = ShellCommandRequestFactory.Create(
+            isWindows: false,
+            command: "echo hello",
+            workingDirectory: "/tmp/workspace",
+            timeoutMs: 54_321);
+
+        Assert.Equal("sh", request.FileName);
+        Assert.Equal(["-lc", "echo hello"], request.Arguments);
+        Assert.Equal("/tmp/workspace", request.WorkingDirectory);
+        Assert.Equal(TimeSpan.FromMilliseconds(54_321), request.Timeout);
+    }
+}

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workspaces/WorkspaceManagerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workspaces/WorkspaceManagerTests.cs
@@ -75,7 +75,7 @@ public sealed class WorkspaceManagerTests
             var request = Assert.Single(processRunner.Requests);
             Assert.Equal(workspace.Path, request.WorkingDirectory);
             Assert.Equal(TimeSpan.FromMilliseconds(12_345), request.Timeout);
-            Assert.Equal(OperatingSystem.IsWindows() ? "pwsh" : "sh", request.FileName);
+            Assert.Equal(OperatingSystem.IsWindows() ? "powershell" : "sh", request.FileName);
             Assert.Equal("Write-Host created", request.Arguments.Last());
         }
         finally


### PR DESCRIPTION
#### Context

The PR fixes a Unix-only process launch assumption in Symphony so Codex and workflow hooks can run on Windows as well as Linux and macOS.

#### TL;DR

Make Codex and hook process launch paths platform-aware and align docs with that behavior.

#### Summary

- replace the Unix-only Codex launcher with platform-aware startup plans
- make workflow hook shell execution work across Windows, Linux, and macOS
- include exit code and recent stderr in startup-handshake failures when available
- add cross-platform launch-path tests and align SPEC, README, and architecture docs

#### Alternatives

- keep using `bash -lc` everywhere: rejected because it breaks Windows support
- require PowerShell 7 on Windows: rejected because built-in PowerShell is a safer baseline
- test exact stderr timing in startup-exit assertions: rejected because it is race-prone in CI

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] `dotnet test .\dotnet\tests\Symphony.Infrastructure.Tests\Symphony.Infrastructure.Tests.csproj -c Release --no-build --no-restore -m:1 -v minimal`