### PR TITLE
feat: compose dashboard panels for the operator homepage

### DIFF
--- a/dotnet/src/Symphony.Host/Components/Dashboard/ActiveSessionsPanel.razor
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/ActiveSessionsPanel.razor
@@ -1,0 +1,67 @@
+@using Symphony.Host.Dashboard
+
+<Card Slots="@PanelSlots" data-testid="dashboard-active-sessions">
+    <div class="flex items-start justify-between gap-4">
+        <div>
+            <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Active Sessions</p>
+            <h2 class="mt-2 text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Current work in flight</h2>
+            <p class="mt-2 text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                Live runs with current tracker state, session metadata, and token usage.
+            </p>
+        </div>
+        <Badge Color="Badge.BadgeColor.Info">@Sessions.Count</Badge>
+    </div>
+
+    @if (Sessions.Count == 0)
+    {
+        <EmptyState Title="No active sessions"
+                    Description="New in-flight work will appear here without requiring a full page reload." />
+    }
+    else
+    {
+        <ul class="space-y-4">
+            @foreach (var session in Sessions)
+            {
+                <li class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-overlay)] p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                        <a class="text-base font-semibold text-[color:var(--color-on-surface-primary)] underline decoration-[color:var(--color-primary-DEFAULT)] decoration-2 underline-offset-4"
+                           href="/sessions/@Uri.EscapeDataString(session.IssueIdentifier)">
+                            @session.IssueIdentifier
+                        </a>
+                        <Badge Color="@DashboardDisplay.GetSessionStateBadgeColor(session.State)">@session.State</Badge>
+                    </div>
+                    <div class="mt-3 space-y-2 text-sm text-[color:var(--color-on-surface-secondary)]">
+                        <p>Started @DashboardDisplay.FormatTimestamp(session.StartedAt) · @DashboardDisplay.FormatElapsed(session.StartedAt, GeneratedAt) live</p>
+                        <p>Session @(session.SessionId ?? "pending") · turns @session.TurnCount · tokens @session.TotalTokens</p>
+                        @if (!string.IsNullOrWhiteSpace(session.LastEvent) || !string.IsNullOrWhiteSpace(session.LastMessage))
+                        {
+                            <p>
+                                Latest: @session.LastEvent
+                                @if (!string.IsNullOrWhiteSpace(session.LastMessage))
+                                {
+                                    <span> · @session.LastMessage</span>
+                                }
+                            </p>
+                        }
+                    </div>
+                </li>
+            }
+        </ul>
+    }
+</Card>
+
+@code {
+    private static readonly CardSlots PanelSlots = new()
+    {
+        Base = "h-full rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex h-full flex-col gap-6 p-5"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required IReadOnlyList<DashboardActiveSessionSnapshot> Sessions { get; set; }
+
+    [Parameter]
+    [EditorRequired]
+    public DateTimeOffset GeneratedAt { get; set; }
+}

--- a/dotnet/src/Symphony.Host/Components/Dashboard/DashboardDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/DashboardDisplay.cs
@@ -1,0 +1,178 @@
+using System.Globalization;
+using Flowbite.Components;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.Components.Dashboard;
+
+internal static class DashboardDisplay
+{
+    internal static string FormatTimestamp(DateTimeOffset? timestamp)
+    {
+        return timestamp?.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture)
+            ?? "Waiting for first tick";
+    }
+
+    internal static string FormatDuration(double durationSeconds)
+    {
+        return durationSeconds >= 60d
+            ? $"{durationSeconds / 60d:0.#} min"
+            : $"{durationSeconds:0.#} s";
+    }
+
+    internal static string FormatElapsed(DateTimeOffset startedAt, DateTimeOffset generatedAt)
+    {
+        return FormatDuration(Math.Max((generatedAt - startedAt).TotalSeconds, 0d));
+    }
+
+    internal static string FormatRetryEta(DateTimeOffset dueAt, DateTimeOffset generatedAt)
+    {
+        var remaining = dueAt - generatedAt;
+        if (remaining <= TimeSpan.Zero)
+        {
+            return "due now";
+        }
+
+        return remaining.TotalMinutes >= 1d
+            ? $"in {remaining.TotalMinutes:0.#} min"
+            : $"in {remaining.TotalSeconds:0}s";
+    }
+
+    internal static Badge.BadgeColor GetHealthBadgeColor(string serviceHealth)
+    {
+        return serviceHealth.ToLowerInvariant() switch
+        {
+            "healthy" => Badge.BadgeColor.Success,
+            "degraded" => Badge.BadgeColor.Warning,
+            _ => Badge.BadgeColor.Gray
+        };
+    }
+
+    internal static Badge.BadgeColor GetWorkflowBadgeColor(string workflowLoadStatus)
+    {
+        return workflowLoadStatus switch
+        {
+            "Loaded" => Badge.BadgeColor.Success,
+            "ReloadFailedUsingLastKnownGood" => Badge.BadgeColor.Warning,
+            _ => Badge.BadgeColor.Gray
+        };
+    }
+
+    internal static Badge.BadgeColor GetSessionStateBadgeColor(string state)
+    {
+        return state.ToLowerInvariant() switch
+        {
+            "in progress" => Badge.BadgeColor.Info,
+            "streaming" => Badge.BadgeColor.Info,
+            "finishing" => Badge.BadgeColor.Info,
+            "retrying" => Badge.BadgeColor.Warning,
+            "succeeded" => Badge.BadgeColor.Success,
+            "failed" => Badge.BadgeColor.Failure,
+            "timedout" => Badge.BadgeColor.Failure,
+            "stalled" => Badge.BadgeColor.Failure,
+            "canceled" => Badge.BadgeColor.Gray,
+            _ => Badge.BadgeColor.Primary
+        };
+    }
+
+    internal static Badge.BadgeColor GetOutcomeBadgeColor(string outcome)
+    {
+        return outcome.ToLowerInvariant() switch
+        {
+            "succeeded" => Badge.BadgeColor.Success,
+            "retrying" => Badge.BadgeColor.Warning,
+            "failed" => Badge.BadgeColor.Failure,
+            "timedout" => Badge.BadgeColor.Failure,
+            "stalled" => Badge.BadgeColor.Failure,
+            "canceled" => Badge.BadgeColor.Gray,
+            _ => Badge.BadgeColor.Primary
+        };
+    }
+
+    internal static string GetHealthMessage(DashboardSnapshot snapshot)
+    {
+        if (string.Equals(snapshot.WorkflowLoadStatus, "ReloadFailedUsingLastKnownGood", StringComparison.Ordinal))
+        {
+            return "Workflow reload failed; the service is using the last-known-good configuration.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(snapshot.LastError))
+        {
+            return "Latest poll attempt failed; the orchestrator is still running.";
+        }
+
+        if (string.Equals(snapshot.ServiceHealth, "Degraded", StringComparison.Ordinal)
+            && snapshot.LastSuccessfulPollAgeSeconds is double ageSeconds)
+        {
+            return $"Last successful poll is {FormatDuration(ageSeconds)} old.";
+        }
+
+        return snapshot.ServiceHealth switch
+        {
+            "Healthy" => "Workflow loaded and recent poll ticks are healthy.",
+            "Degraded" => "Health indicators are degraded; inspect logs for details.",
+            _ => "Waiting for the first successful workflow load and poll tick."
+        };
+    }
+
+    internal static string GetPollMessage(DashboardSnapshot snapshot)
+    {
+        if (snapshot.LastSuccessfulPollAt is null)
+        {
+            return "Waiting for the first successful orchestrator poll.";
+        }
+
+        var age = snapshot.LastSuccessfulPollAgeSeconds is double ageSeconds
+            ? FormatDuration(ageSeconds)
+            : "unknown age";
+        return $"Last success {FormatTimestamp(snapshot.LastSuccessfulPollAt)} ({age} ago).";
+    }
+
+    internal static string GetWorkflowMessage(DashboardSnapshot snapshot)
+    {
+        if (string.Equals(snapshot.WorkflowLoadStatus, "ReloadFailedUsingLastKnownGood", StringComparison.Ordinal))
+        {
+            return string.IsNullOrWhiteSpace(snapshot.WorkflowLastError)
+                ? "Last workflow reload failed; continuing with the cached definition."
+                : $"Reload failed: {snapshot.WorkflowLastError}";
+        }
+
+        return snapshot.WorkflowLastLoadedAt is null
+            ? "Waiting for the initial workflow load."
+            : $"Last loaded {FormatTimestamp(snapshot.WorkflowLastLoadedAt)}.";
+    }
+
+    internal static IReadOnlyList<DashboardAlertMessage> GetAlerts(DashboardSnapshot snapshot)
+    {
+        var alerts = new List<DashboardAlertMessage>();
+
+        if (!string.IsNullOrWhiteSpace(snapshot.LastError))
+        {
+            alerts.Add(new DashboardAlertMessage(
+                AlertColor.Failure,
+                "Polling failure:",
+                snapshot.LastError));
+        }
+
+        if (!string.IsNullOrWhiteSpace(snapshot.WorkflowLastError))
+        {
+            alerts.Add(new DashboardAlertMessage(
+                AlertColor.Warning,
+                "Workflow reload warning:",
+                snapshot.WorkflowLastError));
+        }
+        else if (string.Equals(snapshot.ServiceHealth, "Degraded", StringComparison.Ordinal))
+        {
+            alerts.Add(new DashboardAlertMessage(
+                AlertColor.Warning,
+                "Service health degraded:",
+                GetHealthMessage(snapshot)));
+        }
+
+        return alerts;
+    }
+}
+
+internal sealed record DashboardAlertMessage(
+    AlertColor Color,
+    string TextEmphasis,
+    string Text);

--- a/dotnet/src/Symphony.Host/Components/Dashboard/HealthSummaryCards.razor
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/HealthSummaryCards.razor
@@ -1,0 +1,71 @@
+@using Symphony.Host.Dashboard
+
+@if (Alerts.Count > 0)
+{
+    <div class="mb-4 space-y-3" data-testid="dashboard-summary-alerts">
+        @foreach (var alert in Alerts)
+        {
+            <Alert Color="@alert.Color"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="@alert.TextEmphasis"
+                   Text="@alert.Text" />
+        }
+    </div>
+}
+
+<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="dashboard-summary-grid">
+    <Card Slots="@CardSlots">
+        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Service Health</p>
+        <div class="mt-4 flex items-center gap-3">
+            <Badge Color="@DashboardDisplay.GetHealthBadgeColor(Snapshot.ServiceHealth)">@Snapshot.ServiceHealth</Badge>
+            <span class="text-sm text-[color:var(--color-on-surface-secondary)]">@Snapshot.RunningCount running</span>
+        </div>
+        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">@DashboardDisplay.GetHealthMessage(Snapshot)</p>
+    </Card>
+
+    <Card Slots="@CardSlots">
+        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Orchestrator Mode</p>
+        <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">@Snapshot.OrchestratorMode</h2>
+        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+            State is tracked in-process and served live for the operator shell.
+        </p>
+        <p class="text-sm text-[color:var(--color-on-surface-secondary)]">
+            Retry queue: @Snapshot.RetryingCount queued
+        </p>
+    </Card>
+
+    <Card Slots="@CardSlots">
+        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Last Poll Tick</p>
+        <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">
+            @DashboardDisplay.FormatTimestamp(Snapshot.LastPollTickAt)
+        </h2>
+        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">@DashboardDisplay.GetPollMessage(Snapshot)</p>
+        <p class="text-sm text-[color:var(--color-on-surface-secondary)]">
+            Runtime: @DashboardDisplay.FormatDuration(Snapshot.SecondsRunning)
+        </p>
+    </Card>
+
+    <Card Slots="@CardSlots">
+        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Workflow Config</p>
+        <div class="mt-4 flex items-center gap-3">
+            <Badge Color="@DashboardDisplay.GetWorkflowBadgeColor(Snapshot.WorkflowLoadStatus)">@Snapshot.WorkflowLoadStatus</Badge>
+            <span class="text-sm text-[color:var(--color-on-surface-secondary)]">@Snapshot.TotalTokens tokens</span>
+        </div>
+        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">@DashboardDisplay.GetWorkflowMessage(Snapshot)</p>
+    </Card>
+</div>
+
+@code {
+    private static readonly CardSlots CardSlots = new()
+    {
+        Base = "h-full rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex h-full flex-col gap-3 p-5"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required DashboardSnapshot Snapshot { get; set; }
+
+    private IReadOnlyList<DashboardAlertMessage> Alerts => DashboardDisplay.GetAlerts(Snapshot);
+}

--- a/dotnet/src/Symphony.Host/Components/Dashboard/RecentAttemptsPanel.razor
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/RecentAttemptsPanel.razor
@@ -1,0 +1,62 @@
+@using Symphony.Host.Dashboard
+
+<Card Slots="@PanelSlots" data-testid="dashboard-recent-attempts">
+    <div class="flex items-start justify-between gap-4">
+        <div>
+            <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Recent Attempts</p>
+            <h2 class="mt-2 text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Latest outcomes</h2>
+            <p class="mt-2 text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                Most recent run outcomes with concise error summaries for operator triage.
+            </p>
+        </div>
+        <Badge Color="Badge.BadgeColor.Primary">@Attempts.Count</Badge>
+    </div>
+
+    @if (Attempts.Count == 0)
+    {
+        <EmptyState Title="No recent attempts yet"
+                    Description="Completed worker attempts will appear here after the first run finishes." />
+    }
+    else
+    {
+        <ul class="space-y-4">
+            @foreach (var attempt in Attempts)
+            {
+                <li class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-overlay)] p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                        <span class="text-base font-semibold text-[color:var(--color-on-surface-primary)]">@attempt.IssueIdentifier</span>
+                        <Badge Color="@DashboardDisplay.GetOutcomeBadgeColor(attempt.Outcome)">@attempt.Outcome</Badge>
+                    </div>
+                    <div class="mt-3 space-y-2 text-sm text-[color:var(--color-on-surface-secondary)]">
+                        <p>@GetAttemptLabel(attempt.Attempt) · finished @DashboardDisplay.FormatTimestamp(attempt.CompletedAt) · @DashboardDisplay.FormatDuration(attempt.DurationSeconds)</p>
+                        @if (!string.IsNullOrWhiteSpace(attempt.SessionId))
+                        {
+                            <p>Session @attempt.SessionId</p>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(attempt.Error))
+                        {
+                            <p>@attempt.Error</p>
+                        }
+                    </div>
+                </li>
+            }
+        </ul>
+    }
+</Card>
+
+@code {
+    private static readonly CardSlots PanelSlots = new()
+    {
+        Base = "h-full rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex h-full flex-col gap-6 p-5"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required IReadOnlyList<DashboardRecentAttemptSnapshot> Attempts { get; set; }
+
+    private static string GetAttemptLabel(int? attempt)
+    {
+        return attempt is null ? "Initial run" : $"Attempt {attempt}";
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/Dashboard/RetryQueuePanel.razor
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/RetryQueuePanel.razor
@@ -1,0 +1,57 @@
+@using Symphony.Host.Dashboard
+
+<Card Slots="@PanelSlots" data-testid="dashboard-retry-queue">
+    <div class="flex items-start justify-between gap-4">
+        <div>
+            <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Retry Queue</p>
+            <h2 class="mt-2 text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Scheduled retries</h2>
+            <p class="mt-2 text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                Continuation and failure retries with their next retry ETA and failure reason.
+            </p>
+        </div>
+        <Badge Color="Badge.BadgeColor.Warning">@Entries.Count</Badge>
+    </div>
+
+    @if (Entries.Count == 0)
+    {
+        <EmptyState Title="Retry queue is empty"
+                    Description="Queued continuation and failure retries will appear here when they are scheduled." />
+    }
+    else
+    {
+        <ul class="space-y-4">
+            @foreach (var entry in Entries)
+            {
+                <li class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-overlay)] p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                        <span class="text-base font-semibold text-[color:var(--color-on-surface-primary)]">@entry.IssueIdentifier</span>
+                        <Badge Color="Badge.BadgeColor.Warning">Retry @entry.Attempt</Badge>
+                    </div>
+                    <div class="mt-3 space-y-2 text-sm text-[color:var(--color-on-surface-secondary)]">
+                        <p>ETA @DashboardDisplay.FormatRetryEta(entry.DueAt, GeneratedAt) · due @DashboardDisplay.FormatTimestamp(entry.DueAt)</p>
+                        @if (!string.IsNullOrWhiteSpace(entry.Error))
+                        {
+                            <p>@entry.Error</p>
+                        }
+                    </div>
+                </li>
+            }
+        </ul>
+    }
+</Card>
+
+@code {
+    private static readonly CardSlots PanelSlots = new()
+    {
+        Base = "h-full rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex h-full flex-col gap-6 p-5"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required IReadOnlyList<DashboardRetrySnapshot> Entries { get; set; }
+
+    [Parameter]
+    [EditorRequired]
+    public DateTimeOffset GeneratedAt { get; set; }
+}

--- a/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/DashboardShellContent.razor
@@ -1,6 +1,8 @@
+@implements IAsyncDisposable
+@using Symphony.Host.Components.Dashboard
 @inject IDashboardStateService DashboardStateService
 
-<main class="dashboard-page">
+<main class="dashboard-page flex flex-col gap-6">
     <section class="hero">
         <p class="eyebrow">Symphony</p>
         <h1>Runtime Control Surface</h1>
@@ -10,322 +12,193 @@
         </p>
     </section>
 
-    <section class="summary-grid" aria-label="System summary">
-        <article class="metric-card @(GetHealthClass(snapshot.ServiceHealth))">
-            <span class="metric-label">Service Health</span>
-            <strong class="metric-value">@snapshot.ServiceHealth</strong>
-            <span class="metric-meta">@GetHealthMessage(snapshot)</span>
-        </article>
-        <article class="metric-card">
-            <span class="metric-label">Orchestrator Mode</span>
-            <strong class="metric-value">@snapshot.OrchestratorMode</strong>
-            <span class="metric-meta">State is tracked in-process and served live.</span>
-        </article>
-        <article class="metric-card">
-            <span class="metric-label">Last Poll Tick</span>
-            <strong class="metric-value">@FormatTimestamp(snapshot.LastPollTickAt)</strong>
-            <span class="metric-meta">@GetPollMessage(snapshot)</span>
-        </article>
-        <article class="metric-card">
-            <span class="metric-label">Workflow Config</span>
-            <strong class="metric-value">@snapshot.WorkflowLoadStatus</strong>
-            <span class="metric-meta">@GetWorkflowMessage(snapshot)</span>
-        </article>
-    </section>
-
-    <section class="ops-strip" aria-label="Orchestrator totals">
-        <div class="ops-stat">
-            <span class="metric-label">Running Sessions</span>
-            <strong class="ops-value">@snapshot.RunningCount</strong>
-        </div>
-        <div class="ops-stat">
-            <span class="metric-label">Retry Queue</span>
-            <strong class="ops-value">@snapshot.RetryingCount</strong>
-        </div>
-        <div class="ops-stat">
-            <span class="metric-label">Token Totals</span>
-            <strong class="ops-value">@snapshot.TotalTokens</strong>
-            <span class="ops-meta">input @snapshot.InputTokens / output @snapshot.OutputTokens</span>
-        </div>
-        <div class="ops-stat">
-            <span class="metric-label">Runtime Seconds</span>
-            <strong class="ops-value">@snapshot.SecondsRunning.ToString("0.0")</strong>
-            <span class="ops-meta">Aggregate active-session runtime</span>
-        </div>
-    </section>
-
-    <section class="detail-grid" aria-label="Operational panels">
-        <article class="detail-card panel-card">
-            <div class="panel-heading">
-                <div>
-                    <h2>Active Sessions</h2>
-                    <p>Live runs with current tracker state, session metadata, and token usage.</p>
-                </div>
-            </div>
-
-            @if (snapshot.ActiveSessions.Count == 0)
+    @if (_isLoading)
+    {
+        <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="dashboard-skeleton">
+            @for (var index = 0; index < 4; index++)
             {
-                <p class="empty-state">No active sessions are running right now.</p>
+                <Card Slots="@SkeletonCardSlots">
+                    <Skeleton Variant="SkeletonVariant.Text" Lines="1" AriaLabel="Loading dashboard summary" />
+                    <Skeleton Variant="SkeletonVariant.Text" Lines="2" Width="w-full" />
+                    <Skeleton Variant="SkeletonVariant.Button" Width="w-24" />
+                </Card>
             }
-            else
-            {
-                <ul class="panel-list">
-                    @foreach (var session in snapshot.ActiveSessions)
-                    {
-                        <li class="panel-item">
-                            <div class="panel-item-top">
-                                <strong>@session.IssueIdentifier</strong>
-                                <span class="pill pill--neutral">@session.State</span>
-                            </div>
-                            <p class="panel-meta">
-                                started @FormatTimestamp(session.StartedAt) · @FormatElapsed(session.StartedAt) live
-                            </p>
-                            <p class="panel-meta">
-                                session @(session.SessionId ?? "pending") · turns @session.TurnCount · tokens @session.TotalTokens
-                            </p>
-                            @if (!string.IsNullOrWhiteSpace(session.LastEvent) || !string.IsNullOrWhiteSpace(session.LastMessage))
-                            {
-                                <p class="panel-note">
-                                    Latest: @session.LastEvent
-                                    @if (!string.IsNullOrWhiteSpace(session.LastMessage))
-                                    {
-                                        <span> · @session.LastMessage</span>
-                                    }
-                                </p>
-                            }
-                        </li>
-                    }
-                </ul>
-            }
-        </article>
+        </section>
 
-        <article class="detail-card panel-card">
-            <div class="panel-heading">
-                <div>
-                    <h2>Retry Queue</h2>
-                    <p>Scheduled continuation and failure retries with their next retry ETA.</p>
-                </div>
-            </div>
+        <section class="grid grid-cols-1 gap-6 xl:grid-cols-3">
+            @for (var index = 0; index < 3; index++)
+            {
+                <Card Slots="@SkeletonCardSlots">
+                    <Skeleton Variant="SkeletonVariant.Text" Lines="1" AriaLabel="Loading dashboard panel" />
+                    <Skeleton Variant="SkeletonVariant.Card" Width="w-full" Height="h-48" />
+                </Card>
+            }
+        </section>
+    }
+    else if (_snapshot is not null)
+    {
+        @if (!string.IsNullOrWhiteSpace(_refreshErrorMessage))
+        {
+            <Alert Color="AlertColor.Warning"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="Refresh warning:"
+                   Text="@_refreshErrorMessage" />
+        }
 
-            @if (snapshot.RetryQueue.Count == 0)
-            {
-                <p class="empty-state">No retries are queued at the moment.</p>
-            }
-            else
-            {
-                <ul class="panel-list">
-                    @foreach (var retry in snapshot.RetryQueue)
-                    {
-                        <li class="panel-item">
-                            <div class="panel-item-top">
-                                <strong>@retry.IssueIdentifier</strong>
-                                <span class="pill pill--warning">Retry @retry.Attempt</span>
-                            </div>
-                            <p class="panel-meta">
-                                ETA @FormatRetryEta(retry.DueAt) · due @FormatTimestamp(retry.DueAt)
-                            </p>
-                            @if (!string.IsNullOrWhiteSpace(retry.Error))
-                            {
-                                <p class="panel-note panel-note--warning">@retry.Error</p>
-                            }
-                        </li>
-                    }
-                </ul>
-            }
-        </article>
+        <ErrorBoundary>
+            <ChildContent>
+                <HealthSummaryCards Snapshot="_snapshot" />
+            </ChildContent>
+            <ErrorContent>
+                <Card Slots="@FallbackCardSlots" data-testid="dashboard-summary-fallback">
+                    <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Dashboard summary</p>
+                    <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Summary panel failed</h2>
+                    <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                        The shell is still responsive, but the summary cards hit a rendering error.
+                    </p>
+                </Card>
+            </ErrorContent>
+        </ErrorBoundary>
 
-        <article class="detail-card panel-card">
-            <div class="panel-heading">
-                <div>
-                    <h2>Recent Attempts</h2>
-                    <p>Most recent run outcomes with concise error summaries for operator triage.</p>
-                </div>
-            </div>
+        <section class="grid grid-cols-1 gap-6 xl:grid-cols-3" aria-label="Operational panels">
+            <ErrorBoundary>
+                <ChildContent>
+                    <ActiveSessionsPanel Sessions="_snapshot.ActiveSessions" GeneratedAt="_snapshot.GeneratedAt" />
+                </ChildContent>
+                <ErrorContent>
+                    <Card Slots="@FallbackCardSlots" data-testid="dashboard-active-sessions-fallback">
+                        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Active Sessions</p>
+                        <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Panel failed</h2>
+                        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                            Active session details are temporarily unavailable.
+                        </p>
+                    </Card>
+                </ErrorContent>
+            </ErrorBoundary>
 
-            @if (snapshot.RecentAttempts.Count == 0)
-            {
-                <p class="empty-state">Recent run attempts will appear here after the first worker completes.</p>
-            }
-            else
-            {
-                <ul class="panel-list">
-                    @foreach (var attempt in snapshot.RecentAttempts)
-                    {
-                        <li class="panel-item">
-                            <div class="panel-item-top">
-                                <strong>@attempt.IssueIdentifier</strong>
-                                <span class="pill @GetOutcomeClass(attempt.Outcome)">@attempt.Outcome</span>
-                            </div>
-                            <p class="panel-meta">
-                                @GetAttemptLabel(attempt.Attempt) · finished @FormatTimestamp(attempt.CompletedAt) · @FormatDuration(attempt.DurationSeconds)
-                            </p>
-                            @if (!string.IsNullOrWhiteSpace(attempt.SessionId))
-                            {
-                                <p class="panel-meta">session @attempt.SessionId</p>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(attempt.Error))
-                            {
-                                <p class="panel-note panel-note--warning">@attempt.Error</p>
-                            }
-                        </li>
-                    }
-                </ul>
-            }
-        </article>
-    </section>
+            <ErrorBoundary>
+                <ChildContent>
+                    <RetryQueuePanel Entries="_snapshot.RetryQueue" GeneratedAt="_snapshot.GeneratedAt" />
+                </ChildContent>
+                <ErrorContent>
+                    <Card Slots="@FallbackCardSlots" data-testid="dashboard-retry-queue-fallback">
+                        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Retry Queue</p>
+                        <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Panel failed</h2>
+                        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                            Retry details are temporarily unavailable.
+                        </p>
+                    </Card>
+                </ErrorContent>
+            </ErrorBoundary>
 
-    <section class="detail-grid detail-grid--notes" aria-label="Operational notes">
-        <article class="detail-card">
-            <h2>Operator Notes</h2>
-            <p>
-                API observers can use <code>/api/v1/state</code> and <code>/api/v1/refresh</code>. Dashboard
-                failures must not stop orchestration or the API surface.
-            </p>
-            @if (!string.IsNullOrWhiteSpace(snapshot.LastError))
-            {
-                <p class="detail-alert">Last poll error: @snapshot.LastError</p>
-            }
-        </article>
-    </section>
+            <ErrorBoundary>
+                <ChildContent>
+                    <RecentAttemptsPanel Attempts="_snapshot.RecentAttempts" />
+                </ChildContent>
+                <ErrorContent>
+                    <Card Slots="@FallbackCardSlots" data-testid="dashboard-recent-attempts-fallback">
+                        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Recent Attempts</p>
+                        <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Panel failed</h2>
+                        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                            Recent attempt details are temporarily unavailable.
+                        </p>
+                    </Card>
+                </ErrorContent>
+            </ErrorBoundary>
+        </section>
+    }
 </main>
 
 @code {
-    private DashboardSnapshot snapshot = new(
-        GeneratedAt: DateTimeOffset.UnixEpoch,
-        ServiceHealth: "Starting",
-        OrchestratorMode: "Single-process in-memory",
-        LastPollTickAt: null,
-        LastSuccessfulPollAt: null,
-        LastSuccessfulPollAgeSeconds: null,
-        WorkflowLoadStatus: "Starting",
-        WorkflowLastLoadedAt: null,
-        RunningCount: 0,
-        RetryingCount: 0,
-        InputTokens: 0,
-        OutputTokens: 0,
-        TotalTokens: 0,
-        SecondsRunning: 0d,
-        ActiveSessions: [],
-        RetryQueue: [],
-        RecentAttempts: [],
-        LastError: null,
-        WorkflowLastError: null);
+    private static readonly CardSlots SkeletonCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex flex-col gap-4 p-5"
+    };
+
+    private static readonly CardSlots FallbackCardSlots = new()
+    {
+        Base = "h-full rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex h-full flex-col gap-3 p-5"
+    };
+
+    private PeriodicTimer? _refreshTimer;
+    private CancellationTokenSource? _refreshCancellationTokenSource;
+    private Task? _refreshLoopTask;
+    private DashboardSnapshot? _snapshot;
+    private bool _isLoading = true;
+    private string? _refreshErrorMessage;
 
     protected override async Task OnInitializedAsync()
     {
-        snapshot = await DashboardStateService.GetSnapshotAsync();
+        await LoadSnapshotAsync();
+
+        _refreshCancellationTokenSource = new CancellationTokenSource();
+        _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+        _refreshLoopTask = RunRefreshLoopAsync(_refreshCancellationTokenSource.Token);
     }
 
-    private static string FormatTimestamp(DateTimeOffset? timestamp)
+    public async ValueTask DisposeAsync()
     {
-        return timestamp?.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Waiting for first tick";
-    }
-
-    private static string GetHealthClass(string serviceHealth)
-    {
-        return serviceHealth.ToLowerInvariant() switch
+        if (_refreshCancellationTokenSource is not null)
         {
-            "healthy" => "metric-card--healthy",
-            "degraded" => "metric-card--degraded",
-            _ => "metric-card--starting"
-        };
-    }
-
-    private string FormatRetryEta(DateTimeOffset dueAt)
-    {
-        var remaining = dueAt - snapshot.GeneratedAt;
-        if (remaining <= TimeSpan.Zero)
-        {
-            return "due now";
+            await _refreshCancellationTokenSource.CancelAsync();
+            _refreshCancellationTokenSource.Dispose();
+            _refreshCancellationTokenSource = null;
         }
 
-        return remaining.TotalMinutes >= 1d
-            ? $"in {remaining.TotalMinutes:0.#} min"
-            : $"in {remaining.TotalSeconds:0}s";
-    }
+        _refreshTimer?.Dispose();
+        _refreshTimer = null;
 
-    private string FormatElapsed(DateTimeOffset startedAt)
-    {
-        var elapsed = snapshot.GeneratedAt - startedAt;
-        return FormatDuration(Math.Max(elapsed.TotalSeconds, 0d));
-    }
-
-    private static string FormatDuration(double durationSeconds)
-    {
-        return durationSeconds >= 60d
-            ? $"{durationSeconds / 60d:0.#} min"
-            : $"{durationSeconds:0.#} s";
-    }
-
-    private static string GetAttemptLabel(int? attempt)
-    {
-        return attempt is null ? "Initial run" : $"Attempt {attempt}";
-    }
-
-    private static string GetOutcomeClass(string outcome)
-    {
-        return outcome.ToLowerInvariant() switch
+        if (_refreshLoopTask is not null)
         {
-            "succeeded" => "pill--success",
-            "retrying" => "pill--warning",
-            "failed" => "pill--danger",
-            "timedout" => "pill--danger",
-            "stalled" => "pill--danger",
-            "canceled" => "pill--neutral",
-            _ => "pill--neutral"
-        };
+            try
+            {
+                await _refreshLoopTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
     }
 
-    private static string GetHealthMessage(DashboardSnapshot snapshot)
+    private async Task RunRefreshLoopAsync(CancellationToken cancellationToken)
     {
-        if (string.Equals(snapshot.WorkflowLoadStatus, "ReloadFailedUsingLastKnownGood", StringComparison.Ordinal))
+        if (_refreshTimer is null)
         {
-            return "Workflow reload failed; the service is using the last-known-good configuration.";
+            return;
         }
 
-        if (!string.IsNullOrWhiteSpace(snapshot.LastError))
+        try
         {
-            return "Latest poll attempt failed; the orchestrator is still running.";
-        }
+            while (await _refreshTimer.WaitForNextTickAsync(cancellationToken))
+            {
+                try
+                {
+                    await LoadSnapshotAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    _refreshErrorMessage = exception.Message;
+                }
 
-        if (string.Equals(snapshot.ServiceHealth, "Degraded", StringComparison.Ordinal)
-            && snapshot.LastSuccessfulPollAgeSeconds is double ageSeconds)
-        {
-            return $"Last successful poll is {FormatDuration(ageSeconds)} old.";
+                await InvokeAsync(StateHasChanged);
+            }
         }
-
-        return snapshot.ServiceHealth switch
+        catch (OperationCanceledException)
         {
-            "Healthy" => "Workflow loaded and recent poll ticks are healthy.",
-            "Degraded" => "Health indicators are degraded; inspect logs for details.",
-            _ => "Waiting for the first successful workflow load and poll tick."
-        };
+        }
     }
 
-    private static string GetPollMessage(DashboardSnapshot snapshot)
+    private async Task LoadSnapshotAsync(CancellationToken cancellationToken = default)
     {
-        if (snapshot.LastSuccessfulPollAt is null)
-        {
-            return "Waiting for the first successful orchestrator poll.";
-        }
-
-        var age = snapshot.LastSuccessfulPollAgeSeconds is double ageSeconds
-            ? FormatDuration(ageSeconds)
-            : "unknown age";
-        return $"Last success {FormatTimestamp(snapshot.LastSuccessfulPollAt)} ({age} ago).";
-    }
-
-    private static string GetWorkflowMessage(DashboardSnapshot snapshot)
-    {
-        if (string.Equals(snapshot.WorkflowLoadStatus, "ReloadFailedUsingLastKnownGood", StringComparison.Ordinal))
-        {
-            return string.IsNullOrWhiteSpace(snapshot.WorkflowLastError)
-                ? "Last workflow reload failed; continuing with the cached definition."
-                : $"Reload failed: {snapshot.WorkflowLastError}";
-        }
-
-        return snapshot.WorkflowLastLoadedAt is null
-            ? "Waiting for the initial workflow load."
-            : $"Last loaded {FormatTimestamp(snapshot.WorkflowLastLoadedAt)}.";
+        _snapshot = await DashboardStateService.GetSnapshotAsync(cancellationToken);
+        _refreshErrorMessage = null;
+        _isLoading = false;
     }
 }

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageComponentTests.cs
@@ -1,0 +1,84 @@
+using Bunit;
+using Flowbite.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Host.Components.Dashboard;
+using Symphony.Host.Components.Pages;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class DashboardPageComponentTests : BunitContext
+{
+    public DashboardPageComponentTests()
+    {
+        Services.AddFlowbite();
+    }
+
+    [Fact]
+    public void DashboardPage_shows_skeleton_while_initial_snapshot_is_loading()
+    {
+        var taskSource = new TaskCompletionSource<DashboardSnapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Services.AddSingleton<IDashboardStateService>(new DeferredDashboardStateService(taskSource.Task));
+
+        var cut = Render<DashboardPage>();
+
+        Assert.Contains("data-testid=\"dashboard-skeleton\"", cut.Markup, StringComparison.Ordinal);
+
+        taskSource.SetResult(CreateDashboardSnapshot());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("data-testid=\"dashboard-skeleton\"", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("data-testid=\"dashboard-summary-grid\"", cut.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void HealthSummaryCards_renders_failure_and_warning_alerts_from_snapshot()
+    {
+        var cut = Render<HealthSummaryCards>(parameters => parameters
+            .Add(component => component.Snapshot, CreateDashboardSnapshot(
+                serviceHealth: "Degraded",
+                lastError: "Tracker request failed",
+                workflowLastError: "Workflow syntax is invalid.")));
+
+        Assert.Contains("data-testid=\"dashboard-summary-alerts\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Polling failure:", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Workflow reload warning:", cut.Markup, StringComparison.Ordinal);
+    }
+
+    private sealed class DeferredDashboardStateService(Task<DashboardSnapshot> snapshotTask) : IDashboardStateService
+    {
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return snapshotTask;
+        }
+    }
+
+    private static DashboardSnapshot CreateDashboardSnapshot(
+        string serviceHealth = "Healthy",
+        string? lastError = null,
+        string? workflowLastError = null)
+    {
+        return new DashboardSnapshot(
+            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+            serviceHealth,
+            "Single-process in-memory",
+            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 16, 14, 59, 30, TimeSpan.Zero),
+            30d,
+            workflowLastError is null ? "Loaded" : "ReloadFailedUsingLastKnownGood",
+            new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
+            RunningCount: 2,
+            RetryingCount: 1,
+            InputTokens: 100,
+            OutputTokens: 40,
+            TotalTokens: 140,
+            SecondsRunning: 300d,
+            ActiveSessions: [],
+            RetryQueue: [],
+            RecentAttempts: [],
+            lastError,
+            workflowLastError);
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -23,56 +23,7 @@ public sealed class DashboardPageIntegrationTests
     {
         using var app = await StartDashboardApplicationAsync(
             new StubRuntimeService(),
-            new StaticDashboardStateService(
-                new DashboardSnapshot(
-                    new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
-                    "Healthy",
-                    "Single-process in-memory",
-                    new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
-                    new DateTimeOffset(2026, 3, 16, 14, 59, 30, TimeSpan.Zero),
-                    30d,
-                    "Loaded",
-                    new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
-                    RunningCount: 2,
-                    RetryingCount: 1,
-                    InputTokens: 100,
-                    OutputTokens: 40,
-                    TotalTokens: 140,
-                    SecondsRunning: 300d,
-                    ActiveSessions:
-                    [
-                        new DashboardActiveSessionSnapshot(
-                            "ABC-1",
-                            "In Progress",
-                            "thread-1-turn-1",
-                            3,
-                            "turn_completed",
-                            "Applied changes",
-                            new DateTimeOffset(2026, 3, 16, 14, 55, 0, TimeSpan.Zero),
-                            new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero),
-                            140)
-                    ],
-                    RetryQueue:
-                    [
-                        new DashboardRetrySnapshot(
-                            "ABC-2",
-                            2,
-                            new DateTimeOffset(2026, 3, 16, 15, 1, 0, TimeSpan.Zero),
-                            "retry later")
-                    ],
-                    RecentAttempts:
-                    [
-                        new DashboardRecentAttemptSnapshot(
-                            "ABC-3",
-                            1,
-                            "Retrying",
-                            new DateTimeOffset(2026, 3, 16, 14, 58, 30, TimeSpan.Zero),
-                            22.5d,
-                            "Tracker request failed",
-                            "thread-3-turn-2")
-                    ],
-                    LastError: null,
-                    WorkflowLastError: null)));
+            new StaticDashboardStateService(CreateDashboardSnapshot()));
         var client = CreateHttpClient(app);
 
         var response = await client.GetAsync("/");
@@ -87,6 +38,7 @@ public sealed class DashboardPageIntegrationTests
         Assert.Contains("https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.6.13/dist/floating-ui.dom.umd.min.js", html, StringComparison.Ordinal);
         Assert.Contains("src=\"_content/Flowbite/flowbite.js\"", html, StringComparison.Ordinal);
         Assert.Contains("Runtime Control Surface", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"dashboard-summary-grid\"", html, StringComparison.Ordinal);
         Assert.Contains("Service Health", html, StringComparison.Ordinal);
         Assert.Contains("Workflow Config", html, StringComparison.Ordinal);
         Assert.Contains("Operator Dashboard", html, StringComparison.Ordinal);
@@ -98,12 +50,41 @@ public sealed class DashboardPageIntegrationTests
         Assert.Contains("Single-process in-memory", html, StringComparison.Ordinal);
         Assert.Contains("2026-03-16 15:00:00 UTC", html, StringComparison.Ordinal);
         Assert.Contains("Loaded", html, StringComparison.Ordinal);
-        Assert.Contains("Active Sessions", html, StringComparison.Ordinal);
-        Assert.Contains("Retry Queue", html, StringComparison.Ordinal);
-        Assert.Contains("Recent Attempts", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"dashboard-active-sessions\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"dashboard-retry-queue\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"dashboard-recent-attempts\"", html, StringComparison.Ordinal);
         Assert.Contains("ABC-1", html, StringComparison.Ordinal);
         Assert.Contains("ABC-2", html, StringComparison.Ordinal);
         Assert.Contains("ABC-3", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Root_page_renders_empty_state_panels_and_summary_alerts()
+    {
+        using var app = await StartDashboardApplicationAsync(
+            new StubRuntimeService(),
+            new StaticDashboardStateService(
+                CreateDashboardSnapshot(
+                    serviceHealth: "Degraded",
+                    lastError: "Tracker request failed",
+                    workflowLastError: "Workflow syntax is invalid.",
+                    activeSessions: [],
+                    retryQueue: [],
+                    recentAttempts: [])));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("data-testid=\"dashboard-summary-alerts\"", html, StringComparison.Ordinal);
+        Assert.Contains("Polling failure:", html, StringComparison.Ordinal);
+        Assert.Contains("Tracker request failed", html, StringComparison.Ordinal);
+        Assert.Contains("Workflow reload warning:", html, StringComparison.Ordinal);
+        Assert.Contains("Workflow syntax is invalid.", html, StringComparison.Ordinal);
+        Assert.Contains("No active sessions", html, StringComparison.Ordinal);
+        Assert.Contains("Retry queue is empty", html, StringComparison.Ordinal);
+        Assert.Contains("No recent attempts yet", html, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -240,5 +221,64 @@ public sealed class DashboardPageIntegrationTests
         {
             return Task.FromResult(workflowOptions);
         }
+    }
+
+    private static DashboardSnapshot CreateDashboardSnapshot(
+        string serviceHealth = "Healthy",
+        string? lastError = null,
+        string? workflowLastError = null,
+        IReadOnlyList<DashboardActiveSessionSnapshot>? activeSessions = null,
+        IReadOnlyList<DashboardRetrySnapshot>? retryQueue = null,
+        IReadOnlyList<DashboardRecentAttemptSnapshot>? recentAttempts = null)
+    {
+        return new DashboardSnapshot(
+            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+            serviceHealth,
+            "Single-process in-memory",
+            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 16, 14, 59, 30, TimeSpan.Zero),
+            30d,
+            workflowLastError is null ? "Loaded" : "ReloadFailedUsingLastKnownGood",
+            new DateTimeOffset(2026, 3, 16, 14, 58, 0, TimeSpan.Zero),
+            RunningCount: 2,
+            RetryingCount: 1,
+            InputTokens: 100,
+            OutputTokens: 40,
+            TotalTokens: 140,
+            SecondsRunning: 300d,
+            activeSessions ??
+            [
+                new DashboardActiveSessionSnapshot(
+                    "ABC-1",
+                    "In Progress",
+                    "thread-1-turn-1",
+                    3,
+                    "turn_completed",
+                    "Applied changes",
+                    new DateTimeOffset(2026, 3, 16, 14, 55, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 16, 14, 59, 0, TimeSpan.Zero),
+                    140)
+            ],
+            retryQueue ??
+            [
+                new DashboardRetrySnapshot(
+                    "ABC-2",
+                    2,
+                    new DateTimeOffset(2026, 3, 16, 15, 1, 0, TimeSpan.Zero),
+                    "retry later")
+            ],
+            recentAttempts ??
+            [
+                new DashboardRecentAttemptSnapshot(
+                    "ABC-3",
+                    1,
+                    "Retrying",
+                    new DateTimeOffset(2026, 3, 16, 14, 58, 30, TimeSpan.Zero),
+                    22.5d,
+                    "Tracker request failed",
+                    "thread-3-turn-2")
+            ],
+            lastError,
+            workflowLastError);
     }
 }


### PR DESCRIPTION
#### Context
- Implements story `#83` from `dotnet/IMPLEMENTATIONPLAN_UI.github.md`.
- Replaces the remaining monolithic dashboard rendering with typed Flowbite panel components and page-owned refresh behavior.
- Closes #83.

#### TL;DR
The dashboard homepage now renders through focused `Components/Dashboard/*` Flowbite components, shows skeleton placeholders on first paint, auto-refreshes every 5 seconds, and keeps both route-level and panel-level error isolation intact.

#### Summary
- add `HealthSummaryCards`, `ActiveSessionsPanel`, `RetryQueuePanel`, and `RecentAttemptsPanel` plus shared dashboard formatting helpers
- rebuild `DashboardShellContent` around first-load skeletons, periodic refresh, and panel `ErrorBoundary` fallbacks while preserving the route-level fallback in `DashboardPage`
- extend dashboard integration and bUnit coverage for full-shell rendering, empty states, summary alerts, and loading behavior

#### Alternatives
- Keep all dashboard rendering in a single page component. Rejected because it makes targeted testing and panel-level fault isolation harder.
- Catch dashboard initialization failures inside the route component. Rejected because the route-level `ErrorBoundary` does not catch its own lifecycle failures cleanly.

#### Test Plan
- `dotnet build -c Release dotnet/src/Symphony.Host/Symphony.Host.csproj --no-restore`
- `dotnet test -c Release dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~DashboardPageIntegrationTests|FullyQualifiedName~DashboardPageComponentTests"`
- `dotnet build -c Release dotnet/Symphony.sln --no-restore`
- `dotnet test -c Release --no-build dotnet/Symphony.sln`
- `dotnet format --verify-no-changes dotnet/Symphony.sln --no-restore`