### PR TITLE
feat(theme): add sidebar theme switcher

### DIFF
--- a/SPEC_UI.md
+++ b/SPEC_UI.md
@@ -50,6 +50,7 @@ This version covers:
 - session lists and dashboard views
 - session detail pages
 - browsing session messages, updates, and outcomes
+- switching between the built-in dashboard themes for the current browser session
 
 This version does not require:
 
@@ -99,6 +100,7 @@ The dashboard must allow the operator to:
 - distinguish clearly between active and ended sessions
 - identify the most recent activity for each session
 - open a detail view for any visible session
+- switch between the built-in themes without leaving the shell
 
 The dashboard should make it easy to notice:
 
@@ -106,6 +108,9 @@ The dashboard should make it easy to notice:
 - sessions that have ended successfully
 - sessions that have ended with failure
 - sessions that may require attention
+
+The dashboard theme preference should persist for the current browser via local storage so the
+selected palette is restored after refresh.
 
 ### 6.2 Session detail page
 

--- a/dotnet/ARCHITECTURE_UI.md
+++ b/dotnet/ARCHITECTURE_UI.md
@@ -547,19 +547,23 @@ Tailwind color classes. Required tokens per theme block:
 
 ### 14.5 ThemeService
 
-Register a lightweight `IThemeService` / `ThemeService` singleton in
+Register a lightweight `IThemeService` / `ThemeService` scoped service in
 `SymphonyHostCompositionExtensions.cs`:
 
 - `CurrentTheme` — string property, default `"dark-yellow"`
 - `AvailableThemes` — static list of `ThemeDescriptor` records (key, display name, is dark)
-- `SetTheme(string key)` — persists to `localStorage` and raises `OnThemeChanged` (C# event)
+- `SetThemeAsync(string key)` — persists to `localStorage` and raises `OnThemeChanged`
+  (C# event)
 - On startup, `ThemeService` reads the persisted preference via JS interop
   (`localStorage.getItem("symphony-theme")`) and sets `CurrentTheme` before first render,
   so no theme flash occurs.
 
 The `ThemeSwitcher.razor` sub-component lives in the `MainLayout.razor` sidebar footer and
-renders a Flowbite `Dropdown` listing available themes. On selection it calls
-`IThemeService.SetTheme`, which invokes JS interop to:
+renders a Flowbite `Dropdown` labeled with the current theme display name while listing all
+available themes. `MainLayout.razor` injects the scoped theme service and passes it into the
+sub-component as a typed parameter. The switcher subscribes to `OnThemeChanged` so the trigger
+label updates in place after a selection. On selection it calls `IThemeService.SetThemeAsync`,
+which invokes JS interop to:
 1. Set or remove `class="dark"` on `<html>`
 2. Set `data-theme="{key}"` on `<html>`
 3. Persist `"symphony-theme"` in `localStorage`

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -303,6 +303,8 @@ surface only: if dashboard rendering fails, the orchestrator and JSON API contin
   can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
 - The dashboard health cards now expose last poll tick, last successful poll age, and workflow load
   status so degraded polling or workflow-reload fallback is visible without reading logs.
+- The sidebar footer includes a theme switcher for the built-in `dark-yellow`, `dark-blue`, and
+  `light-blue` palettes; the current browser choice is restored from `localStorage` on refresh.
 - `GET /api/v1/state` for the current running/retrying snapshot, live token totals, runtime counts,
   and operator health fields such as poll staleness and workflow reload status
 - `GET /api/v1/{issueIdentifier}` for issue-specific runtime details with a `404` JSON error envelope when the issue is not tracked

--- a/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
+++ b/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
@@ -6,26 +6,25 @@
 @inject IThemeService ThemeService
 
 <div class="min-h-screen bg-transparent text-[var(--color-on-surface-primary)] lg:flex">
-    <Sidebar @ref="_sidebar"
-             @bind-IsCollapsed="_isSidebarCollapsed"
-             CollapseMode="SidebarCollapseMode.Responsive"
-             CollapseBehavior="SidebarCollapseBehavior.Hide">
-        <SidebarLogo Href="/">Symphony</SidebarLogo>
-        <SidebarItemGroup>
-            <SidebarItem Href="/" Icon="@(new HomeIcon())">
-                Dashboard
-            </SidebarItem>
-            <SidebarItem Href="/sessions"
-                         Label="@_runningSessionsLabel"
-                         LabelColorValue="SidebarItem.LabelColor.Primary">
-                Sessions
-            </SidebarItem>
-        </SidebarItemGroup>
+    <div class="hidden lg:block lg:w-72 lg:shrink-0">
+        <Sidebar>
+            @SidebarContent
+        </Sidebar>
+    </div>
 
-        <div class="mt-auto border-t border-[var(--shell-border)] px-3 pb-4 pt-4">
-            <ThemeSwitcher ThemeService="ThemeService" />
+    @if (!_isSidebarCollapsed)
+    {
+        <button class="fixed inset-0 z-30 bg-slate-950/45 lg:hidden"
+                aria-label="Close menu"
+                @onclick="CloseSidebar">
+        </button>
+
+        <div class="fixed inset-y-0 left-0 z-40 w-72 lg:hidden">
+            <Sidebar>
+                @SidebarContent
+            </Sidebar>
         </div>
-    </Sidebar>
+    }
 
     <div class="min-h-screen min-w-0 flex-1">
         <nav class="sticky top-0 z-30 border-b border-[var(--shell-border)] bg-[color:var(--color-surface-overlay)]/95 backdrop-blur">
@@ -71,11 +70,10 @@
 </div>
 
 @code {
-    private Sidebar? _sidebar;
     private PeriodicTimer? _refreshTimer;
     private CancellationTokenSource? _refreshCancellationTokenSource;
     private Task? _refreshLoopTask;
-    private bool _isSidebarCollapsed;
+    private bool _isSidebarCollapsed = true;
     private string _runningSessionsLabel = "0";
 
     protected override async Task OnInitializedAsync()
@@ -111,13 +109,34 @@
         }
     }
 
-    private async Task ToggleSidebarAsync()
+    private Task ToggleSidebarAsync()
     {
-        if (_sidebar is not null)
-        {
-            await _sidebar.ToggleAsync();
-        }
+        _isSidebarCollapsed = !_isSidebarCollapsed;
+        return Task.CompletedTask;
     }
+
+    private void CloseSidebar()
+    {
+        _isSidebarCollapsed = true;
+    }
+
+    private RenderFragment SidebarContent => @<text>
+        <SidebarLogo Href="/">Symphony</SidebarLogo>
+        <SidebarItemGroup>
+            <SidebarItem Href="/" Icon="@(new HomeIcon())">
+                Dashboard
+            </SidebarItem>
+            <SidebarItem Href="/sessions"
+                         Label="@_runningSessionsLabel"
+                         LabelColorValue="SidebarItem.LabelColor.Primary">
+                Sessions
+            </SidebarItem>
+        </SidebarItemGroup>
+
+        <div class="mt-auto border-t border-[var(--shell-border)] px-3 pb-4 pt-4">
+            <ThemeSwitcher ThemeService="ThemeService" />
+        </div>
+    </text>;
 
     private async Task RunRefreshLoopAsync(CancellationToken cancellationToken)
     {
@@ -155,4 +174,5 @@
             // Keep the shell responsive even if dashboard state refresh fails.
         }
     }
