### PR TITLE
feat: diff dashboard session activity

### DIFF
--- a/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
@@ -7,9 +7,12 @@ namespace Symphony.Host.Dashboard;
 public sealed class DashboardStateService(
     IOrchestratorRuntimeService orchestratorRuntimeService,
     AttemptHistoryTracker attemptHistoryTracker,
-    ServiceHealthSnapshotProvider serviceHealthSnapshotProvider) : IDashboardStateService
+    ServiceHealthSnapshotProvider serviceHealthSnapshotProvider,
+    ISessionActivityStore sessionActivityStore) : IDashboardStateService
 {
     private const string InMemoryMode = "Single-process in-memory";
+    private readonly Lock _snapshotLock = new();
+    private DashboardSnapshot? _lastSnapshot;
 
     public async Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
     {
@@ -48,7 +51,7 @@ public sealed class DashboardStateService(
                     attempt.SessionId))
             .ToArray();
 
-        return new DashboardSnapshot(
+        var snapshot = new DashboardSnapshot(
             runtimeSnapshot.GeneratedAt,
             healthSnapshot.Status,
             InMemoryMode,
@@ -68,5 +71,153 @@ public sealed class DashboardStateService(
             recentAttempts,
             healthSnapshot.PollLastError,
             healthSnapshot.WorkflowLastError);
+
+        lock (_snapshotLock)
+        {
+            DiffSnapshot(_lastSnapshot, snapshot);
+            _lastSnapshot = snapshot;
+        }
+
+        return snapshot;
+    }
+
+    private void DiffSnapshot(DashboardSnapshot? previousSnapshot, DashboardSnapshot currentSnapshot)
+    {
+        var previousRunning = (previousSnapshot?.ActiveSessions ?? [])
+            .ToDictionary(session => session.IssueIdentifier, StringComparer.OrdinalIgnoreCase);
+        var currentRunning = currentSnapshot.ActiveSessions
+            .ToDictionary(session => session.IssueIdentifier, StringComparer.OrdinalIgnoreCase);
+        var previousRetry = new HashSet<DashboardRetrySnapshot>(previousSnapshot?.RetryQueue ?? []);
+        var previousAttempts = new HashSet<DashboardRecentAttemptSnapshot>(previousSnapshot?.RecentAttempts ?? []);
+        var latestAttemptsByIssue = currentSnapshot.RecentAttempts
+            .GroupBy(attempt => attempt.IssueIdentifier, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderByDescending(attempt => attempt.CompletedAt).First(),
+                StringComparer.OrdinalIgnoreCase);
+
+        foreach (var currentSession in currentSnapshot.ActiveSessions)
+        {
+            if (!previousRunning.TryGetValue(currentSession.IssueIdentifier, out var previousSession))
+            {
+                sessionActivityStore.RecordSessionStart(currentSession.IssueIdentifier, currentSession.StartedAt);
+                sessionActivityStore.RecordActivity(
+                    currentSession.IssueIdentifier,
+                    new SessionActivityEntry(
+                        SessionActivityKind.LifecycleMilestone,
+                        currentSession.LastEventAt ?? currentSession.StartedAt,
+                        "Session started",
+                        currentSession.State));
+                continue;
+            }
+
+            if (!string.Equals(previousSession.State, currentSession.State, StringComparison.Ordinal))
+            {
+                sessionActivityStore.RecordActivity(
+                    currentSession.IssueIdentifier,
+                    new SessionActivityEntry(
+                        SessionActivityKind.LifecycleMilestone,
+                        currentSession.LastEventAt ?? currentSnapshot.GeneratedAt,
+                        currentSession.State,
+                        null));
+            }
+
+            if (currentSession.TurnCount > previousSession.TurnCount)
+            {
+                for (var turn = previousSession.TurnCount + 1; turn <= currentSession.TurnCount; turn++)
+                {
+                    sessionActivityStore.RecordActivity(
+                        currentSession.IssueIdentifier,
+                        new SessionActivityEntry(
+                            SessionActivityKind.ProgressUpdate,
+                            currentSession.LastEventAt ?? currentSnapshot.GeneratedAt,
+                            $"Turn {turn}",
+                            currentSession.LastMessage));
+                }
+            }
+
+            if (!string.Equals(previousSession.LastEvent, currentSession.LastEvent, StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(currentSession.LastEvent))
+            {
+                sessionActivityStore.RecordActivity(
+                    currentSession.IssueIdentifier,
+                    new SessionActivityEntry(
+                        SessionActivityKind.AgentMessage,
+                        currentSession.LastEventAt ?? currentSnapshot.GeneratedAt,
+                        currentSession.LastEvent,
+                        currentSession.LastMessage));
+            }
+        }
+
+        foreach (var previousSession in previousRunning.Values)
+        {
+            if (currentRunning.ContainsKey(previousSession.IssueIdentifier))
+            {
+                continue;
+            }
+
+            if (!latestAttemptsByIssue.TryGetValue(previousSession.IssueIdentifier, out var latestAttempt))
+            {
+                latestAttempt = currentSnapshot.RecentAttempts
+                    .Where(attempt => string.Equals(attempt.IssueIdentifier, previousSession.IssueIdentifier, StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(attempt => attempt.CompletedAt)
+                    .FirstOrDefault();
+            }
+
+            sessionActivityStore.RecordSessionEnd(
+                previousSession.IssueIdentifier,
+                latestAttempt?.CompletedAt ?? currentSnapshot.GeneratedAt,
+                latestAttempt?.Outcome ?? "Completed",
+                latestAttempt?.Error);
+        }
+
+        foreach (var retry in currentSnapshot.RetryQueue)
+        {
+            if (previousRetry.Contains(retry))
+            {
+                continue;
+            }
+
+            sessionActivityStore.RecordActivity(
+                retry.IssueIdentifier,
+                new SessionActivityEntry(
+                    SessionActivityKind.Warning,
+                    retry.DueAt,
+                    "Queued for retry",
+                    retry.Error));
+        }
+
+        foreach (var attempt in currentSnapshot.RecentAttempts)
+        {
+            if (previousAttempts.Contains(attempt))
+            {
+                continue;
+            }
+
+            var existingSession = sessionActivityStore.GetSession(attempt.IssueIdentifier);
+            if (existingSession is null)
+            {
+                sessionActivityStore.RecordSessionStart(
+                    attempt.IssueIdentifier,
+                    attempt.CompletedAt.AddSeconds(-attempt.DurationSeconds));
+            }
+
+            sessionActivityStore.RecordActivity(
+                attempt.IssueIdentifier,
+                new SessionActivityEntry(
+                    SessionActivityKind.Outcome,
+                    attempt.CompletedAt,
+                    attempt.Outcome,
+                    attempt.Error));
+
+            if (existingSession is null || existingSession.IsActive)
+            {
+                sessionActivityStore.RecordSessionEnd(
+                    attempt.IssueIdentifier,
+                    attempt.CompletedAt,
+                    attempt.Outcome,
+                    attempt.Error);
+            }
+        }
     }
 }

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
@@ -3,6 +3,7 @@ using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Dashboard;
 using Symphony.Host.Health;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -68,7 +69,8 @@ public sealed class DashboardStateServiceTests
                         null,
                         null,
                         30_000)),
-                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 0, 5, TimeSpan.Zero))));
+                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 0, 5, TimeSpan.Zero))),
+            new SessionActivityStore(NullLogger<SessionActivityStore>.Instance));
 
         var snapshot = await service.GetSnapshotAsync();
 
