### PR TITLE
EU1-S1: integrate Flowbite Blazor services in Symphony.Host

### DIFF
--- a/dotnet/src/Symphony.Host/Components/_Imports.razor
+++ b/dotnet/src/Symphony.Host/Components/_Imports.razor
@@ -1,6 +1,17 @@
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Flowbite.Base
+@using Flowbite.Common
+@using Flowbite.Components
+@using Flowbite.Components.Table
+@using Flowbite.Components.Tabs
+@using Flowbite.Icons
+@using Flowbite.Services
 @using Symphony.Host.Dashboard
 @using Symphony.Host.Components.Layout
+@using static Flowbite.Components.Button
+@using static Flowbite.Components.Dropdown
+@using static Flowbite.Components.Sidebar
+@using static Flowbite.Components.Tooltip
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
+++ b/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
@@ -1,3 +1,4 @@
+using Flowbite.Services;
 using Symphony.Application.DependencyInjection;
 using Symphony.Host.Api;
 using Symphony.Host.Components;
@@ -18,6 +19,7 @@ public static class SymphonyHostCompositionExtensions
         builder.Services
             .AddRazorComponents()
             .AddInteractiveServerComponents();
+        builder.Services.AddFlowbite();
 
         builder.Services
             .AddSymphonyApplication()

--- a/dotnet/src/Symphony.Host/Symphony.Host.csproj
+++ b/dotnet/src/Symphony.Host/Symphony.Host.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Flowbite" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="wwwroot\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Closes #73

#### Context

The UI implementation plan starts by wiring Flowbite into the host project so later shell, theming, and page stories can build on a known package and DI baseline.

#### TL;DR

Add Flowbite to the host project, register its services, and import the required Razor namespaces.

#### Summary

- add a floating `Flowbite` package reference to `Symphony.Host` so restore resolves the latest available prerelease release
- register `builder.Services.AddFlowbite()` in `SymphonyHostCompositionExtensions`
- add the Flowbite Razor imports and component usings required by the UI plan

#### Alternatives

- pin a specific Flowbite beta version, but that conflicts with the plan's requirement to avoid a pinned package version
- defer the package until the first component story, but that delays validation of the baseline host integration

#### Test Plan

- [x] `dotnet format --verify-no-changes --no-restore`
- [x] `dotnet build -c Release`
- [x] `dotnet test -c Release --no-build`