### PR TITLE
feat(host): implement session detail tabs and refresh

### DIFF
--- a/SPEC_UI.md
+++ b/SPEC_UI.md
@@ -218,6 +218,7 @@ The detail view should include:
 - session status and outcome
 - timestamps relevant to the session lifecycle
 - a readable activity history
+- a separate details view for live session metadata such as tokens, turn count, session ID, and attempt number
 - visible messages and updates from the agent
 - warnings and errors when present
 

--- a/dotnet/ARCHITECTURE_UI.md
+++ b/dotnet/ARCHITECTURE_UI.md
@@ -369,7 +369,8 @@ Sections:
    activity exists.
 
 Implementation note: EU7-S1 delivers the breadcrumb, session header card, and activity
-timeline first. The metadata/details tab and active-session auto-refresh follow in EU7-S2.
+timeline first. EU7-S2 adds the metadata/details tab and starts a 2-second refresh loop only
+for active sessions, while ended sessions render once without a timer.
 
 Back navigation uses `Breadcrumb`: Home → Sessions → {Identifier}.
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -302,8 +302,8 @@ surface only: if dashboard rendering fails, the orchestrator and JSON API contin
 - The dashboard now includes active-session, retry-queue, and recent-attempt panels so operators
   can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
 - The session explorer is now available at `/sessions`, with All / Active / Ended filters and deep
-  links into `/sessions/{identifier}` for individual run inspection, breadcrumb navigation, and a
-  chronological activity timeline.
+  links into `/sessions/{identifier}` for individual run inspection, breadcrumb navigation, a
+  chronological activity timeline, and an Activity / Details tab split for live metadata.
 - The dashboard health cards now expose last poll tick, last successful poll age, and workflow load
   status so degraded polling or workflow-reload fallback is visible without reading logs.
 - The sidebar footer includes a theme switcher for the built-in `dark-yellow`, `dark-blue`, and

--- a/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
@@ -1,5 +1,9 @@
 @page "/sessions/{Identifier}"
+@implements IAsyncDisposable
+@using Symphony.Application.Runtime
 @using Symphony.Host.Components.SessionDetail
+@inject IDashboardStateService DashboardStateService
+@inject IOrchestratorRuntimeService OrchestratorRuntimeService
 @inject ISessionActivityStore SessionActivityStore
 
 <main class="dashboard-page flex flex-col gap-6">
@@ -19,7 +23,7 @@
             <Skeleton Variant="SkeletonVariant.Card" Width="w-full" Height="h-80" />
         </Card>
     }
-    else if (_header is null || _timeline is null)
+    else if (_header is null || _timeline is null || _metadata is null)
     {
         <div data-testid="session-detail-not-found">
             <Alert Color="AlertColor.Warning"
@@ -31,8 +35,39 @@
     }
     else
     {
+        @if (!string.IsNullOrWhiteSpace(_refreshErrorMessage))
+        {
+            <Alert Color="AlertColor.Warning"
+                   Rounded="true"
+                   WithBorderAccent="true"
+                   TextEmphasis="Refresh warning:"
+                   Text="@_refreshErrorMessage" />
+        }
+
         <SessionHeaderCard Session="_header" />
-        <SessionActivityTimeline Timeline="_timeline" />
+
+        <div data-testid="session-detail-tabs">
+            <Tabs Variant="TabVariant.Underline"
+                  ActiveIndex="@_activeTabIndex"
+                  ActiveIndexChanged="@HandleActiveTabChanged">
+                <TabListContent>
+                    <Tab Index="0">Activity</Tab>
+                    <Tab Index="1">Details</Tab>
+                </TabListContent>
+                <TabPanelsContent>
+                    <TabPanel Index="0">
+                        <div data-testid="session-detail-activity-panel">
+                            <SessionActivityTimeline Timeline="_timeline" />
+                        </div>
+                    </TabPanel>
+                    <TabPanel Index="1">
+                        <div data-testid="session-detail-details-panel">
+                            <SessionMetadataPanel Metadata="_metadata" />
+                        </div>
+                    </TabPanel>
+                </TabPanelsContent>
+            </Tabs>
+        </div>
     }
 </main>
 
@@ -46,16 +81,111 @@
     [Parameter]
     public string Identifier { get; set; } = string.Empty;
 
