### PR TITLE
EU1-S5: provision Tailwind CLI in CI

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+approval_policy = "on-failure"

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -36,6 +36,39 @@ jobs:
       - name: Verify formatting
         run: dotnet format --verify-no-changes
 
+      - name: Provision Tailwind CLI
+        shell: pwsh
+        run: |
+          $toolDirectory = Join-Path $PWD "src/Symphony.Host/tools"
+          New-Item -ItemType Directory -Path $toolDirectory -Force | Out-Null
+
+          switch ("${{ runner.os }}") {
+            "Windows" {
+              $assetName = "tailwindcss-windows-x64.exe"
+              $targetName = "tailwindcss.exe"
+            }
+            "Linux" {
+              $assetName = "tailwindcss-linux-x64"
+              $targetName = "tailwindcss"
+            }
+            "macOS" {
+              $assetName = "tailwindcss-macos-arm64"
+              $targetName = "tailwindcss"
+            }
+            default {
+              throw "Unsupported runner.os '${{ runner.os }}'."
+            }
+          }
+
+          $downloadUrl = "https://github.com/tailwindlabs/tailwindcss/releases/latest/download/$assetName"
+          $targetPath = Join-Path $toolDirectory $targetName
+
+          Invoke-WebRequest -Uri $downloadUrl -OutFile $targetPath
+
+          if ("${{ runner.os }}" -ne "Windows") {
+            chmod +x $targetPath
+          }
+
       - name: Build
         run: dotnet build -c Release
 


### PR DESCRIPTION
#### Context

Implement story #77 from `dotnet/IMPLEMENTATIONPLAN_UI.github.md` by provisioning the Tailwind standalone CLI inside GitHub Actions before the Host build runs.

#### TL;DR

*Downloads the correct Tailwind CLI binary in CI so `Symphony.Host` can generate `app.min.css` during workflow builds.*

#### Summary

- Adds a cross-platform `Provision Tailwind CLI` step to `.github/workflows/make-all.yml` before `dotnet build`
- Selects the correct Tailwind asset from the latest GitHub release based on `${{ runner.os }}`
- Writes the binary into `dotnet/src/Symphony.Host/tools/` and marks it executable on non-Windows runners
- Carries `.codex/config.toml` on this branch as requested

#### Alternatives

- Keep skipping Tailwind in CI, but that leaves the generated CSS path untested in the workflow
- Add a Node/npm toolchain here, but that is wider than the standalone CLI approach defined in the implementation plan

#### Test Plan

- [x] `dotnet format --verify-no-changes Symphony.sln && dotnet build -c Release Symphony.sln && dotnet test -c Release --no-build Symphony.sln`
- [x] Confirm the workflow now provisions the Tailwind binary before the build step
- [x] Confirm GitHub Actions downloads the binary and generates Host CSS during the PR run

Closes #77

Co-authored-by: Agent <agent@github.com>