@@ -110,7 +112,8 @@ public sealed class DashboardStateServiceTests
                         "workflow_parse_error",
                         "Tracker config is invalid.",
                         30_000)),
-                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 11, 5, TimeSpan.Zero))));
+                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 11, 5, TimeSpan.Zero))),
+            new SessionActivityStore(NullLogger<SessionActivityStore>.Instance));
 
         var snapshot = await service.GetSnapshotAsync();
 
@@ -119,6 +122,160 @@ public sealed class DashboardStateServiceTests
         Assert.Equal("Tracker request failed", snapshot.LastError);
         Assert.Equal("ReloadFailedUsingLastKnownGood", snapshot.WorkflowLoadStatus);
         Assert.Equal("Tracker config is invalid.", snapshot.WorkflowLastError);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_records_session_activity_transitions_between_snapshots()
+    {
+        var runtimeService = new StubRuntimeService
+        {
+            StateSnapshot = new OrchestratorStateSnapshot(
+                new DateTimeOffset(2026, 3, 16, 16, 0, 0, TimeSpan.Zero),
+                [
+                    new RunningIssueSnapshot(
+                        "1",
+                        "ABC-1",
+                        "In Progress",
+                        "thread-1-turn-1",
+                        1,
+                        "session_started",
+                        "Started session",
+                        new DateTimeOffset(2026, 3, 16, 15, 58, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 3, 16, 15, 58, 10, TimeSpan.Zero),
+                        10,
+                        4,
+                        14),
+                    new RunningIssueSnapshot(
+                        "3",
+                        "ABC-3",
+                        "Streaming",
+                        "thread-3-turn-1",
+                        1,
+                        "message_delta",
+                        "Working",
+                        new DateTimeOffset(2026, 3, 16, 15, 57, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 3, 16, 15, 59, 0, TimeSpan.Zero),
+                        20,
+                        10,
+                        30)
+                ],
+                Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                new CodexTotalsSnapshot(30, 14, 44, 120d),
+                RateLimits: null)
+        };
+        var attemptHistoryTracker = new AttemptHistoryTracker();
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordCompleted(new DateTimeOffset(2026, 3, 16, 16, 0, 0, TimeSpan.Zero));
+        var sessionActivityStore = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        var service = new DashboardStateService(
+            runtimeService,
+            attemptHistoryTracker,
+            new ServiceHealthSnapshotProvider(
+                pollingStatusTracker,
+                new StaticWorkflowLoadStatusReader(
+                    new WorkflowLoadStatusSnapshot(
+                        "Loaded",
+                        "C:\\repo\\WORKFLOW.md",
+                        new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                        null,
+                        null,
+                        null,
+                        30_000)),
+                new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 16, 0, 5, TimeSpan.Zero))),
+            sessionActivityStore);
+
+        await service.GetSnapshotAsync();
+
+        runtimeService.StateSnapshot = new OrchestratorStateSnapshot(
+            new DateTimeOffset(2026, 3, 16, 16, 5, 0, TimeSpan.Zero),
+            [
+                new RunningIssueSnapshot(
+                    "1",
+                    "ABC-1",
+                    "Finishing",
+                    "thread-1-turn-2",
+                    2,
+                    "turn_completed",
+                    "Applied changes",
+                    new DateTimeOffset(2026, 3, 16, 15, 58, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 16, 16, 4, 30, TimeSpan.Zero),
+                    40,
+                    15,
+                    55),
+                new RunningIssueSnapshot(
+                    "2",
+                    "ABC-2",
+                    "In Progress",
+                    "thread-2-turn-1",
+                    1,
+                    "session_started",
+                    "Bootstrapped branch",
+                    new DateTimeOffset(2026, 3, 16, 16, 4, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 16, 16, 4, 10, TimeSpan.Zero),
+                    18,
+                    7,
+                    25)
+            ],
+            [
+                new Symphony.Abstractions.Orchestration.RetryDispatchSnapshot(
+                    "1",
+                    "ABC-1",
+                    2,
+                    new DateTimeOffset(2026, 3, 16, 16, 6, 0, TimeSpan.Zero),
+                    "retry later")
+            ],
+            new CodexTotalsSnapshot(58, 22, 80, 180d),
+            RateLimits: null);
+        attemptHistoryTracker.Record(
+            "3",
+            "ABC-3",
+            2,
+            "Succeeded",
+            new DateTimeOffset(2026, 3, 16, 15, 57, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 16, 16, 4, 0, TimeSpan.Zero),
+            null,
+            "thread-3-turn-1");
+        attemptHistoryTracker.Record(
+            "4",
+            "ABC-4",
+            1,
+            "Failed",
+            new DateTimeOffset(2026, 3, 16, 16, 1, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 16, 16, 4, 30, TimeSpan.Zero),
+            "Tracker request failed",
+            "thread-4-turn-1");
+
+        await service.GetSnapshotAsync();
+
+        var abc1Activities = sessionActivityStore.GetActivities("ABC-1");
+        Assert.Contains(abc1Activities, activity => activity.Kind == SessionActivityKind.LifecycleMilestone && activity.Title == "Finishing");
+        Assert.Contains(abc1Activities, activity => activity.Kind == SessionActivityKind.ProgressUpdate && activity.Title == "Turn 2");
+        Assert.Contains(abc1Activities, activity => activity.Kind == SessionActivityKind.AgentMessage && activity.Title == "turn_completed" && activity.Detail == "Applied changes");
+        Assert.Contains(abc1Activities, activity => activity.Kind == SessionActivityKind.Warning && activity.Title == "Queued for retry");
+
+        var abc2Session = sessionActivityStore.GetSession("ABC-2");
+        Assert.NotNull(abc2Session);
+        Assert.True(abc2Session.IsActive);
+        Assert.Contains(
+            sessionActivityStore.GetActivities("ABC-2"),
+            activity => activity.Kind == SessionActivityKind.LifecycleMilestone && activity.Title == "Session started");
+
+        var abc3Session = sessionActivityStore.GetSession("ABC-3");
+        Assert.NotNull(abc3Session);
+        Assert.False(abc3Session.IsActive);
+        Assert.Equal("Succeeded", abc3Session.FinalOutcome);
+        Assert.Contains(
+            sessionActivityStore.GetActivities("ABC-3"),
+            activity => activity.Kind == SessionActivityKind.Outcome && activity.Title == "Succeeded");
+
+        var abc4Session = sessionActivityStore.GetSession("ABC-4");
+        Assert.NotNull(abc4Session);
+        Assert.False(abc4Session.IsActive);
+        Assert.Equal("Failed", abc4Session.FinalOutcome);
+        Assert.Equal("Tracker request failed", abc4Session.FinalError);
+        Assert.Contains(
+            sessionActivityStore.GetActivities("ABC-4"),
+            activity => activity.Kind == SessionActivityKind.Outcome && activity.Title == "Failed" && activity.Detail == "Tracker request failed");
     }
 
     private sealed class StubRuntimeService : IOrchestratorRuntimeService


### PR DESCRIPTION
Closes #82

#### Context
The session activity store now exists, but dashboard snapshots still do not emit lifecycle, retry, or outcome events into it for the upcoming sessions views.

#### TL;DR
Diff dashboard snapshots against the previous snapshot and record session activity transitions into the store.

#### Summary
- Track the previous dashboard snapshot in `DashboardStateService` behind a lock.
- Emit session start, status, turn, agent message, retry, and outcome transitions into `ISessionActivityStore`.
- Extend dashboard service tests to cover the transition matrix across successive snapshots.

#### Alternatives
- Recompute activity history from the store alone; rejected because the store does not know what changed between snapshots.
- Delay diffing until the sessions pages land; rejected because those pages depend on this activity feed.

#### Test Plan
- [x] `dotnet format --verify-no-changes Symphony.sln`
- [x] `dotnet build -c Release Symphony.sln`
- [x] `dotnet test -c Release --no-build Symphony.sln`
- [x] `dotnet test -c Release tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --filter FullyQualifiedName~DashboardStateServiceTests`

Co-authored-by: Agent <agent@github.com>