### PR TITLE
feat(host): add session explorer page

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -301,6 +301,8 @@ The dashboard shell is implemented as an interactive-server Blazor page. It is a
 surface only: if dashboard rendering fails, the orchestrator and JSON API continue running.
 - The dashboard now includes active-session, retry-queue, and recent-attempt panels so operators
   can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
+- The session explorer is now available at `/sessions`, with All / Active / Ended filters and deep
+  links into `/sessions/{identifier}` for individual run inspection.
 - The dashboard health cards now expose last poll tick, last successful poll age, and workflow load
   status so degraded polling or workflow-reload fallback is visible without reading logs.
 - The sidebar footer includes a theme switcher for the built-in `dark-yellow`, `dark-blue`, and

--- a/dotnet/src/Symphony.Host/Components/Pages/SessionListPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionListPage.razor
@@ -1,0 +1,219 @@
+@page "/sessions"
+@implements IAsyncDisposable
+@using System.Globalization
+@using Symphony.Host.Components.Sessions
+@inject IDashboardStateService DashboardStateService
+@inject ISessionActivityStore SessionActivityStore
+
+<main class="dashboard-page flex flex-col gap-6">
+    <section class="hero">
+        <p class="eyebrow">Symphony</p>
+        <h1>Session Explorer</h1>
+        <p class="lede">
+            Browse all active and ended sessions from the current application run without leaving the
+            operator shell.
+        </p>
+    </section>
+
+    @if (_isLoading)
+    {
+        <Card Slots="@ShellCardSlots" data-testid="session-list-skeleton">
+            <Skeleton Variant="SkeletonVariant.Text" Lines="1" AriaLabel="Loading session filters" />
+            <Skeleton Variant="SkeletonVariant.Text" Lines="1" Width="w-72" />
+            <Skeleton Variant="SkeletonVariant.Card" Width="w-full" Height="h-64" />
+        </Card>
+    }
+    else
+    {
+        @if (!string.IsNullOrWhiteSpace(_refreshErrorMessage))
+        {
+            <Alert Color="AlertColor.Warning"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="Refresh warning:"
+                   Text="@_refreshErrorMessage" />
+        }
+
+        <Card Slots="@ShellCardSlots" data-testid="session-list-page">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Session List</p>
+                    <h2 class="mt-2 text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Current run inventory</h2>
+                    <p class="mt-2 text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                        Filter active and ended sessions, then jump into `/sessions/{identifier}` for the full timeline.
+                    </p>
+                </div>
+                <div class="text-sm text-[color:var(--color-on-surface-secondary)]">
+                    Refreshed @(_generatedAt is null ? "never" : _generatedAt.Value.ToUniversalTime().ToString("HH:mm:ss 'UTC'", CultureInfo.InvariantCulture))
+                </div>
+            </div>
+
+            <Tabs Variant="TabVariant.Underline"
+                  ActiveIndex="@_activeTabIndex"
+                  ActiveIndexChanged="@HandleActiveTabChanged">
+                <TabListContent>
+                    <Tab Index="0">All (@_allSessions.Count)</Tab>
+                    <Tab Index="1">Active (@_activeSessions.Count)</Tab>
+                    <Tab Index="2">Ended (@_endedSessions.Count)</Tab>
+                </TabListContent>
+                <TabPanelsContent>
+                    <TabPanel Index="0">
+                        <SessionListTable Sessions="_allSessions" />
+                    </TabPanel>
+                    <TabPanel Index="1">
+                        <SessionListTable Sessions="_activeSessions" />
+                    </TabPanel>
+                    <TabPanel Index="2">
+                        <SessionListTable Sessions="_endedSessions" />
+                    </TabPanel>
+                </TabPanelsContent>
+            </Tabs>
+        </Card>
+    }
+</main>
+
+@code {
+    private static readonly CardSlots ShellCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-xl)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex flex-col gap-6 p-6"
+    };
+
+    private PeriodicTimer? _refreshTimer;
+    private CancellationTokenSource? _refreshCancellationTokenSource;
+    private Task? _refreshLoopTask;
+    private bool _isLoading = true;
+    private int _activeTabIndex;
+    private DateTimeOffset? _generatedAt;
+    private string? _refreshErrorMessage;
+    private IReadOnlyList<SessionListRowViewModel> _allSessions = [];
+    private IReadOnlyList<SessionListRowViewModel> _activeSessions = [];
+    private IReadOnlyList<SessionListRowViewModel> _endedSessions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshAsync();
+
+        _refreshCancellationTokenSource = new CancellationTokenSource();
+        _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+        _refreshLoopTask = RunRefreshLoopAsync(_refreshCancellationTokenSource.Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_refreshCancellationTokenSource is not null)
+        {
+            await _refreshCancellationTokenSource.CancelAsync();
+            _refreshCancellationTokenSource.Dispose();
+            _refreshCancellationTokenSource = null;
+        }
+
+        _refreshTimer?.Dispose();
+        _refreshTimer = null;
+
+        if (_refreshLoopTask is not null)
+        {
+            try
+            {
+                await _refreshLoopTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private async Task RunRefreshLoopAsync(CancellationToken cancellationToken)
+    {
+        if (_refreshTimer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (await _refreshTimer.WaitForNextTickAsync(cancellationToken))
+            {
+                try
+                {
+                    await RefreshAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    _refreshErrorMessage = exception.Message;
+                }
+
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private async Task HandleActiveTabChanged(int index)
+    {
+        _activeTabIndex = index;
+        await Task.CompletedTask;
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await DashboardStateService.GetSnapshotAsync(cancellationToken);
+        var activeSessionsByIssue = snapshot.ActiveSessions
+            .ToDictionary(session => session.IssueIdentifier, StringComparer.OrdinalIgnoreCase);
+
+        var allSessions = SessionActivityStore.GetAllSessions()
+            .Select(session => BuildRow(session, activeSessionsByIssue, snapshot.GeneratedAt))
+            .ToArray();
+
+        _generatedAt = snapshot.GeneratedAt;
+        _allSessions = allSessions;
+        _activeSessions = allSessions.Where(session => session.IsActive).ToArray();
+        _endedSessions = allSessions.Where(session => !session.IsActive).ToArray();
+        _refreshErrorMessage = null;
+        _isLoading = false;
+    }
+
+    private static SessionListRowViewModel BuildRow(
+        SessionRecord session,
+        IReadOnlyDictionary<string, DashboardActiveSessionSnapshot> activeSessionsByIssue,
+        DateTimeOffset generatedAt)
+    {
+        if (activeSessionsByIssue.TryGetValue(session.IssueIdentifier, out var activeSession))
+        {
+            return new SessionListRowViewModel(
+                session.IssueIdentifier,
+                session.IssueUrl,
+                true,
+                activeSession.State,
+                session.StartedAt,
+                null,
+                Math.Max((generatedAt - session.StartedAt).TotalSeconds, 0d),
+                string.IsNullOrWhiteSpace(activeSession.LastEvent)
+                    ? "Awaiting first event"
+                    : activeSession.LastEvent,
+                string.IsNullOrWhiteSpace(activeSession.LastMessage)
+                    ? $"Session {(activeSession.SessionId ?? "pending")} / turns {activeSession.TurnCount}"
+                    : activeSession.LastMessage);
+        }
+
+        var endedAt = session.EndedAt ?? generatedAt;
+        return new SessionListRowViewModel(
+            session.IssueIdentifier,
+            session.IssueUrl,
+            false,
+            session.FinalOutcome ?? "Ended",
+            session.StartedAt,
+            session.EndedAt,
+            Math.Max((endedAt - session.StartedAt).TotalSeconds, 0d),
+            string.IsNullOrWhiteSpace(session.FinalError)
+                ? "Session completed and is available for inspection."
+                : session.FinalError,
+            session.FinalOutcome is null ? null : $"Final outcome: {session.FinalOutcome}");
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionListDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionListDisplay.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using Flowbite.Components;
+
+namespace Symphony.Host.Components.Sessions;
+
+internal static class SessionListDisplay
+{
+    internal static string FormatTimestamp(DateTimeOffset timestamp)
+    {
+        return timestamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+    }
+
+    internal static string FormatDuration(double durationSeconds)
+    {
+        return durationSeconds >= 60d
+            ? $"{durationSeconds / 60d:0.#} min"
+            : $"{durationSeconds:0.#} s";
+    }
+
+    internal static string GetDurationLabel(SessionListRowViewModel session)
+    {
+        var duration = FormatDuration(session.DurationSeconds);
+        return session.IsActive ? $"{duration} live" : duration;
+    }
+
+    internal static Badge.BadgeColor GetStatusColor(SessionListRowViewModel session)
+    {
+        return session.Status.ToLowerInvariant() switch
+        {
+            "in progress" => Badge.BadgeColor.Info,
+            "streaming" => Badge.BadgeColor.Info,
+            "finishing" => Badge.BadgeColor.Info,
+            "retrying" => Badge.BadgeColor.Warning,
+            "succeeded" => Badge.BadgeColor.Success,
+            "failed" => Badge.BadgeColor.Failure,
+            "timedout" => Badge.BadgeColor.Failure,
+            "stalled" => Badge.BadgeColor.Failure,
+            "canceled" => Badge.BadgeColor.Gray,
+            _ when session.IsActive => Badge.BadgeColor.Info,
+            _ => Badge.BadgeColor.Gray
+        };
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionListRowViewModel.cs
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionListRowViewModel.cs
@@ -1,0 +1,12 @@
+namespace Symphony.Host.Components.Sessions;
+
+public sealed record SessionListRowViewModel(
+    string IssueIdentifier,
+    string? IssueUrl,
+    bool IsActive,
+    string Status,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? EndedAt,
+    double DurationSeconds,
+    string Summary,
+    string? Detail);

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionListTable.razor
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionListTable.razor
@@ -1,0 +1,81 @@
+@if (Sessions.Count == 0)
+{
+    <Card Slots="@EmptyStateCardSlots" data-testid="session-list-empty-state">
+        <EmptyState Title="No sessions in this view"
+                    Description="Change the filter or wait for more agent activity to populate the session explorer." />
+    </Card>
+}
+else
+{
+    <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] p-2 shadow-[var(--shell-shadow)]"
+         data-testid="session-list-table">
+        <div class="overflow-x-auto">
+            <Table Striped="true" Hoverable="true" Responsive="true">
+                <TableHead>
+                    <TableRow>
+                        <TableHeadCell>Issue</TableHeadCell>
+                        <TableHeadCell>Status</TableHeadCell>
+                        <TableHeadCell>Started</TableHeadCell>
+                        <TableHeadCell>Ended / Duration</TableHeadCell>
+                        <TableHeadCell>Outcome / last event</TableHeadCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody class="divide-y">
+                    @foreach (var session in Sessions)
+                    {
+                        <TableRow class="bg-[color:var(--color-surface-raised)]">
+                            <TableCell IsFirstColumn="true">
+                                <div class="flex flex-col gap-1">
+                                    <a class="font-semibold text-[color:var(--color-on-surface-primary)] underline decoration-[color:var(--color-primary-DEFAULT)] decoration-2 underline-offset-4"
+                                       href="/sessions/@Uri.EscapeDataString(session.IssueIdentifier)">
+                                        @session.IssueIdentifier
+                                    </a>
+                                    @if (!string.IsNullOrWhiteSpace(session.IssueUrl))
+                                    {
+                                        <a class="text-xs font-medium text-[color:var(--color-on-surface-secondary)] hover:text-[color:var(--color-primary-DEFAULT)]"
+                                           href="@session.IssueUrl">
+                                            Tracker issue
+                                        </a>
+                                    }
+                                </div>
+                            </TableCell>
+                            <TableCell>
+                                <Badge Color="@SessionListDisplay.GetStatusColor(session)">
+                                    @session.Status
+                                </Badge>
+                            </TableCell>
+                            <TableCell class="whitespace-nowrap text-sm text-[color:var(--color-on-surface-secondary)]">
+                                @SessionListDisplay.FormatTimestamp(session.StartedAt)
+                            </TableCell>
+                            <TableCell class="text-sm text-[color:var(--color-on-surface-secondary)]">
+                                <div class="font-medium text-[color:var(--color-on-surface-primary)]">
+                                    @(session.EndedAt is null ? "Live" : SessionListDisplay.FormatTimestamp(session.EndedAt.Value))
+                                </div>
+                                <div>@SessionListDisplay.GetDurationLabel(session)</div>
+                            </TableCell>
+                            <TableCell class="text-sm text-[color:var(--color-on-surface-secondary)]">
+                                <div class="font-medium text-[color:var(--color-on-surface-primary)]">@session.Summary</div>
+                                @if (!string.IsNullOrWhiteSpace(session.Detail))
+                                {
+                                    <div class="mt-1">@session.Detail</div>
+                                }
+                            </TableCell>
+                        </TableRow>
+                    }
+                </TableBody>
+            </Table>
+        </div>
+    </div>
+}
+
+@code {
+    private static readonly CardSlots EmptyStateCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "p-6"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required IReadOnlyList<SessionListRowViewModel> Sessions { get; set; }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionListPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionListPageIntegrationTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Net.Http.Json;
+using Flowbite.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
+using Symphony.Application.Runtime;
+using Symphony.Host.Api;
+using Symphony.Host.Components;
+using Symphony.Host.Dashboard;
+using Symphony.Host.Theming;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SessionListPageIntegrationTests
+{
+    [Fact]
+    public async Task Sessions_page_renders_active_and_ended_session_rows()
+    {
+        var store = CreateStore(
+            new DashboardSnapshot(
+                new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero),
+                "Healthy",
+                "Single-process in-memory",
+                new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 3, 20, 7, 59, 40, TimeSpan.Zero),
+                20d,
+                "Loaded",
+                new DateTimeOffset(2026, 3, 20, 7, 55, 0, TimeSpan.Zero),
+                RunningCount: 1,
+                RetryingCount: 0,
+                InputTokens: 80,
+                OutputTokens: 30,
+                TotalTokens: 110,
+                SecondsRunning: 420d,
+                ActiveSessions:
+                [
+                    new DashboardActiveSessionSnapshot(
+                        "ABC-1",
+                        "In Progress",
+                        "thread-1-turn-2",
+                        2,
+                        "turn_completed",
+                        "Applied changes",
+                        new DateTimeOffset(2026, 3, 20, 7, 50, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 3, 20, 7, 59, 30, TimeSpan.Zero),
+                        110)
+                ],
+                RetryQueue: [],
+                RecentAttempts: [],
+                LastError: null,
+                WorkflowLastError: null));
+        using var app = await StartSessionListApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot()));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/sessions");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Session Explorer", html, StringComparison.Ordinal);
+        Assert.Contains("All (2)", html, StringComparison.Ordinal);
+        Assert.Contains("Active (1)", html, StringComparison.Ordinal);
+        Assert.Contains("Ended (1)", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-list-table\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"/sessions/ABC-1\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"/sessions/ABC-2\"", html, StringComparison.Ordinal);
+        Assert.Contains("In Progress", html, StringComparison.Ordinal);
+        Assert.Contains("Succeeded", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Sessions_page_renders_empty_state_when_store_is_empty()
+    {
+        var store = CreateStore(CreateSnapshot(activeSessions: []), includeEndedSession: false);
+        using var app = await StartSessionListApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot(activeSessions: [])));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/sessions");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("data-testid=\"session-list-empty-state\"", html, StringComparison.Ordinal);
+        Assert.Contains("No sessions in this view", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Sessions_page_keeps_api_routes_available_when_rendering_succeeds()
+    {
+        var store = CreateStore(CreateSnapshot());
+        using var app = await StartSessionListApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot()));
+        var client = CreateHttpClient(app);
+
+        var pageResponse = await client.GetAsync("/sessions");
+        var apiResponse = await client.PostAsJsonAsync("/api/v1/refresh", new { });
+
+        Assert.Equal(HttpStatusCode.OK, pageResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, apiResponse.StatusCode);
+    }
+
+    private static SessionActivityStore CreateStore(DashboardSnapshot snapshot, bool includeEndedSession = true)
+    {
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+
+        foreach (var activeSession in snapshot.ActiveSessions)
+        {
+            store.RecordSessionStart(activeSession.IssueIdentifier, activeSession.StartedAt, $"https://github.com/AGiorgetti/my-symphony/issues/{activeSession.IssueIdentifier}");
+        }
+
+        if (includeEndedSession)
+        {
+            store.RecordSessionStart("ABC-2", new DateTimeOffset(2026, 3, 20, 7, 15, 0, TimeSpan.Zero), "https://github.com/AGiorgetti/my-symphony/issues/ABC-2");
+            store.RecordSessionEnd("ABC-2", new DateTimeOffset(2026, 3, 20, 7, 35, 0, TimeSpan.Zero), "Succeeded");
+        }
+
+        return store;
+    }
+
+    private static DashboardSnapshot CreateSnapshot(IReadOnlyList<DashboardActiveSessionSnapshot>? activeSessions = null)
+    {
+        return new DashboardSnapshot(
+            new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero),
+            "Healthy",
+            "Single-process in-memory",
+            new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 20, 7, 59, 40, TimeSpan.Zero),
+            20d,
+            "Loaded",
+            new DateTimeOffset(2026, 3, 20, 7, 55, 0, TimeSpan.Zero),
+            RunningCount: activeSessions?.Count ?? 1,
+            RetryingCount: 0,
+            InputTokens: 80,
+            OutputTokens: 30,
+            TotalTokens: 110,
+            SecondsRunning: 420d,
+            activeSessions ??
+            [
+                new DashboardActiveSessionSnapshot(
+                    "ABC-1",
+                    "In Progress",
+                    "thread-1-turn-2",
+                    2,
+                    "turn_completed",
+                    "Applied changes",
+                    new DateTimeOffset(2026, 3, 20, 7, 50, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 20, 7, 59, 30, TimeSpan.Zero),
+                    110)
+            ],
+            RetryQueue: [],
+            RecentAttempts: [],
+            LastError: null,
+            WorkflowLastError: null);
+    }
+
+    private static HttpClient CreateHttpClient(WebApplication app)
+    {
+        var server = app.Services.GetRequiredService<IServer>();
+        var addresses = server.Features.Get<IServerAddressesFeature>()
+            ?? throw new InvalidOperationException("Test server addresses are unavailable.");
+        var address = Assert.Single(addresses.Addresses);
+
+        return new HttpClient
+        {
+            BaseAddress = new Uri(address)
+        };
+    }
+
+    private static async Task<WebApplication> StartSessionListApplicationAsync(
+        ISessionActivityStore sessionActivityStore,
+        IDashboardStateService dashboardStateService)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+        builder.Services.AddFlowbite();
+        builder.Services.AddSingleton<IOrchestratorRuntimeService>(new StubRuntimeService());
+        builder.Services.AddSingleton(sessionActivityStore);
+        builder.Services.AddSingleton<ISessionActivityStore>(sessionActivityStore);
+        builder.Services.AddSingleton<IDashboardStateService>(dashboardStateService);
+        builder.Services.AddScoped<IThemeService, ThemeService>();
+        builder.Services.AddScoped<ThemeService>();
+        builder.Services.AddSingleton<IWorkflowOptionsProvider>(
+            new StaticWorkflowOptionsProvider(
+                new WorkflowServiceOptions(
+                    new WorkflowTrackerOptions(
+                        "github",
+                        "https://api.github.com",
+                        "token",
+                        null,
+                        "owner/repo",
+                        null,
+                        null,
+                        ["Todo"],
+                        ["Done"]),
+                    new WorkflowPollingOptions(1_000),
+                    new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                    new WorkflowHookOptions(
+                        null,
+                        null,
+                        null,
+                        null,
+                        60_000),
+                    new WorkflowAgentOptions(
+                        1,
+                        20,
+                        300_000,
+                        new Dictionary<string, int>(StringComparer.Ordinal)),
+                    new WorkflowCodexOptions(
+                        "codex app-server",
+                        null,
+                        null,
+                        null,
+                        3_600_000,
+                        5_000,
+                        300_000))));
+
+        var app = builder.Build();
+        app.UseStaticFiles();
+        app.UseAntiforgery();
+        app.MapSymphonyApi();
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class StaticDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
+    {
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class StubRuntimeService : IOrchestratorRuntimeService
+    {
+        public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(
+                new OrchestratorStateSnapshot(
+                    DateTimeOffset.UtcNow,
+                    Array.Empty<RunningIssueSnapshot>(),
+                    Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                    new CodexTotalsSnapshot(0, 0, 0, 0d),
+                    RateLimits: null));
+        }
+
+        public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<OrchestratorIssueSnapshot?>(null);
+        }
+
+        public PollingRefreshReceipt RequestRefresh()
+        {
+            return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionListTableTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionListTableTests.cs
@@ -1,0 +1,113 @@
+using Bunit;
+using Flowbite.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Host.Components.Pages;
+using Symphony.Host.Components.Sessions;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SessionListTableTests : BunitContext
+{
+    public SessionListTableTests()
+    {
+        Services.AddFlowbite();
+    }
+
+    [Fact]
+    public void SessionListTable_renders_empty_state_for_empty_results()
+    {
+        var cut = Render<SessionListTable>(parameters => parameters.Add(component => component.Sessions, Array.Empty<SessionListRowViewModel>()));
+
+        Assert.Contains("data-testid=\"session-list-empty-state\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("No sessions in this view", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionListPage_switches_between_all_active_and_ended_tabs()
+    {
+        var store = new SessionActivityStore(Microsoft.Extensions.Logging.Abstractions.NullLogger<SessionActivityStore>.Instance);
+        store.RecordSessionStart("ABC-1", new DateTimeOffset(2026, 3, 20, 7, 50, 0, TimeSpan.Zero));
+        store.RecordSessionStart("ABC-2", new DateTimeOffset(2026, 3, 20, 7, 10, 0, TimeSpan.Zero));
+        store.RecordSessionEnd("ABC-2", new DateTimeOffset(2026, 3, 20, 7, 30, 0, TimeSpan.Zero), "Succeeded");
+
+        Services.AddSingleton<ISessionActivityStore>(store);
+        Services.AddSingleton<IDashboardStateService>(
+            new StaticDashboardStateService(
+                new DashboardSnapshot(
+                    new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero),
+                    "Healthy",
+                    "Single-process in-memory",
+                    new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 20, 7, 59, 40, TimeSpan.Zero),
+                    20d,
+                    "Loaded",
+                    new DateTimeOffset(2026, 3, 20, 7, 55, 0, TimeSpan.Zero),
+                    RunningCount: 1,
+                    RetryingCount: 0,
+                    InputTokens: 80,
+                    OutputTokens: 30,
+                    TotalTokens: 110,
+                    SecondsRunning: 420d,
+                    ActiveSessions:
+                    [
+                        new DashboardActiveSessionSnapshot(
+                            "ABC-1",
+                            "In Progress",
+                            "thread-1-turn-2",
+                            2,
+                            "turn_completed",
+                            "Applied changes",
+                            new DateTimeOffset(2026, 3, 20, 7, 50, 0, TimeSpan.Zero),
+                            new DateTimeOffset(2026, 3, 20, 7, 59, 30, TimeSpan.Zero),
+                            110)
+                    ],
+                    RetryQueue: [],
+                    RecentAttempts: [],
+                    LastError: null,
+                    WorkflowLastError: null)));
+
+        var cut = Render<SessionListPage>();
+
+        Assert.Contains("ABC-1", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("ABC-2", cut.Markup, StringComparison.Ordinal);
+        Assert.Equal("0", cut.Find("#tab-0").GetAttribute("tabindex"));
+        Assert.Equal("-1", cut.Find("#tab-1").GetAttribute("tabindex"));
+        Assert.Equal("-1", cut.Find("#tab-2").GetAttribute("tabindex"));
+        Assert.Equal("display: block", cut.Find("#tabpanel-0").GetAttribute("style"));
+        Assert.Equal("display: none", cut.Find("#tabpanel-1").GetAttribute("style"));
+        Assert.Equal("display: none", cut.Find("#tabpanel-2").GetAttribute("style"));
+
+        cut.FindAll("button").Single(button => button.TextContent.Contains("Active", StringComparison.Ordinal)).Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("-1", cut.Find("#tab-0").GetAttribute("tabindex"));
+            Assert.Equal("0", cut.Find("#tab-1").GetAttribute("tabindex"));
+            Assert.Equal("-1", cut.Find("#tab-2").GetAttribute("tabindex"));
+            Assert.Equal("display: none", cut.Find("#tabpanel-0").GetAttribute("style"));
+            Assert.Equal("display: block", cut.Find("#tabpanel-1").GetAttribute("style"));
+            Assert.Equal("display: none", cut.Find("#tabpanel-2").GetAttribute("style"));
+        });
+
+        cut.FindAll("button").Single(button => button.TextContent.Contains("Ended", StringComparison.Ordinal)).Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("-1", cut.Find("#tab-0").GetAttribute("tabindex"));
+            Assert.Equal("-1", cut.Find("#tab-1").GetAttribute("tabindex"));
+            Assert.Equal("0", cut.Find("#tab-2").GetAttribute("tabindex"));
+            Assert.Equal("display: none", cut.Find("#tabpanel-0").GetAttribute("style"));
+            Assert.Equal("display: none", cut.Find("#tabpanel-1").GetAttribute("style"));
+            Assert.Equal("display: block", cut.Find("#tabpanel-2").GetAttribute("style"));
+        });
+    }
+
+    private sealed class StaticDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
+    {
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(snapshot);
+        }
+    }
+}


### PR DESCRIPTION
#### Context

Add the first dedicated session explorer page so operators can browse active and ended runs without relying on the dashboard cards. Closes #85.

#### TL;DR

*Add a /sessions explorer page with Flowbite tabs, tables, and coverage for active and ended runs.*

#### Summary

- Add `/sessions` with All, Active, and Ended tabs backed by the activity store
- Render session rows through a reusable Flowbite table with status badges and deep links
- Add integration and bUnit coverage for page rendering, empty state, and tab switching

#### Alternatives

- Keep the experience inside the dashboard page, but that leaves session browsing cramped and harder to extend

#### Test Plan

- [x] `dotnet format --verify-no-changes dotnet/Symphony.sln --no-restore && dotnet build -c Release dotnet/Symphony.sln --no-restore && dotnet test -c Release --no-build dotnet/Symphony.sln`
- [x] `dotnet test -c Release dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~SessionListPageIntegrationTests|FullyQualifiedName~SessionListTableTests"`
