### PR TITLE
test(host): close remaining bunit component gaps

### DIFF
--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageComponentTests.cs
@@ -47,6 +47,17 @@ public sealed class DashboardPageComponentTests : BunitContext
         Assert.Contains("Workflow reload warning:", cut.Markup, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ActiveSessionsPanel_renders_empty_state_when_no_sessions_are_running()
+    {
+        var cut = Render<ActiveSessionsPanel>(parameters => parameters
+            .Add(component => component.Sessions, Array.Empty<DashboardActiveSessionSnapshot>())
+            .Add(component => component.GeneratedAt, new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero)));
+
+        Assert.Contains("No active sessions", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("New in-flight work will appear here", cut.Markup, StringComparison.Ordinal);
+    }
+
     private sealed class DeferredDashboardStateService(Task<DashboardSnapshot> snapshotTask) : IDashboardStateService
     {
         public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -55,6 +55,12 @@ public sealed class SessionDetailComponentTests : BunitContext
                             "Tracker moved to In Progress",
                             TimelineColor.Gray),
                         new SessionActivityTimelineEntryModel(
+                            SessionActivityKind.AgentMessage,
+                            new DateTimeOffset(2026, 3, 20, 9, 0, 30, TimeSpan.Zero),
+                            "turn_started",
+                            "Agent picked up the first turn",
+                            TimelineColor.Blue),
+                        new SessionActivityTimelineEntryModel(
                             SessionActivityKind.Warning,
                             new DateTimeOffset(2026, 3, 20, 9, 1, 0, TimeSpan.Zero),
                             "Queued for retry",
@@ -68,6 +74,26 @@ public sealed class SessionDetailComponentTests : BunitContext
         Assert.Contains("data-testid=\"session-detail-failure-alert\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Session started", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Queued for retry", cut.Markup, StringComparison.Ordinal);
+
+        var timelineItems = cut.FindComponents<TimelineItem>();
+
+        Assert.Collection(
+            timelineItems,
+            item =>
+            {
+                Assert.Equal("Session started", item.Instance.Title);
+                Assert.Equal(TimelineColor.Gray, item.Instance.Color);
+            },
+            item =>
+            {
+                Assert.Equal("turn_started", item.Instance.Title);
+                Assert.Equal(TimelineColor.Blue, item.Instance.Color);
+            },
+            item =>
+            {
+                Assert.Equal("Queued for retry", item.Instance.Title);
+                Assert.Equal(TimelineColor.Orange, item.Instance.Color);
+            });
     }
 
     [Fact]


### PR DESCRIPTION
#### Context

Issue `#89` asked for the remaining bUnit sub-component coverage in the host integration test project. The `bunit` package and several component tests were already present, so this PR closes the specific gaps still missing from the acceptance criteria.

#### TL;DR

This is a test-only PR that adds the missing `ActiveSessionsPanel` empty-state assertion and strengthens `SessionActivityTimeline` coverage to verify rendered order and `TimelineColor`.

#### Summary

- add a bUnit test for `ActiveSessionsPanel` when no sessions are running
- strengthen `SessionActivityTimeline` to assert ordered `TimelineItem` titles and colors
- re-run the focused component suite plus the full solution validation

#### Test Plan

- [x] `dotnet test -c Release dotnet/tests/Symphony.Host.IntegrationTests/Symphony.Host.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~DashboardPageComponentTests|FullyQualifiedName~SessionDetailComponentTests|FullyQualifiedName~SessionListTableTests|FullyQualifiedName~SessionStatusBadgeTests"`
- [x] `dotnet build -c Release dotnet/Symphony.sln --no-restore`
- [x] `dotnet test -c Release --no-build dotnet/Symphony.sln`
- [x] `dotnet format --verify-no-changes dotnet/Symphony.sln --no-restore`