### PR TITLE
feat: add session activity store

### DIFF
--- a/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
+++ b/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
@@ -26,6 +26,7 @@ public static class SymphonyHostCompositionExtensions
             .AddSymphonyInfrastructure()
             .AddConfiguredTrackerAdapter(builder.Configuration);
         builder.Services.AddSingleton<ServiceHealthSnapshotProvider>();
+        builder.Services.AddSingleton<ISessionActivityStore, SessionActivityStore>();
         builder.Services.AddSingleton<IDashboardStateService, DashboardStateService>();
 
         return builder;

--- a/dotnet/src/Symphony.Host/Dashboard/ISessionActivityStore.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/ISessionActivityStore.cs
@@ -1,0 +1,20 @@
+namespace Symphony.Host.Dashboard;
+
+public interface ISessionActivityStore
+{
+    void RecordSessionStart(string issueIdentifier, DateTimeOffset startedAt, string? issueUrl = null);
+
+    void RecordActivity(string issueIdentifier, SessionActivityEntry activity);
+
+    void RecordSessionEnd(string issueIdentifier, DateTimeOffset endedAt, string outcome, string? error = null);
+
+    IReadOnlyList<SessionRecord> GetAllSessions();
+
+    IReadOnlyList<SessionRecord> GetActiveSessions();
+
+    IReadOnlyList<SessionRecord> GetEndedSessions();
+
+    SessionRecord? GetSession(string issueIdentifier);
+
+    IReadOnlyList<SessionActivityEntry> GetActivities(string issueIdentifier);
+}

--- a/dotnet/src/Symphony.Host/Dashboard/SessionActivityModels.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/SessionActivityModels.cs
@@ -1,0 +1,26 @@
+namespace Symphony.Host.Dashboard;
+
+public enum SessionActivityKind
+{
+    LifecycleMilestone,
+    AgentMessage,
+    ProgressUpdate,
+    Warning,
+    Error,
+    Outcome
+}
+
+public sealed record SessionActivityEntry(
+    SessionActivityKind Kind,
+    DateTimeOffset Timestamp,
+    string Title,
+    string? Detail);
+
+public sealed record SessionRecord(
+    string IssueIdentifier,
+    string? IssueUrl,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? EndedAt,
+    string? FinalOutcome,
+    string? FinalError,
+    bool IsActive);

