### PR TITLE
feat(host): add session detail page

### DIFF
--- a/SPEC_UI.md
+++ b/SPEC_UI.md
@@ -213,6 +213,7 @@ A session detail view should provide enough information for an operator to under
 The detail view should include:
 
 - a clear session summary
+- breadcrumb navigation back to the dashboard and session list
 - the related issue or work item information
 - session status and outcome
 - timestamps relevant to the session lifecycle

--- a/dotnet/ARCHITECTURE_UI.md
+++ b/dotnet/ARCHITECTURE_UI.md
@@ -368,6 +368,9 @@ Sections:
 4. **Error panel** — `Alert Color="AlertColor.Failure"` when `FinalError` or any `Error`
    activity exists.
 
+Implementation note: EU7-S1 delivers the breadcrumb, session header card, and activity
+timeline first. The metadata/details tab and active-session auto-refresh follow in EU7-S2.
+
 Back navigation uses `Breadcrumb`: Home → Sessions → {Identifier}.
 
 Auto-refresh: 2 seconds for active sessions; no timer for ended sessions (render once).

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -302,7 +302,8 @@ surface only: if dashboard rendering fails, the orchestrator and JSON API contin
 - The dashboard now includes active-session, retry-queue, and recent-attempt panels so operators
   can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
 - The session explorer is now available at `/sessions`, with All / Active / Ended filters and deep
-  links into `/sessions/{identifier}` for individual run inspection.
+  links into `/sessions/{identifier}` for individual run inspection, breadcrumb navigation, and a
+  chronological activity timeline.
 - The dashboard health cards now expose last poll tick, last successful poll age, and workflow load
   status so degraded polling or workflow-reload fallback is visible without reading logs.
 - The sidebar footer includes a theme switcher for the built-in `dark-yellow`, `dark-blue`, and