+    private PeriodicTimer? _refreshTimer;
+    private CancellationTokenSource? _refreshCancellationTokenSource;
+    private Task? _refreshLoopTask;
     private bool _isLoading = true;
+    private bool _isSessionActive;
+    private int _activeTabIndex;
     private string _requestedIdentifier = string.Empty;
+    private string? _refreshErrorMessage;
     private SessionHeaderDisplayModel? _header;
     private SessionActivityTimelineModel? _timeline;
+    private SessionMetadataPanelModel? _metadata;
 
-    protected override Task OnParametersSetAsync()
+    protected override async Task OnParametersSetAsync()
     {
-        _requestedIdentifier = Identifier?.Trim() ?? string.Empty;
-        _isLoading = false;
+        await StopRefreshLoopAsync();
 
+        _requestedIdentifier = Identifier?.Trim() ?? string.Empty;
+        _isLoading = true;
+        _refreshErrorMessage = null;
+
+        await LoadAsync();
+
+        if (_isSessionActive)
+        {
+            _refreshCancellationTokenSource = new CancellationTokenSource();
+            _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+            _refreshLoopTask = RunRefreshLoopAsync(_refreshCancellationTokenSource.Token);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopRefreshLoopAsync();
+    }
+
+    private async Task RunRefreshLoopAsync(CancellationToken cancellationToken)
+    {
+        if (_refreshTimer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (await _refreshTimer.WaitForNextTickAsync(cancellationToken))
+            {
+                try
+                {
+                    await LoadAsync(cancellationToken);
+                    if (!_isSessionActive)
+                    {
+                        return;
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    _refreshErrorMessage = exception.Message;
+                }
+
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private async Task StopRefreshLoopAsync()
+    {
+        if (_refreshCancellationTokenSource is not null)
+        {
+            await _refreshCancellationTokenSource.CancelAsync();
+            _refreshCancellationTokenSource.Dispose();
+            _refreshCancellationTokenSource = null;
+        }
+
+        _refreshTimer?.Dispose();
+        _refreshTimer = null;
+
+        if (_refreshLoopTask is not null)
+        {
+            try
+            {
+                await _refreshLoopTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            _refreshLoopTask = null;
+        }
+    }
+
+    private async Task HandleActiveTabChanged(int index)
+    {
+        _activeTabIndex = index;
+        await Task.CompletedTask;
+    }
+
+    private async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
         var session = string.IsNullOrWhiteSpace(_requestedIdentifier)
             ? null
             : SessionActivityStore.GetSession(_requestedIdentifier);
@@ -64,12 +194,23 @@
         {
             _header = null;
             _timeline = null;
-            return Task.CompletedTask;
+            _metadata = null;
+            _isSessionActive = false;
+            _isLoading = false;
+            return;
         }
+
+        var snapshot = await DashboardStateService.GetSnapshotAsync(cancellationToken);
+        var activeSession = snapshot.ActiveSessions
+            .FirstOrDefault(candidate => string.Equals(candidate.IssueIdentifier, session.IssueIdentifier, StringComparison.OrdinalIgnoreCase));
+        var issueSnapshot = await OrchestratorRuntimeService.GetIssueSnapshotAsync(session.IssueIdentifier, cancellationToken);
 
         _header = BuildHeader(session);
         _timeline = BuildTimeline(session, SessionActivityStore.GetActivities(session.IssueIdentifier));
-        return Task.CompletedTask;
+        _metadata = BuildMetadata(session, activeSession, issueSnapshot, snapshot);
+        _isSessionActive = session.IsActive;
+        _refreshErrorMessage = null;
+        _isLoading = false;
     }
 
     private static SessionHeaderDisplayModel BuildHeader(SessionRecord session)
@@ -140,6 +281,45 @@
         }
 
         return new SessionActivityTimelineModel(orderedActivities, latestAttentionAlert, failureAlert);
+    }
+
+    private static SessionMetadataPanelModel BuildMetadata(
+        SessionRecord session,
+        DashboardActiveSessionSnapshot? activeSession,
+        OrchestratorIssueSnapshot? issueSnapshot,
+        DashboardSnapshot snapshot)
+    {
+        var recentAttempt = snapshot.RecentAttempts
+            .Where(attempt => string.Equals(attempt.IssueIdentifier, session.IssueIdentifier, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(attempt => attempt.CompletedAt)
+            .FirstOrDefault();
+        var runningSession = issueSnapshot?.Running;
+        var sessionId = runningSession?.SessionId ?? activeSession?.SessionId ?? recentAttempt?.SessionId;
+        var turnCount = runningSession?.TurnCount ?? activeSession?.TurnCount ?? SessionDetailDisplay.TryParseTurnCount(sessionId);
+        var attempt = issueSnapshot is null ? recentAttempt?.Attempt : issueSnapshot.CurrentRetryAttempt;
+        var isAttemptKnown = issueSnapshot is not null || recentAttempt is not null;
+
+        return new SessionMetadataPanelModel(
+            runningSession?.InputTokens,
+            runningSession?.OutputTokens,
+            runningSession?.TotalTokens ?? activeSession?.TotalTokens,
+            turnCount,
+            sessionId,
+            attempt,
+            isAttemptKnown,
+            GetMetadataAvailabilityMessage(session, runningSession is not null));
+    }
+
+    private static string? GetMetadataAvailabilityMessage(SessionRecord session, bool hasRunningSnapshot)
+    {
+        if (!session.IsActive)
+        {
+            return "Finished sessions keep the last known session ID and attempt when available. Live token counters are only available while the session is active.";
+        }
+
+        return hasRunningSnapshot
+            ? null
+            : "Live runtime metadata is temporarily unavailable while the active session snapshot catches up.";
     }
 
     private static string ComposeAlertMessage(SessionActivityEntry entry)

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
@@ -51,6 +51,16 @@ internal static class SessionDetailDisplay
         };
     }
 
+    internal static string GetAttemptLabel(int? attempt, bool isKnown)
+    {
+        if (!isKnown)
+        {
+            return "Unavailable";
+        }
+
+        return attempt is null ? "Initial run" : $"Attempt {attempt}";
+    }
+
     internal static string GetKindLabel(SessionActivityKind kind)
     {
         return kind switch
@@ -89,6 +99,25 @@ internal static class SessionDetailDisplay
             SessionActivityKind.Outcome => IsSuccessfulOutcome(entry) ? TimelineColor.Green : TimelineColor.Red,
             _ => TimelineColor.Gray
         };
+    }
+
+    internal static int? TryParseTurnCount(string? sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return null;
+        }
+
+        var markerIndex = sessionId.LastIndexOf("-turn-", StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            return null;
+        }
+
+        var turnSegment = sessionId[(markerIndex + 6)..];
+        return int.TryParse(turnSegment, NumberStyles.Integer, CultureInfo.InvariantCulture, out var turnCount)
+            ? turnCount
+            : null;
     }
 
     private static bool IsSuccessfulOutcome(SessionActivityEntry entry)

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanel.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanel.razor
@@ -1,0 +1,72 @@
+<div data-testid="session-detail-metadata">
+    <Card Slots="@MetadataCardSlots">
+        <div class="space-y-2">
+            <p class="text-xs font-bold uppercase tracking-[0.24em] text-[color:var(--color-primary-DEFAULT)]">Details</p>
+            <h2 class="text-2xl font-semibold text-[color:var(--color-on-surface-primary)]">Session metadata</h2>
+            <p class="text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                Live runtime token counters plus the latest known session identity and attempt metadata.
+            </p>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(Metadata.AvailabilityMessage))
+        {
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] px-4 py-3 text-sm leading-6 text-[color:var(--color-on-surface-secondary)]">
+                @Metadata.AvailabilityMessage
+            </div>
+        }
+
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4" data-testid="session-detail-metadata-input-tokens">
+                <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Input tokens</p>
+                <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">@FormatLong(Metadata.InputTokens)</p>
+            </div>
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4" data-testid="session-detail-metadata-output-tokens">
+                <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Output tokens</p>
+                <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">@FormatLong(Metadata.OutputTokens)</p>
+            </div>
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4" data-testid="session-detail-metadata-total-tokens">
+                <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Combined tokens</p>
+                <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">@FormatLong(Metadata.TotalTokens)</p>
+            </div>
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4" data-testid="session-detail-metadata-turn-count">
+                <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Turn count</p>
+                <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">@FormatInt(Metadata.TurnCount)</p>
+            </div>
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4" data-testid="session-detail-metadata-session-id">
+                <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Session ID</p>
+                <p class="mt-2 break-all text-base font-semibold text-[color:var(--color-on-surface-primary)]">@FormatText(Metadata.SessionId)</p>
+            </div>
+            <div class="rounded-[var(--shell-radius-lg)] border border-[var(--shell-border)] bg-[color:var(--color-surface-base)] p-4" data-testid="session-detail-metadata-attempt">
+                <p class="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--color-on-surface-secondary)]">Attempt</p>
+                <p class="mt-2 text-base font-semibold text-[color:var(--color-on-surface-primary)]">@SessionDetailDisplay.GetAttemptLabel(Metadata.Attempt, Metadata.IsAttemptKnown)</p>
+            </div>
+        </div>
+    </Card>
+</div>
+
+@code {
+    private static readonly CardSlots MetadataCardSlots = new()
+    {
+        Base = "rounded-[var(--shell-radius-xl)] border border-[var(--shell-border)] bg-[color:var(--color-surface-raised)] shadow-[var(--shell-shadow)]",
+        Body = "flex flex-col gap-6 p-6"
+    };
+
+    [Parameter]
+    [EditorRequired]
+    public required SessionMetadataPanelModel Metadata { get; set; }
+
+    private static string FormatLong(long? value)
+    {
+        return value?.ToString("N0") ?? "Unavailable";
+    }
+
+    private static string FormatInt(int? value)
+    {
+        return value?.ToString() ?? "Unavailable";
+    }
+
+    private static string FormatText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "Unavailable" : value;
+    }
+}

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanelModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanelModel.cs
@@ -1,0 +1,11 @@
+namespace Symphony.Host.Components.SessionDetail;
+
+public sealed record SessionMetadataPanelModel(
+    long? InputTokens,
+    long? OutputTokens,
+    long? TotalTokens,
+    int? TurnCount,
+    string? SessionId,
+    int? Attempt,
+    bool IsAttemptKnown,
+    string? AvailabilityMessage);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -2,6 +2,10 @@ using Bunit;
 using Flowbite.Components;
 using Flowbite.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Application.Polling;