+
 }

--- a/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
+++ b/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
@@ -75,7 +75,7 @@
     private PeriodicTimer? _refreshTimer;
     private CancellationTokenSource? _refreshCancellationTokenSource;
     private Task? _refreshLoopTask;
-    private bool _isSidebarCollapsed = true;
+    private bool _isSidebarCollapsed;
     private string _runningSessionsLabel = "0";
 
     protected override async Task OnInitializedAsync()

--- a/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
+++ b/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
 @inject IDashboardStateService DashboardStateService
 @inject IThemeService ThemeService
 
-<div class="min-h-screen bg-transparent text-[var(--color-on-surface-primary)]">
+<div class="min-h-screen bg-transparent text-[var(--color-on-surface-primary)] lg:flex">
     <Sidebar @ref="_sidebar"
              @bind-IsCollapsed="_isSidebarCollapsed"
              CollapseMode="SidebarCollapseMode.Responsive"
@@ -27,7 +27,7 @@
         </div>
     </Sidebar>
 
-    <div class="min-h-screen lg:pl-64">
+    <div class="min-h-screen min-w-0 flex-1">
         <nav class="sticky top-0 z-30 border-b border-[var(--shell-border)] bg-[color:var(--color-surface-overlay)]/95 backdrop-blur">
             <div class="mx-auto flex w-full max-w-screen-2xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
                 <div class="flex items-center gap-3">

--- a/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
+++ b/dotnet/src/Symphony.Host/Components/Layout/MainLayout.razor
@@ -3,6 +3,7 @@
 @using System.Globalization
 @using Flowbite.Layout
 @inject IDashboardStateService DashboardStateService
+@inject IThemeService ThemeService
 
 <div class="min-h-screen bg-transparent text-[var(--color-on-surface-primary)]">
     <Sidebar @ref="_sidebar"
@@ -20,6 +21,10 @@
                 Sessions
             </SidebarItem>
         </SidebarItemGroup>
+
+        <div class="mt-auto border-t border-[var(--shell-border)] px-3 pb-4 pt-4">
+            <ThemeSwitcher ThemeService="ThemeService" />
+        </div>
     </Sidebar>
 
     <div class="min-h-screen lg:pl-64">