--- a/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
@@ -1,0 +1,151 @@
+@page "/sessions/{Identifier}"
+@using Symphony.Host.Components.SessionDetail
+@inject ISessionActivityStore SessionActivityStore
+
+<main class="dashboard-page flex flex-col gap-6">
+    <div data-testid="session-detail-breadcrumb">
+        <Breadcrumb>
+            <BreadcrumbItem Href="/">Home</BreadcrumbItem>
+            <BreadcrumbItem Href="/sessions">Sessions</BreadcrumbItem>
+            <BreadcrumbItem>@_requestedIdentifier</BreadcrumbItem>
+        </Breadcrumb>
+    </div>
+
+    @if (_isLoading)
+    {
+        <Card Slots="@ShellCardSlots" data-testid="session-detail-skeleton">
+            <Skeleton Variant="SkeletonVariant.Text" Lines="1" Width="w-40" />
+            <Skeleton Variant="SkeletonVariant.Text" Lines="1" Width="w-72" />
+            <Skeleton Variant="SkeletonVariant.Card" Width="w-full" Height="h-80" />
+        </Card>
+    }
+    else if (_header is null || _timeline is null)
+    {
+        <div data-testid="session-detail-not-found">
+            <Alert Color="AlertColor.Warning"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="Session not found:"
+                   Text="@($"No session with identifier '{_requestedIdentifier}' is available in the current application run.")" />
+        </div>
+    }
+    else
+    {
+        <SessionHeaderCard Session="_header" />
+        <SessionActivityTimeline Timeline="_timeline" />
+    }
+</main>
+
+@code {
+    private static readonly CardSlots ShellCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-xl)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex flex-col gap-6 p-6"
+    };
+
+    [Parameter]
+    public string Identifier { get; set; } = string.Empty;
+
+    private bool _isLoading = true;
+    private string _requestedIdentifier = string.Empty;
+    private SessionHeaderDisplayModel? _header;
+    private SessionActivityTimelineModel? _timeline;
+
+    protected override Task OnParametersSetAsync()
+    {
+        _requestedIdentifier = Identifier?.Trim() ?? string.Empty;
+        _isLoading = false;
+
+        var session = string.IsNullOrWhiteSpace(_requestedIdentifier)
+            ? null
+            : SessionActivityStore.GetSession(_requestedIdentifier);
+
+        if (session is null)
+        {
+            _header = null;
+            _timeline = null;
+            return Task.CompletedTask;
+        }
+
+        _header = BuildHeader(session);
+        _timeline = BuildTimeline(session, SessionActivityStore.GetActivities(session.IssueIdentifier));
+        return Task.CompletedTask;
+    }
+
+    private static SessionHeaderDisplayModel BuildHeader(SessionRecord session)
+    {
+        var statusText = session.IsActive ? "Active" : session.FinalOutcome ?? "Ended";
+        var parsedStatus = SessionDetailDisplay.TryParseStatus(statusText);
+        var statusColor = parsedStatus is null
+            ? SessionDetailDisplay.GetFallbackStatusColor(statusText, session.IsActive)
+            : Badge.BadgeColor.Primary;
+
+        return new SessionHeaderDisplayModel(
+            session.IssueIdentifier,
+            session.IssueUrl,
+            session.IsActive,
+            statusText,
+            parsedStatus,
+            statusColor,
+            session.StartedAt,
+            session.EndedAt);
+    }
+
+    private static SessionActivityTimelineModel BuildTimeline(
+        SessionRecord session,
+        IReadOnlyList<SessionActivityEntry> activities)
+    {
+        var orderedActivities = activities
+            .OrderBy(activity => activity.Timestamp)
+            .Select(
+                activity => new SessionActivityTimelineEntryModel(
+                    activity.Kind,
+                    activity.Timestamp,
+                    activity.Title,
+                    activity.Detail,
+                    SessionDetailDisplay.GetTimelineColor(activity)))
+            .ToArray();
+
+        var latestWarning = activities
+            .Where(activity => activity.Kind == SessionActivityKind.Warning)
+            .OrderByDescending(activity => activity.Timestamp)
+            .FirstOrDefault();
+        var latestError = activities
+            .Where(activity => activity.Kind == SessionActivityKind.Error)
+            .OrderByDescending(activity => activity.Timestamp)
+            .FirstOrDefault();
+
+        SessionActivityTimelineAlertModel? latestAttentionAlert = null;
+        if (latestWarning is not null && latestError is null)
+        {
+            latestAttentionAlert = new SessionActivityTimelineAlertModel(
+                AlertColor.Warning,
+                "Latest warning:",
+                ComposeAlertMessage(latestWarning));
+        }
+
+        SessionActivityTimelineAlertModel? failureAlert = null;
+        var failureMessage = !string.IsNullOrWhiteSpace(session.FinalError)
+            ? session.FinalError
+            : latestError is null
+                ? null
+                : ComposeAlertMessage(latestError);
+
+        if (!string.IsNullOrWhiteSpace(failureMessage))
+        {
+            failureAlert = new SessionActivityTimelineAlertModel(
+                AlertColor.Failure,
+                "Failure detail:",
+                failureMessage);
+        }
+
+        return new SessionActivityTimelineModel(orderedActivities, latestAttentionAlert, failureAlert);
+    }
+
+    private static string ComposeAlertMessage(SessionActivityEntry entry)
+    {
+        return string.IsNullOrWhiteSpace(entry.Detail)
+            ? entry.Title
+            : $"{entry.Title} - {entry.Detail}";
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
@@ -1,0 +1,79 @@
+<div data-testid="session-detail-timeline">
+<Card Slots="@TimelineCardSlots">
+    <div class="space-y-2">
+        <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Timeline</p>
+        <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Session activity</h2>
+        <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+            Lifecycle milestones, agent messages, warnings, and outcomes in chronological order.
+        </p>
+    </div>
+
+    @if (Timeline.LatestAttentionAlert is not null)
+    {
+        <div data-testid="session-detail-latest-attention-alert">
+            <Alert Color="@Timeline.LatestAttentionAlert.Color"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="@Timeline.LatestAttentionAlert.Emphasis"
+                   Text="@Timeline.LatestAttentionAlert.Message" />
+        </div>
+    }
+
+    @if (Timeline.FailureAlert is not null)
+    {
+        <div data-testid="session-detail-failure-alert">
+            <Alert Color="@Timeline.FailureAlert.Color"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="@Timeline.FailureAlert.Emphasis"
+                   Text="@Timeline.FailureAlert.Message" />
+        </div>
+    }
+
+    @if (Timeline.Entries.Count == 0)
+    {
+        <EmptyState Title="No session activity recorded"
+                    Description="The session exists, but no timeline entries are available yet." />
+    }
+    else
+    {
+        <Timeline Order="TimelineOrder.Vertical">
+            @for (var index = 0; index < Timeline.Entries.Count; index++)
+            {
+                var entry = Timeline.Entries[index];
+                <TimelineItem Title="@entry.Title"
+                              Date="@SessionDetailDisplay.FormatTimestamp(entry.Timestamp)"
+                              Color="@entry.Color"
+                              IsLast="@(index == Timeline.Entries.Count - 1)"
+                              DatePrefix="Logged at">
+                    <ChildContent>
+                        <div class="space-y-3" data-testid="session-detail-timeline-entry">
+                            <div class="inline-flex">
+                                <Badge Color="@SessionDetailDisplay.GetKindBadgeColor(entry.Kind)">
+                                    @SessionDetailDisplay.GetKindLabel(entry.Kind)
+                                </Badge>
+                            </div>
+                            @if (!string.IsNullOrWhiteSpace(entry.Detail))
+                            {
+                                <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">@entry.Detail</p>
+                            }
+                        </div>
+                    </ChildContent>
+                </TimelineItem>
+            }
+        </Timeline>
+    }
+</Card>
+</div>
+
+@code {
+    private static readonly CardSlots TimelineCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-xl)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex flex-col gap-6 p-6"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required SessionActivityTimelineModel Timeline { get; set; }
+}

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineAlertModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineAlertModel.cs
@@ -1,0 +1,8 @@
+using Flowbite.Components;
+
+namespace Symphony.Host.Components.SessionDetail;
+
+public sealed record SessionActivityTimelineAlertModel(
+    AlertColor Color,
+    string Emphasis,
+    string Message);

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineEntryModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineEntryModel.cs
@@ -1,0 +1,11 @@
+using Flowbite.Components;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.Components.SessionDetail;
+
+public sealed record SessionActivityTimelineEntryModel(
+    SessionActivityKind Kind,
+    DateTimeOffset Timestamp,
+    string Title,
+    string? Detail,
+    TimelineColor Color);

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineModel.cs
@@ -1,0 +1,6 @@
+namespace Symphony.Host.Components.SessionDetail;
+
+public sealed record SessionActivityTimelineModel(
+    IReadOnlyList<SessionActivityTimelineEntryModel> Entries,
+    SessionActivityTimelineAlertModel? LatestAttentionAlert,
+    SessionActivityTimelineAlertModel? FailureAlert);

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using Flowbite.Components;
+using Symphony.Domain.Runs;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.Components.SessionDetail;
+
+internal static class SessionDetailDisplay
+{
+    internal static string FormatTimestamp(DateTimeOffset timestamp)
+    {
+        return timestamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+    }
+
+    internal static Badge.BadgeColor GetFallbackStatusColor(string statusText, bool isActive)
+    {
+        if (isActive)
+        {
+            return Badge.BadgeColor.Info;
+        }
+
+        return statusText.Trim().ToLowerInvariant() switch
+        {
+            "succeeded" => Badge.BadgeColor.Success,
+            "retrying" => Badge.BadgeColor.Warning,
+            "failed" => Badge.BadgeColor.Failure,
+            "timedout" => Badge.BadgeColor.Failure,
+            "stalled" => Badge.BadgeColor.Failure,
+            "canceled" => Badge.BadgeColor.Gray,
+            "canceledbyreconciliation" => Badge.BadgeColor.Gray,
+            _ => Badge.BadgeColor.Gray
+        };
+    }
+
+    internal static RunAttemptStatus? TryParseStatus(string statusText)
+    {
+        return statusText.Trim().ToLowerInvariant() switch
+        {
+            "preparingworkspace" => RunAttemptStatus.PreparingWorkspace,
+            "buildingprompt" => RunAttemptStatus.BuildingPrompt,
+            "launchingagentprocess" => RunAttemptStatus.LaunchingAgentProcess,
+            "initializingsession" => RunAttemptStatus.InitializingSession,
+            "streamingturn" => RunAttemptStatus.StreamingTurn,
+            "finishing" => RunAttemptStatus.Finishing,
+            "succeeded" => RunAttemptStatus.Succeeded,
+            "failed" => RunAttemptStatus.Failed,
+            "timedout" => RunAttemptStatus.TimedOut,
+            "stalled" => RunAttemptStatus.Stalled,
+            "canceledbyreconciliation" => RunAttemptStatus.CanceledByReconciliation,
+            _ => null
+        };
+    }
+
+    internal static string GetKindLabel(SessionActivityKind kind)
+    {
+        return kind switch
+        {
+            SessionActivityKind.LifecycleMilestone => "Lifecycle",
+            SessionActivityKind.AgentMessage => "Agent message",
+            SessionActivityKind.ProgressUpdate => "Progress",
+            SessionActivityKind.Warning => "Warning",
+            SessionActivityKind.Error => "Error",
+            SessionActivityKind.Outcome => "Outcome",
+            _ => "Activity"
+        };
+    }
+
+    internal static Badge.BadgeColor GetKindBadgeColor(SessionActivityKind kind)
+    {
+        return kind switch
+        {
+            SessionActivityKind.AgentMessage => Badge.BadgeColor.Info,
+            SessionActivityKind.Warning => Badge.BadgeColor.Warning,
+            SessionActivityKind.Error => Badge.BadgeColor.Failure,
+            SessionActivityKind.Outcome => Badge.BadgeColor.Success,
+            _ => Badge.BadgeColor.Gray
+        };
+    }
+
+    internal static TimelineColor GetTimelineColor(SessionActivityEntry entry)
+    {
+        return entry.Kind switch
+        {
+            SessionActivityKind.LifecycleMilestone => TimelineColor.Gray,
+            SessionActivityKind.AgentMessage => TimelineColor.Blue,
+            SessionActivityKind.ProgressUpdate => TimelineColor.Gray,
+            SessionActivityKind.Warning => TimelineColor.Orange,
+            SessionActivityKind.Error => TimelineColor.Red,
+            SessionActivityKind.Outcome => IsSuccessfulOutcome(entry) ? TimelineColor.Green : TimelineColor.Red,
+            _ => TimelineColor.Gray
+        };
+    }
+
+    private static bool IsSuccessfulOutcome(SessionActivityEntry entry)
+    {
+        var combined = $"{entry.Title} {entry.Detail}".Trim().ToLowerInvariant();
+        return combined.Contains("succeeded", StringComparison.Ordinal)
+            || combined.Contains("completed", StringComparison.Ordinal);
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionHeaderCard.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionHeaderCard.razor
@@ -1,0 +1,61 @@
+@using Symphony.Host.Components.Sessions
+
+<div data-testid="session-detail-header">
+<Card Slots="@HeaderCardSlots">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div class="space-y-3">
+            <div>
+                <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Session</p>
+                <h1 class="mt-2 text-3xl font-semibold text-[color:var(--color-on-surface-primary)]">@Session.Identifier</h1>
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+                <SessionStatusBadge Status="@Session.Status"
+                                   Text="@Session.StatusText"
+                                   ColorOverride="@(Session.Status is null ? Session.StatusColor : null)" />
+                @if (Session.IsActive)
+                {
+                    <div class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-on-surface-secondary)]"
+                         data-testid="session-header-active-indicator">
+                        <Spinner Size="SpinnerSize.Sm" Color="SpinnerColor.Info" />
+                        <span>Session is active</span>
+                    </div>
+                }
+            </div>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(Session.IssueUrl))
+        {
+            <a class="inline-flex items-center justify-center rounded-lg border border-[var(--shell-border)] px-4 py-2 text-sm font-semibold text-[color:var(--color-on-surface-primary)] transition hover:border-[color:var(--color-primary-DEFAULT)] hover:text-[color:var(--color-primary-DEFAULT)]"
+               href="@Session.IssueUrl"
+               data-testid="session-header-tracker-link">
+                Open tracker issue
+            </a>
+        }
+    </div>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+        <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4">
+            <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Started</p>
+            <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">@SessionDetailDisplay.FormatTimestamp(Session.StartedAt)</p>
+        </div>
+        <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4">
+            <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Ended</p>
+            <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">
+                @(Session.EndedAt is null ? "Still running" : SessionDetailDisplay.FormatTimestamp(Session.EndedAt.Value))
+            </p>
+        </div>
+    </div>
+</Card>
+</div>
+
+@code {
+    private static readonly CardSlots HeaderCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-xl)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex flex-col gap-6 p-6"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required SessionHeaderDisplayModel Session { get; set; }
+}

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionHeaderDisplayModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionHeaderDisplayModel.cs
@@ -1,0 +1,14 @@
+using Flowbite.Components;
+using Symphony.Domain.Runs;
+
+namespace Symphony.Host.Components.SessionDetail;
+
+public sealed record SessionHeaderDisplayModel(
+    string Identifier,
+    string? IssueUrl,
+    bool IsActive,
+    string StatusText,
+    RunAttemptStatus? Status,
+    Badge.BadgeColor StatusColor,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? EndedAt);

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionStatusBadge.razor
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionStatusBadge.razor
@@ -1,13 +1,40 @@
 @using Symphony.Domain.Runs
 