+using Symphony.Application.Runtime;
+using Symphony.Host.Components.Pages;
 using Symphony.Host.Components.SessionDetail;
 using Symphony.Host.Dashboard;
 
@@ -64,5 +68,191 @@ public sealed class SessionDetailComponentTests : BunitContext
         Assert.Contains("data-testid=\"session-detail-failure-alert\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Session started", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Queued for retry", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionMetadataPanel_renders_metadata_fields_and_attempt_label()
+    {
+        var cut = Render<SessionMetadataPanel>(
+            parameters => parameters.Add(
+                component => component.Metadata,
+                new SessionMetadataPanelModel(
+                    120,
+                    45,
+                    165,
+                    4,
+                    "thread-1-turn-4",
+                    2,
+                    true,
+                    "Finished sessions keep the last known session ID and attempt when available.")));
+
+        Assert.Contains("165", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("thread-1-turn-4", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Attempt 2", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Finished sessions keep the last known session ID and attempt when available.", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionDetailPage_starts_refresh_loop_for_active_sessions_only()
+    {
+        var startedAt = new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero);
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        store.RecordSessionStart("ABC-1", startedAt, "https://github.com/AGiorgetti/my-symphony/issues/ABC-1");
+        store.RecordActivity("ABC-1", new SessionActivityEntry(SessionActivityKind.LifecycleMilestone, startedAt, "Session started", "Tracker moved to In Progress"));
+
+        var dashboardStateService = new CountingDashboardStateService(
+            new DashboardSnapshot(
+                startedAt.AddMinutes(1),
+                "Healthy",
+                "Single-process in-memory",
+                startedAt.AddMinutes(1),
+                startedAt.AddMinutes(1),
+                5d,
+                "Loaded",
+                startedAt,
+                RunningCount: 1,
+                RetryingCount: 0,
+                InputTokens: 120,
+                OutputTokens: 45,
+                TotalTokens: 165,
+                SecondsRunning: 60d,
+                [
+                    new DashboardActiveSessionSnapshot(
+                        "ABC-1",
+                        "StreamingTurn",
+                        "thread-1-turn-4",
+                        4,
+                        "turn_completed",
+                        "Applied changes",
+                        startedAt,
+                        startedAt.AddMinutes(1),
+                        165)
+                ],
+                RetryQueue: [],
+                RecentAttempts: [],
+                LastError: null,
+                WorkflowLastError: null));
+        var runtimeService = new StaticRuntimeService(
+            new OrchestratorIssueSnapshot(
+                "ABC-1",
+                "1",
+                "running",
+                RestartCount: 1,
+                CurrentRetryAttempt: 2,
+                new RunningIssueSnapshot(
+                    "1",
+                    "ABC-1",
+                    "StreamingTurn",
+                    "thread-1-turn-4",
+                    4,
+                    "turn_completed",
+                    "Applied changes",
+                    startedAt,
+                    startedAt.AddMinutes(1),
+                    120,
+                    45,
+                    165),
+                Retry: null,
+                LastError: null,
+                RecentEvents: []));
+
+        Services.AddSingleton<ISessionActivityStore>(store);
+        Services.AddSingleton<IDashboardStateService>(dashboardStateService);
+        Services.AddSingleton<IOrchestratorRuntimeService>(runtimeService);
+
+        using var cut = Render<SessionDetailPage>(
+            parameters => parameters.Add(component => component.Identifier, "ABC-1"));
+
+        cut.WaitForAssertion(
+            () => Assert.True(dashboardStateService.CallCount >= 2),
+            TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task SessionDetailPage_skips_refresh_loop_for_ended_sessions()
+    {
+        var startedAt = new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero);
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        store.RecordSessionStart("ABC-2", startedAt, "https://github.com/AGiorgetti/my-symphony/issues/ABC-2");
+        store.RecordSessionEnd("ABC-2", startedAt.AddMinutes(4), "Succeeded");
+
+        var dashboardStateService = new CountingDashboardStateService(
+            new DashboardSnapshot(
+                startedAt.AddMinutes(5),
+                "Healthy",
+                "Single-process in-memory",
+                startedAt.AddMinutes(5),
+                startedAt.AddMinutes(5),
+                5d,
+                "Loaded",
+                startedAt,
+                RunningCount: 0,
+                RetryingCount: 0,
+                InputTokens: 0,
+                OutputTokens: 0,
+                TotalTokens: 0,
+                SecondsRunning: 0d,
+                ActiveSessions: [],
+                RetryQueue: [],
+                RecentAttempts:
+                [
+                    new DashboardRecentAttemptSnapshot(
+                        "ABC-2",
+                        1,
+                        "Succeeded",
+                        startedAt.AddMinutes(4),
+                        240d,
+                        null,
+                        "thread-2-turn-3")
+                ],
+                LastError: null,
+                WorkflowLastError: null));
+
+        Services.AddSingleton<ISessionActivityStore>(store);
+        Services.AddSingleton<IDashboardStateService>(dashboardStateService);
+        Services.AddSingleton<IOrchestratorRuntimeService>(new StaticRuntimeService(issueSnapshot: null));
+
+        using var cut = Render<SessionDetailPage>(
+            parameters => parameters.Add(component => component.Identifier, "ABC-2"));
+
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(1, dashboardStateService.CallCount);
+        Assert.Contains("data-testid=\"session-detail-metadata\"", cut.Markup, StringComparison.Ordinal);
+    }
+
+    private sealed class CountingDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
+    {
+        public int CallCount { get; private set; }
+
+        public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class StaticRuntimeService(OrchestratorIssueSnapshot? issueSnapshot) : IOrchestratorRuntimeService
+    {
+        public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(
+                new OrchestratorStateSnapshot(
+                    DateTimeOffset.UtcNow,
+                    Array.Empty<RunningIssueSnapshot>(),
+                    Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                    new CodexTotalsSnapshot(0, 0, 0, 0d),
+                    RateLimits: null));
+        }
+
+        public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(issueSnapshot);
+        }
+
+        public PollingRefreshReceipt RequestRefresh()
+        {
+            return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
     }
 }

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
@@ -20,10 +20,13 @@ namespace Symphony.Host.IntegrationTests;
 public sealed class SessionDetailPageIntegrationTests
 {
     [Fact]
-    public async Task Session_detail_page_renders_breadcrumb_header_and_timeline()
+    public async Task Session_detail_page_renders_breadcrumb_tabs_and_live_metadata()
     {
         var store = CreateStoreWithActiveSession();
-        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot()));
+        using var app = await StartSessionDetailApplicationAsync(
+            store,
+            new StaticDashboardStateService(CreateSnapshot()),
+            CreateActiveRuntimeService());
         var client = CreateHttpClient(app);
 
         var response = await client.GetAsync("/sessions/ABC-1");
@@ -35,7 +38,14 @@ public sealed class SessionDetailPageIntegrationTests
         Assert.Contains("data-testid=\"session-detail-header\"", html, StringComparison.Ordinal);
         Assert.Contains("Open tracker issue", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-header-active-indicator\"", html, StringComparison.Ordinal);
-        Assert.Contains("data-testid=\"session-detail-timeline\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-tabs\"", html, StringComparison.Ordinal);
+        Assert.Contains("Activity", html, StringComparison.Ordinal);
+        Assert.Contains("Details", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-details-panel\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-metadata\"", html, StringComparison.Ordinal);
+        Assert.Contains("thread-1-turn-2", html, StringComparison.Ordinal);
+        Assert.Contains("Attempt 2", html, StringComparison.Ordinal);
+        Assert.Contains("110", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-latest-attention-alert\"", html, StringComparison.Ordinal);
 
         var startedIndex = html.IndexOf("Session started", StringComparison.Ordinal);
@@ -48,10 +58,26 @@ public sealed class SessionDetailPageIntegrationTests
     }
 
     [Fact]
-    public async Task Session_detail_page_renders_failure_alert_for_final_error()
+    public async Task Session_detail_page_renders_failure_alert_and_ended_metadata_note()
     {
         var store = CreateStoreWithFailedSession();
-        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot(activeSessions: [])));
+        using var app = await StartSessionDetailApplicationAsync(
+            store,
+            new StaticDashboardStateService(
+                CreateSnapshot(
+                    activeSessions: [],
+                    recentAttempts:
+                    [
+                        new DashboardRecentAttemptSnapshot(
+                            "ABC-2",
+                            1,
+                            "Failed",
+                            new DateTimeOffset(2026, 3, 20, 8, 5, 0, TimeSpan.Zero),
+                            300d,
+                            "Prompt build failed",
+                            "thread-2-turn-3")
+                    ])),
+            new StaticRuntimeService(issueSnapshot: null));
         var client = CreateHttpClient(app);
 
         var response = await client.GetAsync("/sessions/ABC-2");
@@ -61,13 +87,19 @@ public sealed class SessionDetailPageIntegrationTests
         Assert.Contains("Failed", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-failure-alert\"", html, StringComparison.Ordinal);
         Assert.Contains("Prompt build failed", html, StringComparison.Ordinal);
+        Assert.Contains("thread-2-turn-3", html, StringComparison.Ordinal);
+        Assert.Contains("Attempt 1", html, StringComparison.Ordinal);
+        Assert.Contains("Finished sessions keep the last known session ID and attempt when available.", html, StringComparison.Ordinal);
     }
 
     [Fact]
     public async Task Session_detail_page_renders_not_found_message_for_unknown_session()
     {
         var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
-        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot(activeSessions: [])));
+        using var app = await StartSessionDetailApplicationAsync(
+            store,
+            new StaticDashboardStateService(CreateSnapshot(activeSessions: [])),
+            new StaticRuntimeService(issueSnapshot: null));
         var client = CreateHttpClient(app);
 
         var response = await client.GetAsync("/sessions/ABC-404");