--- a/dotnet/src/Symphony.Host/Dashboard/SessionActivityStore.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/SessionActivityStore.cs
@@ -1,0 +1,154 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+
+namespace Symphony.Host.Dashboard;
+
+public sealed class SessionActivityStore(ILogger<SessionActivityStore> logger) : ISessionActivityStore
+{
+    private const int ActivityHistoryLimit = 500;
+
+    private readonly ConcurrentDictionary<string, SessionState> _sessions = new(StringComparer.OrdinalIgnoreCase);
+
+    public void RecordSessionStart(string issueIdentifier, DateTimeOffset startedAt, string? issueUrl = null)
+    {
+        ExecuteWrite(
+            issueIdentifier,
+            () =>
+            {
+                _sessions.AddOrUpdate(
+                    issueIdentifier,
+                    _ => new SessionState(
+                        new SessionRecord(issueIdentifier, issueUrl, startedAt, null, null, null, true),
+                        ImmutableList<SessionActivityEntry>.Empty),
+                    (_, existing) => existing with
+                    {
+                        Record = existing.Record with
+                        {
+                            IssueUrl = issueUrl ?? existing.Record.IssueUrl,
+                            StartedAt = startedAt,
+                            EndedAt = null,
+                            FinalOutcome = null,
+                            FinalError = null,
+                            IsActive = true
+                        }
+                    });
+            });
+    }
+
+    public void RecordActivity(string issueIdentifier, SessionActivityEntry activity)
+    {
+        ExecuteWrite(
+            issueIdentifier,
+            () =>
+            {
+                _sessions.AddOrUpdate(
+                    issueIdentifier,
+                    _ => new SessionState(
+                        new SessionRecord(issueIdentifier, null, activity.Timestamp, null, null, null, true),
+                        TrimActivities(ImmutableList<SessionActivityEntry>.Empty.Add(activity), activity.Timestamp)),
+                    (_, existing) => existing with
+                    {
+                        Activities = TrimActivities(existing.Activities.Add(activity), activity.Timestamp)
+                    });
+            });
+    }
+
+    public void RecordSessionEnd(string issueIdentifier, DateTimeOffset endedAt, string outcome, string? error = null)
+    {
+        ExecuteWrite(
+            issueIdentifier,
+            () =>
+            {
+                _sessions.AddOrUpdate(
+                    issueIdentifier,
+                    _ => new SessionState(
+                        new SessionRecord(issueIdentifier, null, endedAt, endedAt, outcome, error, false),
+                        ImmutableList<SessionActivityEntry>.Empty),
+                    (_, existing) => existing with
+                    {
+                        Record = existing.Record with
+                        {
+                            EndedAt = endedAt,
+                            FinalOutcome = outcome,
+                            FinalError = error,
+                            IsActive = false
+                        }
+                    });
+            });
+    }
+
+    public IReadOnlyList<SessionRecord> GetAllSessions()
+    {
+        return _sessions.Values
+            .Select(state => state.Record)
+            .OrderByDescending(record => record.StartedAt)
+            .ToArray();
+    }
+
+    public IReadOnlyList<SessionRecord> GetActiveSessions()
+    {
+        return _sessions.Values
+            .Select(state => state.Record)
+            .Where(record => record.IsActive)
+            .OrderByDescending(record => record.StartedAt)
+            .ToArray();
+    }
+
+    public IReadOnlyList<SessionRecord> GetEndedSessions()
+    {
+        return _sessions.Values
+            .Select(state => state.Record)
+            .Where(record => !record.IsActive)
+            .OrderByDescending(record => record.EndedAt ?? record.StartedAt)
+            .ToArray();
+    }
+
+    public SessionRecord? GetSession(string issueIdentifier)
+    {
+        return _sessions.TryGetValue(issueIdentifier, out var state)
+            ? state.Record
+            : null;
+    }
+
+    public IReadOnlyList<SessionActivityEntry> GetActivities(string issueIdentifier)
+    {
+        return _sessions.TryGetValue(issueIdentifier, out var state)
+            ? state.Activities
+            : [];
+    }
+
+    private void ExecuteWrite(string issueIdentifier, Action action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
+
+        try
+        {
+            action();
+        }
+        catch (Exception exception)
+        {
+            logger.LogDebug(exception, "Failed to update session activity state for {IssueIdentifier}.", issueIdentifier);
+        }
+    }
+
+    private static ImmutableList<SessionActivityEntry> TrimActivities(
+        ImmutableList<SessionActivityEntry> activities,
+        DateTimeOffset timestamp)
+    {
+        if (activities.Count <= ActivityHistoryLimit)
+        {
+            return activities;
+        }
+
+        return activities.GetRange(activities.Count - 499, 499)
+            .Add(
+                new SessionActivityEntry(
+                    SessionActivityKind.Warning,
+                    timestamp,
+                    "Activity history trimmed",
+                    "Older session activity entries were removed to keep the timeline bounded."));
+    }
+
+    private sealed record SessionState(SessionRecord Record, ImmutableList<SessionActivityEntry> Activities);
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionActivityStoreTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionActivityStoreTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SessionActivityStoreTests
+{
+    [Fact]
+    public void RecordSessionStart_and_end_updates_lifecycle_views()
+    {
+        var store = CreateStore();
+        var startedAt = new DateTimeOffset(2026, 3, 19, 14, 0, 0, TimeSpan.Zero);
+        var endedAt = startedAt.AddMinutes(7);
+
+        store.RecordSessionStart("ABC-1", startedAt, "https://github.com/AGiorgetti/my-symphony/issues/81");
+        store.RecordSessionEnd("ABC-1", endedAt, "Succeeded");
+
+        var session = Assert.Single(store.GetAllSessions());
+        Assert.Equal("ABC-1", session.IssueIdentifier);
+        Assert.Equal("https://github.com/AGiorgetti/my-symphony/issues/81", session.IssueUrl);
+        Assert.Equal(startedAt, session.StartedAt);
+        Assert.Equal(endedAt, session.EndedAt);
+        Assert.Equal("Succeeded", session.FinalOutcome);
+        Assert.False(session.IsActive);
+        Assert.Empty(store.GetActiveSessions());
+        Assert.Single(store.GetEndedSessions());
+    }
+
+    [Fact]
+    public void RecordActivity_persists_entries_for_a_session()
+    {
+        var store = CreateStore();
+        var timestamp = new DateTimeOffset(2026, 3, 19, 14, 5, 0, TimeSpan.Zero);
+
+        store.RecordSessionStart("ABC-2", timestamp.AddMinutes(-1));
+        store.RecordActivity("ABC-2", new SessionActivityEntry(SessionActivityKind.ProgressUpdate, timestamp, "Turn 2", "Applied changes"));
+
+        var activity = Assert.Single(store.GetActivities("ABC-2"));
+        Assert.Equal(SessionActivityKind.ProgressUpdate, activity.Kind);
+        Assert.Equal("Turn 2", activity.Title);
+        Assert.Equal("Applied changes", activity.Detail);
+    }
+
+    [Fact]
+    public void RecordActivity_trims_history_to_500_entries_and_appends_warning()
+    {
+        var store = CreateStore();
+        var baseTimestamp = new DateTimeOffset(2026, 3, 19, 15, 0, 0, TimeSpan.Zero);
+
+        store.RecordSessionStart("ABC-3", baseTimestamp);
+
+        for (var index = 0; index < 501; index++)
+        {
+            store.RecordActivity(
+                "ABC-3",
+                new SessionActivityEntry(
+                    SessionActivityKind.AgentMessage,
+                    baseTimestamp.AddSeconds(index),
+                    $"Message {index}",
+                    null));
+        }
+
+        var activities = store.GetActivities("ABC-3");
+
+        Assert.Equal(500, activities.Count);
+        Assert.DoesNotContain(activities, activity => activity.Title == "Message 0");
+        Assert.DoesNotContain(activities, activity => activity.Title == "Message 1");
+        Assert.Equal("Message 500", activities[^2].Title);
+        Assert.Equal(SessionActivityKind.Warning, activities[^1].Kind);
+        Assert.Equal("Activity history trimmed", activities[^1].Title);
+    }
+
+    [Fact]
+    public async Task Concurrent_reads_and_writes_do_not_throw_and_keep_store_consistent()
+    {
+        var store = CreateStore();
+        var startedAt = new DateTimeOffset(2026, 3, 19, 16, 0, 0, TimeSpan.Zero);
+
+        store.RecordSessionStart("ABC-4", startedAt);
+
+        var writerTasks = Enumerable.Range(0, 24)
+            .Select(
+                index => Task.Run(
+                    () => store.RecordActivity(
+                        "ABC-4",
+                        new SessionActivityEntry(
+                            SessionActivityKind.AgentMessage,
+                            startedAt.AddSeconds(index),
+                            $"Message {index}",
+                            "parallel write"))))
+            .ToArray();
+        var readerTasks = Enumerable.Range(0, 24)
+            .Select(
+                readerIndex => Task.Run(
+                    () =>
+                    {
+                        _ = readerIndex;
+                        _ = store.GetAllSessions();
+                        _ = store.GetActiveSessions();
+                        _ = store.GetEndedSessions();
+                        _ = store.GetSession("ABC-4");
+                        _ = store.GetActivities("ABC-4");
+                    }))
+            .ToArray();
+
+        await Task.WhenAll(writerTasks.Concat(readerTasks));
+
+        var session = Assert.Single(store.GetActiveSessions());
+        Assert.Equal("ABC-4", session.IssueIdentifier);
+        Assert.Equal(24, store.GetActivities("ABC-4").Count);
+    }
+
+    private static SessionActivityStore CreateStore()
+    {
+        return new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+    }
+}


### PR DESCRIPTION
Closes #81

#### Context
The dashboard needs a durable in-memory session activity store before snapshot diffing and the sessions pages can surface session lifecycle history.

#### TL;DR
Add the dashboard session activity store, register it in host DI, and cover lifecycle, trimming, and concurrent access with tests.

#### Summary
- Add session activity models and the `ISessionActivityStore` contract under `Symphony.Host.Dashboard`.
- Implement a singleton in-memory `SessionActivityStore` with bounded immutable activity history.
- Register the store in host DI and add tests for lifecycle updates, trimming, and concurrent readers/writers.

#### Alternatives
- Delay the store until snapshot diffing lands; rejected because EU4-S2 depends directly on this abstraction.
- Use mutable lists with coarse locking; rejected because immutable snapshots simplify concurrent reads.

#### Test Plan
- [x] `dotnet format --verify-no-changes Symphony.sln`
- [x] `dotnet build -c Release Symphony.sln`
- [x] `dotnet test -c Release Symphony.sln`
- [x] `dotnet test -c Release tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --filter FullyQualifiedName~SessionActivityStoreTests`

Co-authored-by: Agent <agent@github.com>