-<Badge Color="@GetColor(Status)">
-    @Status
+<Badge Color="@ResolveColor()">
+    @ResolveText()
 </Badge>
 
 @code {
     [Parameter]
-    [EditorRequired]
-    public RunAttemptStatus Status { get; set; }
+    public RunAttemptStatus? Status { get; set; }
+
+    [Parameter]
+    public string? Text { get; set; }
+
+    [Parameter]
+    public Badge.BadgeColor? ColorOverride { get; set; }
+
+    private Badge.BadgeColor ResolveColor()
+    {
+        if (ColorOverride is not null)
+        {
+            return ColorOverride.Value;
+        }
+
+        return Status is null
+            ? Badge.BadgeColor.Primary
+            : GetColor(Status.Value);
+    }
+
+    private string ResolveText()
+    {
+        if (!string.IsNullOrWhiteSpace(Text))
+        {
+            return Text;
+        }
+
+        return Status?.ToString() ?? string.Empty;
+    }
 
     private static Badge.BadgeColor GetColor(RunAttemptStatus status)
     {

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -1,0 +1,68 @@
+using Bunit;
+using Flowbite.Components;
+using Flowbite.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Host.Components.SessionDetail;
+using Symphony.Host.Dashboard;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SessionDetailComponentTests : BunitContext
+{
+    public SessionDetailComponentTests()
+    {
+        Services.AddFlowbite();
+    }
+
+    [Fact]
+    public void SessionHeaderCard_renders_status_tracker_link_and_spinner_for_active_sessions()
+    {
+        var cut = Render<SessionHeaderCard>(
+            parameters => parameters.Add(
+                component => component.Session,
+                new SessionHeaderDisplayModel(
+                    "ABC-1",
+                    "https://github.com/AGiorgetti/my-symphony/issues/ABC-1",
+                    true,
+                    "Active",
+                    Status: null,
+                    Badge.BadgeColor.Info,
+                    new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero),
+                    EndedAt: null)));
+
+        Assert.Contains("ABC-1", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Open tracker issue", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Session is active", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Still running", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionActivityTimeline_renders_warning_and_failure_alerts()
+    {
+        var cut = Render<SessionActivityTimeline>(
+            parameters => parameters.Add(
+                component => component.Timeline,
+                new SessionActivityTimelineModel(
+                    [
+                        new SessionActivityTimelineEntryModel(
+                            SessionActivityKind.LifecycleMilestone,
+                            new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero),
+                            "Session started",
+                            "Tracker moved to In Progress",
+                            TimelineColor.Gray),
+                        new SessionActivityTimelineEntryModel(
+                            SessionActivityKind.Warning,
+                            new DateTimeOffset(2026, 3, 20, 9, 1, 0, TimeSpan.Zero),
+                            "Queued for retry",
+                            "Waiting for the next dispatcher slot",
+                            TimelineColor.Orange)
+                    ],
+                    new SessionActivityTimelineAlertModel(AlertColor.Warning, "Latest warning:", "Queued for retry - Waiting for the next dispatcher slot"),
+                    new SessionActivityTimelineAlertModel(AlertColor.Failure, "Failure detail:", "Prompt build failed"))));
+
+        Assert.Contains("data-testid=\"session-detail-latest-attention-alert\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-failure-alert\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Session started", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Queued for retry", cut.Markup, StringComparison.Ordinal);
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
@@ -1,0 +1,270 @@
+using System.Net;
+using System.Net.Http.Json;
+using Flowbite.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Application.Configuration;
+using Symphony.Application.Polling;
+using Symphony.Application.Runtime;
+using Symphony.Host.Api;
+using Symphony.Host.Components;
+using Symphony.Host.Dashboard;
+using Symphony.Host.Theming;
+
+namespace Symphony.Host.IntegrationTests;
+
+public sealed class SessionDetailPageIntegrationTests
+{
+    [Fact]
+    public async Task Session_detail_page_renders_breadcrumb_header_and_timeline()
+    {
+        var store = CreateStoreWithActiveSession();
+        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot()));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/sessions/ABC-1");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("data-testid=\"session-detail-breadcrumb\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"/sessions\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-header\"", html, StringComparison.Ordinal);
+        Assert.Contains("Open tracker issue", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-header-active-indicator\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-timeline\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-latest-attention-alert\"", html, StringComparison.Ordinal);
+
+        var startedIndex = html.IndexOf("Session started", StringComparison.Ordinal);
+        var messageIndex = html.IndexOf("turn_completed", StringComparison.Ordinal);
+        var warningIndex = html.LastIndexOf("Queued for retry", StringComparison.Ordinal);
+
+        Assert.True(startedIndex >= 0);
+        Assert.True(messageIndex > startedIndex);
+        Assert.True(warningIndex > messageIndex);
+    }
+
+    [Fact]
+    public async Task Session_detail_page_renders_failure_alert_for_final_error()
+    {
+        var store = CreateStoreWithFailedSession();
+        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot(activeSessions: [])));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/sessions/ABC-2");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Failed", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-failure-alert\"", html, StringComparison.Ordinal);
+        Assert.Contains("Prompt build failed", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Session_detail_page_renders_not_found_message_for_unknown_session()
+    {
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot(activeSessions: [])));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/sessions/ABC-404");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("data-testid=\"session-detail-not-found\"", html, StringComparison.Ordinal);
+        Assert.Contains("ABC-404", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Session_detail_page_keeps_api_routes_available_when_rendering_succeeds()
+    {
+        var store = CreateStoreWithActiveSession();
+        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot()));
+        var client = CreateHttpClient(app);
+
+        var pageResponse = await client.GetAsync("/sessions/ABC-1");
+        var apiResponse = await client.PostAsJsonAsync("/api/v1/refresh", new { });
+
+        Assert.Equal(HttpStatusCode.OK, pageResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, apiResponse.StatusCode);
+    }
+
+    private static SessionActivityStore CreateStoreWithActiveSession()
+    {
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        var startedAt = new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero);
+
+        store.RecordSessionStart("ABC-1", startedAt, "https://github.com/AGiorgetti/my-symphony/issues/ABC-1");
+        store.RecordActivity("ABC-1", new SessionActivityEntry(SessionActivityKind.LifecycleMilestone, startedAt, "Session started", "Tracker moved to In Progress"));
+        store.RecordActivity("ABC-1", new SessionActivityEntry(SessionActivityKind.AgentMessage, startedAt.AddMinutes(1), "turn_completed", "Applied changes"));
+        store.RecordActivity("ABC-1", new SessionActivityEntry(SessionActivityKind.Warning, startedAt.AddMinutes(2), "Queued for retry", "Waiting for the next dispatcher slot"));
+
+        return store;
+    }
+
+    private static SessionActivityStore CreateStoreWithFailedSession()
+    {
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        var startedAt = new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero);
+        var endedAt = startedAt.AddMinutes(5);
+
+        store.RecordSessionStart("ABC-2", startedAt, "https://github.com/AGiorgetti/my-symphony/issues/ABC-2");
+        store.RecordActivity("ABC-2", new SessionActivityEntry(SessionActivityKind.LifecycleMilestone, startedAt, "Session started", "Tracker moved to In Progress"));
+        store.RecordActivity("ABC-2", new SessionActivityEntry(SessionActivityKind.Error, endedAt, "Prompt build failed", "The workflow prompt could not be assembled."));
+        store.RecordSessionEnd("ABC-2", endedAt, "Failed", "Prompt build failed");
+
+        return store;
+    }
+
+    private static DashboardSnapshot CreateSnapshot(IReadOnlyList<DashboardActiveSessionSnapshot>? activeSessions = null)
+    {
+        return new DashboardSnapshot(
+            new DateTimeOffset(2026, 3, 20, 9, 5, 0, TimeSpan.Zero),
+            "Healthy",
+            "Single-process in-memory",
+            new DateTimeOffset(2026, 3, 20, 9, 5, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 20, 9, 4, 40, TimeSpan.Zero),
+            20d,
+            "Loaded",
+            new DateTimeOffset(2026, 3, 20, 8, 55, 0, TimeSpan.Zero),
+            RunningCount: activeSessions?.Count ?? 1,
+            RetryingCount: 0,
+            InputTokens: 80,
+            OutputTokens: 30,
+            TotalTokens: 110,
+            SecondsRunning: 420d,
+            activeSessions ??
+            [
+                new DashboardActiveSessionSnapshot(
+                    "ABC-1",
+                    "In Progress",
+                    "thread-1-turn-2",
+                    2,
+                    "turn_completed",
+                    "Applied changes",
+                    new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 20, 9, 2, 0, TimeSpan.Zero),
+                    110)
+            ],
+            RetryQueue: [],
+            RecentAttempts: [],
+            LastError: null,
+            WorkflowLastError: null);
+    }
+
+    private static HttpClient CreateHttpClient(WebApplication app)
+    {
+        var server = app.Services.GetRequiredService<IServer>();
+        var addresses = server.Features.Get<IServerAddressesFeature>()
+            ?? throw new InvalidOperationException("Test server addresses are unavailable.");
+        var address = Assert.Single(addresses.Addresses);
+
+        return new HttpClient
+        {
+            BaseAddress = new Uri(address)
+        };
+    }
+
+    private static async Task<WebApplication> StartSessionDetailApplicationAsync(
+        ISessionActivityStore sessionActivityStore,
+        IDashboardStateService dashboardStateService)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+        builder.Services.AddFlowbite();
+        builder.Services.AddSingleton<IOrchestratorRuntimeService>(new StubRuntimeService());
+        builder.Services.AddSingleton(sessionActivityStore);
+        builder.Services.AddSingleton<ISessionActivityStore>(sessionActivityStore);
+        builder.Services.AddSingleton<IDashboardStateService>(dashboardStateService);
+        builder.Services.AddScoped<IThemeService, ThemeService>();
+        builder.Services.AddScoped<ThemeService>();
+        builder.Services.AddSingleton<IWorkflowOptionsProvider>(
+            new StaticWorkflowOptionsProvider(
+                new WorkflowServiceOptions(
+                    new WorkflowTrackerOptions(
+                        "github",
+                        "https://api.github.com",
+                        "token",
+                        null,
+                        "owner/repo",
+                        null,
+                        null,
+                        ["Todo"],
+                        ["Done"]),
+                    new WorkflowPollingOptions(1_000),
+                    new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                    new WorkflowHookOptions(
+                        null,
+                        null,
+                        null,
+                        null,
+                        60_000),
+                    new WorkflowAgentOptions(
+                        1,
+                        20,
+                        300_000,
+                        new Dictionary<string, int>(StringComparer.Ordinal)),
+                    new WorkflowCodexOptions(
+                        "codex app-server",
+                        null,
+                        null,
+                        null,
+                        3_600_000,
+                        5_000,
+                        300_000))));
+
+        var app = builder.Build();
+        app.UseStaticFiles();
+        app.UseAntiforgery();
+        app.MapSymphonyApi();
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class StaticDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
+    {
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class StubRuntimeService : IOrchestratorRuntimeService
+    {
+        public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(
+                new OrchestratorStateSnapshot(
+                    DateTimeOffset.UtcNow,
+                    Array.Empty<RunningIssueSnapshot>(),
+                    Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                    new CodexTotalsSnapshot(0, 0, 0, 0d),
+                    RateLimits: null));
+        }
+
+        public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<OrchestratorIssueSnapshot?>(null);
+        }
+
+        public PollingRefreshReceipt RequestRefresh()
+        {
+            return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionStatusBadgeTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionStatusBadgeTests.cs
@@ -37,4 +37,18 @@ public sealed class SessionStatusBadgeTests : BunitContext
         Assert.Equal(expectedColor, badge.Instance.Color);
         Assert.Contains(status.ToString(), cut.Markup, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void SessionStatusBadge_uses_custom_text_and_color_override_when_status_is_not_available()
+    {
+        var cut = Render<SessionStatusBadge>(
+            parameters => parameters
+                .Add(component => component.Text, "Active")
+                .Add(component => component.ColorOverride, Badge.BadgeColor.Info));
+
+        var badge = cut.FindComponent<Badge>();
+
+        Assert.Equal(Badge.BadgeColor.Info, badge.Instance.Color);
+        Assert.Contains("Active", cut.Markup, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
#### Context

Add the first session detail page so operators can inspect a single run with breadcrumb navigation, a status header, and an activity timeline. Closes #86.

#### TL;DR

*Add `/sessions/{Identifier}` with a session header, failure/warning alerts, and a chronological activity timeline.*

#### Summary

- Add `/sessions/{Identifier}` with breadcrumb navigation and a typed session header card
- Add a typed Flowbite timeline with warning and failure alerts for session activity
- Extend `SessionStatusBadge` for custom labels and add integration and component coverage

#### Alternatives

- Keep session inspection inside the list page, but that makes warnings and failures harder to read and extend

#### Test Plan

- [x] `dotnet format --verify-no-changes dotnet/Symphony.sln --no-restore && dotnet build -c Release dotnet/Symphony.sln --no-restore && dotnet test -c Release --no-build dotnet/Symphony.sln`
- [x] `dotnet test -c Release dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~SessionDetailPageIntegrationTests|FullyQualifiedName~SessionDetailComponentTests|FullyQualifiedName~SessionStatusBadgeTests"`