@@ -82,7 +114,10 @@ public sealed class SessionDetailPageIntegrationTests
     public async Task Session_detail_page_keeps_api_routes_available_when_rendering_succeeds()
     {
         var store = CreateStoreWithActiveSession();
-        using var app = await StartSessionDetailApplicationAsync(store, new StaticDashboardStateService(CreateSnapshot()));
+        using var app = await StartSessionDetailApplicationAsync(
+            store,
+            new StaticDashboardStateService(CreateSnapshot()),
+            CreateActiveRuntimeService());
         var client = CreateHttpClient(app);
 
         var pageResponse = await client.GetAsync("/sessions/ABC-1");
@@ -119,7 +154,9 @@ public sealed class SessionDetailPageIntegrationTests
         return store;
     }
 
-    private static DashboardSnapshot CreateSnapshot(IReadOnlyList<DashboardActiveSessionSnapshot>? activeSessions = null)
+    private static DashboardSnapshot CreateSnapshot(
+        IReadOnlyList<DashboardActiveSessionSnapshot>? activeSessions = null,
+        IReadOnlyList<DashboardRecentAttemptSnapshot>? recentAttempts = null)
     {
         return new DashboardSnapshot(
             new DateTimeOffset(2026, 3, 20, 9, 5, 0, TimeSpan.Zero),
@@ -150,7 +187,7 @@ public sealed class SessionDetailPageIntegrationTests
                     110)
             ],
             RetryQueue: [],
