### PR TITLE
feat: add session status badge

### DIFF
--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionStatusBadge.razor
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionStatusBadge.razor
@@ -1,0 +1,30 @@
+@using Symphony.Domain.Runs
+
+<Badge Color="@GetColor(Status)">
+    @Status
+</Badge>
+
+@code {
+    [Parameter]
+    [EditorRequired]
+    public RunAttemptStatus Status { get; set; }
+
+    private static Badge.BadgeColor GetColor(RunAttemptStatus status)
+    {
+        return status switch
+        {
+            RunAttemptStatus.Succeeded => Badge.BadgeColor.Success,
+            RunAttemptStatus.PreparingWorkspace => Badge.BadgeColor.Info,
+            RunAttemptStatus.BuildingPrompt => Badge.BadgeColor.Info,
+            RunAttemptStatus.LaunchingAgentProcess => Badge.BadgeColor.Info,
+            RunAttemptStatus.InitializingSession => Badge.BadgeColor.Info,
+            RunAttemptStatus.StreamingTurn => Badge.BadgeColor.Info,
+            RunAttemptStatus.Finishing => Badge.BadgeColor.Info,
+            RunAttemptStatus.Failed => Badge.BadgeColor.Failure,
+            RunAttemptStatus.TimedOut => Badge.BadgeColor.Failure,
+            RunAttemptStatus.Stalled => Badge.BadgeColor.Failure,
+            RunAttemptStatus.CanceledByReconciliation => Badge.BadgeColor.Gray,
+            _ => Badge.BadgeColor.Primary
+        };
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionStatusBadgeTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionStatusBadgeTests.cs
@@ -1,0 +1,40 @@
+using Bunit;
+using Flowbite.Components;
+using Flowbite.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Domain.Runs;
+using Symphony.Host.Components.Sessions;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SessionStatusBadgeTests : BunitContext
+{
+    public SessionStatusBadgeTests()
+    {
+        Services.AddFlowbite();
+    }
+
+    [Theory]
+    [InlineData(RunAttemptStatus.Succeeded, Badge.BadgeColor.Success)]
+    [InlineData(RunAttemptStatus.PreparingWorkspace, Badge.BadgeColor.Info)]
+    [InlineData(RunAttemptStatus.BuildingPrompt, Badge.BadgeColor.Info)]
+    [InlineData(RunAttemptStatus.LaunchingAgentProcess, Badge.BadgeColor.Info)]
+    [InlineData(RunAttemptStatus.InitializingSession, Badge.BadgeColor.Info)]
+    [InlineData(RunAttemptStatus.StreamingTurn, Badge.BadgeColor.Info)]
+    [InlineData(RunAttemptStatus.Finishing, Badge.BadgeColor.Info)]
+    [InlineData(RunAttemptStatus.Failed, Badge.BadgeColor.Failure)]
+    [InlineData(RunAttemptStatus.TimedOut, Badge.BadgeColor.Failure)]
+    [InlineData(RunAttemptStatus.Stalled, Badge.BadgeColor.Failure)]
+    [InlineData(RunAttemptStatus.CanceledByReconciliation, Badge.BadgeColor.Gray)]
+    public void SessionStatusBadge_maps_status_to_expected_badge_color(
+        RunAttemptStatus status,
+        Badge.BadgeColor expectedColor)
+    {
+        var cut = Render<SessionStatusBadge>(parameters => parameters.Add(component => component.Status, status));
+
+        var badge = cut.FindComponent<Badge>();
+
+        Assert.Equal(expectedColor, badge.Instance.Color);
+        Assert.Contains(status.ToString(), cut.Markup, StringComparison.Ordinal);
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="*" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
Closes #84

#### Context
The upcoming sessions pages need a single shared badge component so status colors stay consistent across the dashboard and session detail views.

#### TL;DR
Add a shared Flowbite session status badge and cover every `RunAttemptStatus` mapping with bUnit tests.

#### Summary
- Add `SessionStatusBadge.razor` under `Components/Sessions` as a typed Flowbite `Badge` wrapper.
- Map each `RunAttemptStatus` value to the required `Badge.BadgeColor`.
- Add `bunit` to the host test project and cover every status mapping with a component test.

#### Alternatives
- Duplicate badge markup in each page; rejected because the status-to-color mapping would drift.
- Assert CSS classes only; rejected because the story specifically calls for verifying the badge color mapping itself.

#### Test Plan
- [x] `dotnet format --verify-no-changes Symphony.sln`
- [x] `dotnet build -c Release Symphony.sln`
- [x] `dotnet test -c Release --no-build Symphony.sln`
- [x] `dotnet test -c Release tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --filter FullyQualifiedName~SessionStatusBadgeTests`

Co-authored-by: Agent <agent@github.com>