--- a/dotnet/src/Symphony.Host/Components/Shell/ThemeSwitcher.razor
+++ b/dotnet/src/Symphony.Host/Components/Shell/ThemeSwitcher.razor
@@ -1,0 +1,88 @@
+@implements IDisposable
+
+<div class="space-y-2" data-testid="theme-switcher">
+    <p class="text-[0.6875rem] font-bold uppercase tracking-[0.24em] text-[color:var(--color-on-surface-secondary)]">
+        Theme
+    </p>
+
+    <Dropdown Placement="DropdownPlacement.Top"
+              Size="DropdownSize.Small"
+              Slots="@_slots">
+        <Label>@CurrentThemeDisplayName</Label>
+        <ChildContent>
+            @foreach (var theme in ThemeService.AvailableThemes)
+            {
+                <DropdownItem OnClick="@(() => SelectThemeAsync(theme.Key))">
+                    <div class="flex items-center justify-between gap-3">
+                        <span>@theme.DisplayName</span>
+                        @if (IsSelected(theme))
+                        {
+                            <span class="text-[0.6875rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-primary-DEFAULT)]">
+                                Current
+                            </span>
+                        }
+                    </div>
+                </DropdownItem>
+            }
+        </ChildContent>
+    </Dropdown>
+</div>
+
+@code {
+    private static readonly DropdownSlots _slots = new()
+    {
+        Trigger = "flex w-full items-center justify-between rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-overlay)] px-3 py-2 text-sm font-medium text-[color:var(--color-on-surface-primary)] hover:bg-[color:var(--color-surface-raised)] focus:ring-[color:var(--color-primary-DEFAULT)]",
+        Menu = "w-60 rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Item = "text-[color:var(--color-on-surface-primary)] hover:bg-[color:var(--color-surface-overlay)]"
+    };
+
+    private IThemeService? _subscribedThemeService;
+
+    [Parameter, EditorRequired]
+    public IThemeService ThemeService { get; set; } = default!;
+
+    private string CurrentThemeDisplayName =>
+        ThemeService.AvailableThemes.FirstOrDefault(theme =>
+            string.Equals(theme.Key, ThemeService.CurrentTheme, StringComparison.OrdinalIgnoreCase))?.DisplayName
+        ?? ThemeService.CurrentTheme;
+
+    protected override void OnParametersSet()
+    {
+        if (ReferenceEquals(_subscribedThemeService, ThemeService))
+        {
+            return;
+        }
+
+        if (_subscribedThemeService is not null)
+        {
+            _subscribedThemeService.OnThemeChanged -= HandleThemeChanged;
+        }
+
+        _subscribedThemeService = ThemeService;
+        _subscribedThemeService.OnThemeChanged += HandleThemeChanged;
+    }
+
+    public void Dispose()
+    {
+        if (_subscribedThemeService is not null)
+        {
+            _subscribedThemeService.OnThemeChanged -= HandleThemeChanged;
+            _subscribedThemeService = null;
+        }
+    }
+
+    private bool IsSelected(ThemeDescriptor theme)
+    {
+        return string.Equals(theme.Key, ThemeService.CurrentTheme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private Task SelectThemeAsync(string themeKey)
+    {
+        return ThemeService.SetThemeAsync(themeKey);
+    }
+
+    private void HandleThemeChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/_Imports.razor
+++ b/dotnet/src/Symphony.Host/Components/_Imports.razor
@@ -10,7 +10,9 @@
 @using Flowbite.Services
 @using Symphony.Host.Dashboard
 @using Symphony.Host.Components.Layout
+@using Symphony.Host.Components.Shell
 @using Symphony.Host.Components.Theme
+@using Symphony.Host.Theming
 @using static Flowbite.Components.Button
 @using static Flowbite.Components.Dropdown
 @using static Flowbite.Components.Sidebar

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -90,6 +90,8 @@ public sealed class DashboardPageIntegrationTests
         Assert.Contains("Service Health", html, StringComparison.Ordinal);
         Assert.Contains("Workflow Config", html, StringComparison.Ordinal);
         Assert.Contains("Operator Dashboard", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"theme-switcher\"", html, StringComparison.Ordinal);
+        Assert.Contains("Dark Yellow", html, StringComparison.Ordinal);
         Assert.Contains("href=\"/sessions\"", html, StringComparison.Ordinal);
         Assert.Contains("Live sessions", html, StringComparison.Ordinal);
         Assert.Contains(">2</span>", html, StringComparison.Ordinal);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/ThemeSwitcherTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/ThemeSwitcherTests.cs
@@ -1,0 +1,128 @@
+using Bunit;
+using Flowbite.Components;
+using Flowbite.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Host.Components.Shell;
+using Symphony.Host.Theming;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class ThemeSwitcherTests : BunitContext
+{
+    public ThemeSwitcherTests()
+    {
+        Services.AddFlowbite();
+        Services.AddSingleton<IFloatingService, TestFloatingService>();
+    }
+
+    [Fact]
+    public void ThemeSwitcher_renders_current_theme_label_and_available_options()
+    {
+        var themeService = new TestThemeService();
+
+        var cut = Render<ThemeSwitcher>(parameters => parameters.Add(component => component.ThemeService, themeService));
+
+        cut.Find("[data-testid=\"theme-switcher\"] button").Click();
+
+        Assert.Contains("Dark Yellow", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Dark Blue", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Light Blue", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ThemeSwitcher_selecting_theme_calls_theme_service()
+    {
+        var themeService = new TestThemeService();
+        var cut = Render<ThemeSwitcher>(parameters => parameters.Add(component => component.ThemeService, themeService));
+
+        cut.Find("[data-testid=\"theme-switcher\"] button").Click();
+        var dropdownItems = cut.FindComponents<DropdownItem>();
+
+        Assert.Equal(3, dropdownItems.Count);
+
+        await cut.InvokeAsync(() => dropdownItems[1].Instance.OnClick.InvokeAsync());
+
+        Assert.Equal("dark-blue", Assert.Single(themeService.SelectedThemes));
+        Assert.Equal("Dark Blue", cut.Find("[data-testid=\"theme-switcher\"] button").TextContent.Trim());
+    }
+
+    [Fact]
+    public void ThemeSwitcher_updates_when_theme_service_raises_change_event()
+    {
+        var themeService = new TestThemeService();
+        var cut = Render<ThemeSwitcher>(parameters => parameters.Add(component => component.ThemeService, themeService));
+
+        themeService.ChangeTheme("light-blue");
+
+        cut.WaitForAssertion(() =>
+            Assert.Equal("Light Blue", cut.Find("[data-testid=\"theme-switcher\"] button").TextContent.Trim()));
+    }
+
+    private sealed class TestThemeService : IThemeService
+    {
+        private static readonly ThemeDescriptor[] Themes =
+        [
+            new("dark-yellow", "Dark Yellow", true),
+            new("dark-blue", "Dark Blue", true),
+            new("light-blue", "Light Blue", false)
+        ];
+
+        public string CurrentTheme { get; private set; } = "dark-yellow";
+
+        public IReadOnlyList<ThemeDescriptor> AvailableThemes => Themes;
+
+        public event Action? OnThemeChanged;
+
+        public List<string> SelectedThemes { get; } = [];
+
+        public Task SetThemeAsync(string key)
+        {
+            SelectedThemes.Add(key);
+            ChangeTheme(key);
+            return Task.CompletedTask;
+        }
+
+        public void ChangeTheme(string key)
+        {
+            CurrentTheme = key;
+            OnThemeChanged?.Invoke();
+        }
+    }
+
+    private sealed class TestFloatingService : IFloatingService, IDisposable
+    {
+        public Task<string?> InitializeAsync(string id, FloatingOptions? options = null)
+        {
+            return Task.FromResult<string?>("top");
+        }
+
+        public Task UpdatePositionAsync(string id)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DestroyAsync(string id)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ExistsAsync(string id)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task<string?> GetPlacementAsync(string id)
+        {
+            return Task.FromResult<string?>("top");
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
#### Context

EU3-S2 exposes the built-in theme service in the shell so operators can switch dashboard palettes without leaving the layout or losing the stored browser preference.

#### TL;DR

Add a sidebar footer theme dropdown that switches and persists the current dashboard palette.

#### Summary

- add a `ThemeSwitcher` Flowbite dropdown under `Components/Shell/` and place it in the `MainLayout` sidebar footer
- pass `IThemeService` into the sub-component as a typed parameter so it can list themes and react to `OnThemeChanged`
- add bUnit and integration coverage, then update the UI docs for the new operator-visible switcher

#### Alternatives

- inject `IThemeService` directly into `ThemeSwitcher`, which would violate the UI plan rule that sub-components stay parameter-driven
- defer the switcher until the page work lands, which would leave the theme service without any visible operator control

#### Test Plan

- [x] `dotnet test -c Release 'dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj' --filter 'FullyQualifiedName~ThemeSwitcherTests'`
- [x] `dotnet test -c Release 'dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj' --filter 'FullyQualifiedName~DashboardPageIntegrationTests'`
- [x] `dotnet build -c Release 'dotnet/Symphony.sln'`
- [x] `dotnet test -c Release --no-build 'dotnet/Symphony.sln'`
- [x] `dotnet format --verify-no-changes 'dotnet/Symphony.sln'`
- [x] Manual viewport verification for the theme switcher at 375px, 768px, and 1280px

Closes #80