### PR TITLE
feat(theme): add persisted host theme service

### DIFF
--- a/dotnet/src/Symphony.Host/Components/App.razor
+++ b/dotnet/src/Symphony.Host/Components/App.razor
@@ -5,11 +5,48 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
     <title>Symphony Dashboard</title>
+    <script>
+        (() => {
+            const storageKey = "symphony-theme";
+            const validThemes = new Set(["dark-yellow", "dark-blue", "light-blue"]);
+            const darkThemes = new Set(["dark-yellow", "dark-blue"]);
+
+            window.symphonyTheme = {
+                getStoredTheme() {
+                    try {
+                        const storedTheme = window.localStorage.getItem(storageKey);
+                        return validThemes.has(storedTheme) ? storedTheme : null;
+                    } catch {
+                        return null;
+                    }
+                },
+                setDarkClass(isDark) {
+                    document.documentElement.classList.toggle("dark", !!isDark);
+                },
+                setThemeAttribute(themeKey) {
+                    document.documentElement.setAttribute("data-theme", themeKey);
+                },
+                storeTheme(themeKey) {
+                    try {
+                        window.localStorage.setItem(storageKey, themeKey);
+                    } catch {
+                    }
+                }
+            };
+
+            const storedTheme = window.symphonyTheme.getStoredTheme();
+            if (storedTheme !== null) {
+                window.symphonyTheme.setDarkClass(darkThemes.has(storedTheme));
+                window.symphonyTheme.setThemeAttribute(storedTheme);
+            }
+        })();
+    </script>
     <link rel="stylesheet" href="app.min.css" />
     <link rel="stylesheet" href="_content/Flowbite/flowbite.min.css" />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
 <body>
+    <ThemeInitializer @rendermode="InteractiveServer" />
     <Routes @rendermode="InteractiveServer" />
     <script src="https://cdn.jsdelivr.net/npm/@@floating-ui/core@@1.6.13/dist/floating-ui.core.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@@floating-ui/dom@@1.6.13/dist/floating-ui.dom.umd.min.js"></script>

--- a/dotnet/src/Symphony.Host/Components/Theme/ThemeInitializer.razor
+++ b/dotnet/src/Symphony.Host/Components/Theme/ThemeInitializer.razor
@@ -1,0 +1,13 @@
+@inject Symphony.Host.Theming.ThemeService ThemeService
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await ThemeService.InitializeAsync();
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/_Imports.razor
+++ b/dotnet/src/Symphony.Host/Components/_Imports.razor
@@ -10,6 +10,7 @@
 @using Flowbite.Services
 @using Symphony.Host.Dashboard
 @using Symphony.Host.Components.Layout
+@using Symphony.Host.Components.Theme
 @using static Flowbite.Components.Button
 @using static Flowbite.Components.Dropdown
 @using static Flowbite.Components.Sidebar

--- a/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
+++ b/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
@@ -4,6 +4,7 @@ using Symphony.Host.Api;
 using Symphony.Host.Components;
 using Symphony.Host.Dashboard;
 using Symphony.Host.Health;
+using Symphony.Host.Theming;
 using Symphony.Infrastructure.DependencyInjection;
 
 namespace Symphony.Host.Composition;
@@ -28,6 +29,8 @@ public static class SymphonyHostCompositionExtensions
         builder.Services.AddSingleton<ServiceHealthSnapshotProvider>();
         builder.Services.AddSingleton<ISessionActivityStore, SessionActivityStore>();
         builder.Services.AddSingleton<IDashboardStateService, DashboardStateService>();
+        builder.Services.AddScoped<IThemeService, ThemeService>();
+        builder.Services.AddScoped<ThemeService>();
 
         return builder;
     }

--- a/dotnet/src/Symphony.Host/Theming/IThemeService.cs
+++ b/dotnet/src/Symphony.Host/Theming/IThemeService.cs
@@ -1,0 +1,12 @@
+namespace Symphony.Host.Theming;
+
+public interface IThemeService
+{
+    string CurrentTheme { get; }
+
+    IReadOnlyList<ThemeDescriptor> AvailableThemes { get; }
+
+    event Action? OnThemeChanged;
+
+    Task SetThemeAsync(string key);
+}

