### PR TITLE
EU1-S4: bootstrap Flowbite assets and default theme

### DIFF
--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/dotnet/src/Symphony.Host/Components/App.razor
+++ b/dotnet/src/Symphony.Host/Components/App.razor
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark" data-theme="dark-yellow">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
     <title>Symphony Dashboard</title>
-    <link rel="stylesheet" href="app.css" />
+    <link rel="stylesheet" href="app.min.css" />
+    <link rel="stylesheet" href="_content/Flowbite/flowbite.min.css" />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
 <body>
     <Routes @rendermode="InteractiveServer" />
+    <script src="https://cdn.jsdelivr.net/npm/@@floating-ui/core@@1.6.13/dist/floating-ui.core.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@floating-ui/dom@@1.6.13/dist/floating-ui.dom.umd.min.js"></script>
+    <script src="_content/Flowbite/flowbite.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 </html>

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -77,6 +77,12 @@ public sealed class DashboardPageIntegrationTests
         var html = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("<html lang=\"en\" class=\"dark\" data-theme=\"dark-yellow\">", html, StringComparison.Ordinal);
+        Assert.Contains("<link rel=\"stylesheet\" href=\"app.min.css\" />", html, StringComparison.Ordinal);
+        Assert.Contains("<link rel=\"stylesheet\" href=\"_content/Flowbite/flowbite.min.css\" />", html, StringComparison.Ordinal);
+        Assert.Contains("https://cdn.jsdelivr.net/npm/@floating-ui/core@1.6.13/dist/floating-ui.core.umd.min.js", html, StringComparison.Ordinal);
+        Assert.Contains("https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.6.13/dist/floating-ui.dom.umd.min.js", html, StringComparison.Ordinal);
+        Assert.Contains("<script src=\"_content/Flowbite/flowbite.js\"></script>", html, StringComparison.Ordinal);
         Assert.Contains("Runtime Control Surface", html, StringComparison.Ordinal);
         Assert.Contains("Service Health", html, StringComparison.Ordinal);
         Assert.Contains("Workflow Config", html, StringComparison.Ordinal);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -77,12 +77,13 @@ public sealed class DashboardPageIntegrationTests
         var html = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("<html lang=\"en\" class=\"dark\" data-theme=\"dark-yellow\">", html, StringComparison.Ordinal);
-        Assert.Contains("<link rel=\"stylesheet\" href=\"app.min.css\" />", html, StringComparison.Ordinal);
-        Assert.Contains("<link rel=\"stylesheet\" href=\"_content/Flowbite/flowbite.min.css\" />", html, StringComparison.Ordinal);
+        Assert.Contains("class=\"dark\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-theme=\"dark-yellow\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"app.min.css\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"_content/Flowbite/flowbite.min.css\"", html, StringComparison.Ordinal);
         Assert.Contains("https://cdn.jsdelivr.net/npm/@floating-ui/core@1.6.13/dist/floating-ui.core.umd.min.js", html, StringComparison.Ordinal);
         Assert.Contains("https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.6.13/dist/floating-ui.dom.umd.min.js", html, StringComparison.Ordinal);
-        Assert.Contains("<script src=\"_content/Flowbite/flowbite.js\"></script>", html, StringComparison.Ordinal);
+        Assert.Contains("src=\"_content/Flowbite/flowbite.js\"", html, StringComparison.Ordinal);
         Assert.Contains("Runtime Control Surface", html, StringComparison.Ordinal);
         Assert.Contains("Service Health", html, StringComparison.Ordinal);
         Assert.Contains("Workflow Config", html, StringComparison.Ordinal);


### PR DESCRIPTION
#### Context

Implement story #76 from `dotnet/IMPLEMENTATIONPLAN_UI.github.md` by updating the Host document shell for the minified Tailwind output, Flowbite assets, and the default dark/yellow theme bootstrap.

#### TL;DR

*Switches the app shell onto `app.min.css`, wires in Flowbite + Floating UI assets, and defaults the document to the `dark-yellow` theme.*

#### Summary

- Updates `dotnet/src/Symphony.Host/Components/App.razor` to load `app.min.css`, Flowbite CSS, Floating UI scripts, and `flowbite.js`
- Sets `<html class="dark" data-theme="dark-yellow">` so the app boots in the required default theme
- Extends the Host integration test to assert the new root HTML asset references and theme bootstrap markup
- Refreshes `.github/workflows/make-all.yml` to current Node 24-compatible action releases as requested

#### Alternatives

- Keep the old `app.css` link and theme-neutral document shell, but that leaves the new Tailwind/Flowbite setup incomplete
- Split the workflow action upgrade into a separate PR, but carrying it here keeps the requested next-iteration update on the same branch

#### Test Plan

- [x] `dotnet format --verify-no-changes Symphony.sln && dotnet build -c Release Symphony.sln && dotnet test -c Release --no-build Symphony.sln`
- [x] Confirm the root HTML response contains `app.min.css`, Flowbite assets, Floating UI scripts, and `class="dark" data-theme="dark-yellow"`
- [x] Manual browser check: first load shows dark background and yellow accent without a light flash

Closes #76

Co-authored-by: Agent <agent@github.com>