-            RecentAttempts: [],
+            RecentAttempts: recentAttempts ?? [],
             LastError: null,
             WorkflowLastError: null);
     }
@@ -170,13 +207,15 @@ public sealed class SessionDetailPageIntegrationTests
 
     private static async Task<WebApplication> StartSessionDetailApplicationAsync(
         ISessionActivityStore sessionActivityStore,
-        IDashboardStateService dashboardStateService)
+        IDashboardStateService dashboardStateService,
+        IOrchestratorRuntimeService runtimeService)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         builder.Services.AddRazorComponents().AddInteractiveServerComponents();
         builder.Services.AddFlowbite();
-        builder.Services.AddSingleton<IOrchestratorRuntimeService>(new StubRuntimeService());
+        builder.Services.AddSingleton(runtimeService);
+        builder.Services.AddSingleton<IOrchestratorRuntimeService>(runtimeService);
         builder.Services.AddSingleton(sessionActivityStore);
         builder.Services.AddSingleton<ISessionActivityStore>(sessionActivityStore);
         builder.Services.AddSingleton<IDashboardStateService>(dashboardStateService);
@@ -228,6 +267,33 @@ public sealed class SessionDetailPageIntegrationTests
         return app;
     }
 
+    private static StaticRuntimeService CreateActiveRuntimeService()
+    {
+        return new StaticRuntimeService(
+            new OrchestratorIssueSnapshot(
+                "ABC-1",
+                "1",
+                "running",
+                RestartCount: 1,
+                CurrentRetryAttempt: 2,
+                new RunningIssueSnapshot(
+                    "1",
+                    "ABC-1",
+                    "StreamingTurn",
+                    "thread-1-turn-2",
+                    2,
+                    "turn_completed",
+                    "Applied changes",
+                    new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 3, 20, 9, 2, 0, TimeSpan.Zero),
+                    80,
+                    30,
+                    110),
+                Retry: null,
+                LastError: null,
+                RecentEvents: []));
+    }
+
     private sealed class StaticDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
     {
         public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
@@ -244,7 +310,7 @@ public sealed class SessionDetailPageIntegrationTests
         }
     }
 