--- a/dotnet/src/Symphony.Host/Theming/ThemeDescriptor.cs
+++ b/dotnet/src/Symphony.Host/Theming/ThemeDescriptor.cs
@@ -1,0 +1,6 @@
+namespace Symphony.Host.Theming;
+
+public sealed record ThemeDescriptor(
+    string Key,
+    string DisplayName,
+    bool IsDark);

--- a/dotnet/src/Symphony.Host/Theming/ThemeService.cs
+++ b/dotnet/src/Symphony.Host/Theming/ThemeService.cs
@@ -1,0 +1,67 @@
+using Microsoft.JSInterop;
+
+namespace Symphony.Host.Theming;
+
+public sealed class ThemeService(IJSRuntime jsRuntime) : IThemeService
+{
+    private static readonly ThemeDescriptor[] BuiltInThemes =
+    [
+        new("dark-yellow", "Dark Yellow", true),
+        new("dark-blue", "Dark Blue", true),
+        new("light-blue", "Light Blue", false)
+    ];
+
+    private readonly Dictionary<string, ThemeDescriptor> _themesByKey = BuiltInThemes
+        .ToDictionary(theme => theme.Key, StringComparer.OrdinalIgnoreCase);
+
+    private bool _initialized;
+
+    public string CurrentTheme { get; private set; } = "dark-yellow";
+
+    public IReadOnlyList<ThemeDescriptor> AvailableThemes => BuiltInThemes;
+
+    public event Action? OnThemeChanged;
+
+    public async Task SetThemeAsync(string key)
+    {
+        if (!_themesByKey.TryGetValue(key, out var theme))
+        {
+            return;
+        }
+
+        await ApplyThemeAsync(theme, persist: true).ConfigureAwait(false);
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        var storedTheme = await jsRuntime.InvokeAsync<string?>("symphonyTheme.getStoredTheme").ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(storedTheme) || !_themesByKey.TryGetValue(storedTheme, out var theme))
+        {
+            return;
+        }
+
+        await ApplyThemeAsync(theme, persist: false).ConfigureAwait(false);
+    }
+
+    private async Task ApplyThemeAsync(ThemeDescriptor theme, bool persist)
+    {
+        CurrentTheme = theme.Key;
+
+        await jsRuntime.InvokeVoidAsync("symphonyTheme.setDarkClass", theme.IsDark).ConfigureAwait(false);
+        await jsRuntime.InvokeVoidAsync("symphonyTheme.setThemeAttribute", theme.Key).ConfigureAwait(false);
+
+        if (persist)
+        {
+            await jsRuntime.InvokeVoidAsync("symphonyTheme.storeTheme", theme.Key).ConfigureAwait(false);
+        }
+
+        OnThemeChanged?.Invoke();
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -12,6 +12,7 @@ using Symphony.Application.Runtime;
 using Symphony.Host.Api;
 using Symphony.Host.Components;
 using Symphony.Host.Dashboard;
+using Symphony.Host.Theming;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -143,6 +144,8 @@ public sealed class DashboardPageIntegrationTests
         builder.Services.AddFlowbite();
         builder.Services.AddSingleton<IOrchestratorRuntimeService>(runtimeService);
         builder.Services.AddSingleton<IDashboardStateService>(dashboardStateService);
+        builder.Services.AddScoped<IThemeService, ThemeService>();
+        builder.Services.AddScoped<ThemeService>();
         builder.Services.AddSingleton<IWorkflowOptionsProvider>(
             new StaticWorkflowOptionsProvider(
                 new WorkflowServiceOptions(

--- a/dotnet/tests/Symphony.Host.IntegrationTests/ThemeServiceTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/ThemeServiceTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using Microsoft.JSInterop;
+using Symphony.Host.Theming;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class ThemeServiceTests
+{
+    [Theory]
+    [InlineData("dark-yellow", true)]
+    [InlineData("dark-blue", true)]
+    [InlineData("light-blue", false)]
+    public async Task SetThemeAsync_applies_each_built_in_theme_and_raises_change_event(string themeKey, bool isDark)
+    {
+        var jsRuntime = new RecordingJsRuntime();
+        var service = new ThemeService(jsRuntime);
+        var changeNotifications = 0;
+        service.OnThemeChanged += () => changeNotifications++;
+
+        await service.SetThemeAsync(themeKey);
+
+        Assert.Equal(themeKey, service.CurrentTheme);
+        Assert.Equal(1, changeNotifications);
+        Assert.Equal(3, jsRuntime.Invocations.Count);
+        Assert.Equal("symphonyTheme.setDarkClass", jsRuntime.Invocations[0].Identifier);
+        Assert.Equal(isDark, Assert.Single(jsRuntime.Invocations[0].Arguments));
+        Assert.Equal("symphonyTheme.setThemeAttribute", jsRuntime.Invocations[1].Identifier);
+        Assert.Equal(themeKey, Assert.Single(jsRuntime.Invocations[1].Arguments));
+        Assert.Equal("symphonyTheme.storeTheme", jsRuntime.Invocations[2].Identifier);
+        Assert.Equal(themeKey, Assert.Single(jsRuntime.Invocations[2].Arguments));
+    }
+
+    [Fact]
+    public async Task SetThemeAsync_invalid_key_is_ignored()
+    {
+        var jsRuntime = new RecordingJsRuntime();
+        var service = new ThemeService(jsRuntime);
+        var changeNotifications = 0;
+        service.OnThemeChanged += () => changeNotifications++;
+
+        await service.SetThemeAsync("unknown-theme");
+
+        Assert.Equal("dark-yellow", service.CurrentTheme);
+        Assert.Equal(0, changeNotifications);
+        Assert.Empty(jsRuntime.Invocations);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_loads_valid_stored_theme_without_persisting_it_again()
+    {
+        var jsRuntime = new RecordingJsRuntime
+        {
+            Results =
+            {
+                ["symphonyTheme.getStoredTheme"] = "light-blue"
+            }
+        };
+        var service = new ThemeService(jsRuntime);
+
+        await service.InitializeAsync();
+
+        Assert.Equal("light-blue", service.CurrentTheme);
+        Assert.Collection(
+            jsRuntime.Invocations,
+            invocation => Assert.Equal("symphonyTheme.getStoredTheme", invocation.Identifier),
+            invocation => Assert.Equal("symphonyTheme.setDarkClass", invocation.Identifier),
+            invocation => Assert.Equal("symphonyTheme.setThemeAttribute", invocation.Identifier));
+    }
+
+    private sealed class RecordingJsRuntime : IJSRuntime
+    {
+        public List<JsInvocation> Invocations { get; } = [];
+
+        public ConcurrentDictionary<string, object?> Results { get; } = new(StringComparer.Ordinal);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            Invocations.Add(new JsInvocation(identifier, args ?? []));
+
+            if (Results.TryGetValue(identifier, out var value))
+            {
+                return ValueTask.FromResult((TValue?)value)!;
+            }
+
+            return ValueTask.FromResult(default(TValue)!);
+        }
+    }
+
+    private sealed record JsInvocation(string Identifier, IReadOnlyList<object?> Arguments);
+}


### PR DESCRIPTION
#### Context

EU3-S1 adds the host-level theme service needed before the dashboard can expose theme controls and persist a selected theme across circuits.

#### TL;DR

Add a scoped theme service that applies and persists the dashboard theme before interactive render.

#### Summary

- add `ThemeDescriptor`, `IThemeService`, and `ThemeService` with the three built-in themes
- bootstrap the stored theme in `App.razor` and add `ThemeInitializer` for interactive sync
- register the theme services in the host and cover the service and dashboard host wiring with tests

#### Alternatives

- keep theme state inline in `App.razor`, which would make later UI controls and circuit sync harder to test
- defer persistence until theme controls land, which would leave the shell without a reusable theme abstraction

#### Test Plan

- [x] `dotnet format --verify-no-changes 'dotnet/Symphony.sln'`
- [x] `dotnet test -c Release 'dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj' --filter 'FullyQualifiedName~ThemeServiceTests'`
- [x] `dotnet test -c Release 'dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj' --filter 'FullyQualifiedName~DashboardPageIntegrationTests'`
- [x] `dotnet test -c Release --no-build 'dotnet/Symphony.sln'`

Closes #79