-    private sealed class StubRuntimeService : IOrchestratorRuntimeService
+    private sealed class StaticRuntimeService(OrchestratorIssueSnapshot? issueSnapshot) : IOrchestratorRuntimeService
     {
         public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
         {
@@ -259,7 +325,7 @@ public sealed class SessionDetailPageIntegrationTests
 
         public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(string issueIdentifier, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult<OrchestratorIssueSnapshot?>(null);
+            return Task.FromResult(issueSnapshot);
         }
 
         public PollingRefreshReceipt RequestRefresh()


### PR DESCRIPTION
#### Context

Issue `#87` adds the second half of the session detail experience from the UI implementation plan. `EU7-S1` already shipped the breadcrumb, summary header, and activity timeline; this change completes the page with the metadata/details view and live refresh behavior for active sessions.

#### TL;DR

The session detail page now has Flowbite underline tabs for `Activity` and `Details`, a typed metadata panel for token/session/attempt data, and a 2-second refresh loop that only runs while the selected session is still active.

#### Summary

- add `SessionMetadataPanel` and `SessionMetadataPanelModel`
- update `SessionDetailPage` to load dashboard/runtime state, render activity/details tabs, and refresh active sessions every 2 seconds
- keep unknown identifiers graceful and keep ended sessions single-render with no timer
- extend session detail integration/component coverage and update the UI docs

#### Test Plan

- [x] `dotnet build -c Release dotnet/src/Symphony.Host/Symphony.Host.csproj --no-restore`
- [x] `dotnet test -c Release dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~SessionDetailPageIntegrationTests|FullyQualifiedName~SessionDetailComponentTests"`
- [x] `dotnet build -c Release dotnet/Symphony.sln --no-restore`
- [x] `dotnet test -c Release --no-build dotnet/Symphony.sln`
- [x] `dotnet format --verify-no-changes dotnet/Symphony.sln --no-restore`