### PR TITLE
Implement same-session continuation turns up to agent.max_turns

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -265,17 +265,20 @@ Notes:
 - The application layer keeps dispatch staging in a bounded in-memory channel and enforces
   `agent.max_concurrent_agents` with a semaphore-backed execution gate. Status consumers can read
   queued and running work directly from the in-memory dispatch snapshot.
-- Successful worker exits schedule a one-second continuation retry. Failed worker exits are retried
-  with exponential backoff starting at 10 seconds, capped by `agent.max_retry_backoff_ms`, and are
-  surfaced through the in-memory retry snapshot.
+- Each worker run can execute multiple Codex turns on the same live app-server thread and
+  workspace, up to `agent.max_turns`. The first turn uses the workflow prompt template; later turns
+  send continuation guidance only after Symphony refreshes the issue state from the tracker.
+- After a normal worker exit, Symphony schedules a one-second continuation retry. Failed worker
+  exits are retried with exponential backoff starting at 10 seconds, capped by
+  `agent.max_retry_backoff_ms`, and are surfaced through the in-memory retry snapshot.
 - Operator-facing health now degrades when the last successful poll becomes stale or when
   `WORKFLOW.md` reload fails and Symphony falls back to the last-known-good workflow snapshot.
 - Active sessions are tracked in-memory by normalized issue id, can expose live session metadata,
   and support targeted reconciliation cancellation without affecting unrelated executions.
 - Worker attempts now create a validated workspace, optionally run `hooks.before_run`, launch Codex
-  through a shell appropriate to the host OS, send the `initialize` / `thread/start` /
-  `turn/start` handshake, then run `hooks.after_run` as a best-effort cleanup step after the
-  attempt ends.
+  through a shell appropriate to the host OS, send the `initialize` / `thread/start` handshake,
+  execute one or more `turn/start` requests on the same live thread when continuation is warranted,
+  then run `hooks.after_run` as a best-effort cleanup step after the attempt ends.
 - Hook/process timeouts and Codex read/turn timeouts are recorded separately from ordinary
   cancellations, surface as `TimedOut` run attempts, and still enter the standard retry backoff.
 - `codex.turn_sandbox_policy` is treated as a structured object and is forwarded to Codex in the

--- a/dotnet/src/Symphony.Application/Orchestration/ActiveSessionRegistry.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/ActiveSessionRegistry.cs
@@ -118,6 +118,21 @@ public sealed class ActiveSessionRegistry(
             session.SessionId);
     }
 
+    private void UpdateIssue(ActiveSessionEntry entry, Issue issue)
+    {
+        lock (_stateLock)
+        {
+            entry.Issue = issue;
+        }
+
+        logger.LogInformation(
+            "session_tracking refreshed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} issue_state={issue_state} outcome=completed",
+            issue.Id,
+            issue.Identifier,
+            entry.Session?.SessionId,
+            issue.State);
+    }
+
     private void UpdateStatus(ActiveSessionEntry entry, RunAttemptStatus status, string? error)
     {
         lock (_stateLock)
@@ -237,6 +252,7 @@ public sealed class ActiveSessionRegistry(
                 _entry.Issue,
                 _entry.Attempt,
                 CancellationToken,
+                issue => _owner.UpdateIssue(_entry, issue),
                 session => _owner.UpdateSession(_entry, session),
                 (status, error) => _owner.UpdateStatus(_entry, status, error));
         }

--- a/dotnet/src/Symphony.Application/Orchestration/QueuedIssueExecutionContext.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/QueuedIssueExecutionContext.cs
@@ -6,6 +6,7 @@ namespace Symphony.Application.Orchestration;
 
 public sealed class QueuedIssueExecutionContext
 {
+    private readonly Action<Issue> _updateIssue;
     private readonly Action<LiveSessionMetadata> _updateSession;
     private readonly Action<RunAttemptStatus, string?> _updateStatus;
 
@@ -13,17 +14,19 @@ public sealed class QueuedIssueExecutionContext
         Issue issue,
         int? attempt,
         CancellationToken cancellationToken,
+        Action<Issue> updateIssue,
         Action<LiveSessionMetadata> updateSession,
         Action<RunAttemptStatus, string?> updateStatus)
     {
         Issue = issue ?? throw new ArgumentNullException(nameof(issue));
         Attempt = attempt;
         CancellationToken = cancellationToken;
+        _updateIssue = updateIssue ?? throw new ArgumentNullException(nameof(updateIssue));
         _updateSession = updateSession ?? throw new ArgumentNullException(nameof(updateSession));
         _updateStatus = updateStatus ?? throw new ArgumentNullException(nameof(updateStatus));
     }
 
-    public Issue Issue { get; }
+    public Issue Issue { get; private set; }
 
     public int? Attempt { get; }
 
@@ -32,6 +35,13 @@ public sealed class QueuedIssueExecutionContext
     public LiveSessionMetadata? Session { get; private set; }
 
     public string? SessionId => Session?.SessionId;
+
+    public void UpdateIssue(Issue issue)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+        Issue = issue;
+        _updateIssue(issue);
+    }
 
     public void UpdateSession(LiveSessionMetadata session)
     {

--- a/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
+++ b/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
@@ -21,7 +21,8 @@ internal sealed class CodexAppServerClient(
         QueuedIssueExecutionContext context,
         string workspacePath,
         string prompt,
-        WorkflowCodexOptions codexOptions)
+        WorkflowCodexOptions codexOptions,
+        Func<int, CancellationToken, Task<string?>>? continuationPromptFactory = null)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(workspacePath);
@@ -97,47 +98,38 @@ internal sealed class CodexAppServerClient(
                 .ConfigureAwait(false);
             var threadId = ExtractRequiredNestedId(threadStartResponse, "thread");
 
-            await SendAsync(
-                    session,
-                    new
-                    {
-                        id = 3,
-                        method = "turn/start",
-                        @params = new
-                        {
-                            threadId,
-                            input = new object[]
-                            {
-                                new
-                                {
-                                    type = "text",
-                                    text = prompt
-                                }
-                            },
-                            cwd = workspacePath,
-                            title = $"{context.Issue.Identifier}: {context.Issue.Title}",
-                            approvalPolicy = codexOptions.ApprovalPolicy,
-                            sandboxPolicy = codexOptions.TurnSandboxPolicy
-                        }
-                    },
-                    context.CancellationToken)
-                .ConfigureAwait(false);
-            var turnStartResponse = await ReadResponseAsync(session, 3, codexOptions.ReadTimeoutMs, context, startupDiagnostics, context.CancellationToken)
-                .ConfigureAwait(false);
-            var turnId = ExtractRequiredNestedId(turnStartResponse, "turn");
+            var title = $"{context.Issue.Identifier}: {context.Issue.Title}";
+            var completedTurnCount = 0;
+            var nextPrompt = prompt;
 
-            context.UpdateSession(
-                new LiveSessionMetadata(
-                    threadId,
-                    turnId,
-                    codexAppServerPid: session.ProcessId?.ToString(CultureInfo.InvariantCulture),
-                    lastCodexEvent: "session_started",
-                    lastCodexTimestamp: timeProvider.GetUtcNow(),
-                    lastCodexMessage: "turn_started",
-                    turnCount: 1));
-            context.UpdateStatus(RunAttemptStatus.StreamingTurn);
+            while (true)
+            {
+                completedTurnCount++;
+                var turnStartRequestId = completedTurnCount + 2;
+                await RunTurnAsync(
+                        session,
+                        context,
+                        workspacePath,
+                        title,
+                        threadId,
+                        nextPrompt,
+                        turnStartRequestId,
+                        completedTurnCount,
+                        codexOptions,
+                        startupDiagnostics)
+                    .ConfigureAwait(false);
 
-            await ReadTurnStreamAsync(session, context, codexOptions.TurnTimeoutMs).ConfigureAwait(false);
+                if (continuationPromptFactory is null)
+                {
+                    break;
+                }
+
+                nextPrompt = await continuationPromptFactory(completedTurnCount, context.CancellationToken).ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(nextPrompt))
+                {
+                    break;
+                }
+            }
 
             logger.LogInformation(
                 "codex_launch completed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} outcome=completed",
@@ -166,6 +158,67 @@ internal sealed class CodexAppServerClient(
             {
             }
         }
+    }
+
+    private async Task RunTurnAsync(
+        ICodexProcessSession session,
+        QueuedIssueExecutionContext context,
+        string workspacePath,
+        string title,
+        string threadId,
+        string prompt,
+        int requestId,
+        int turnNumber,
+        WorkflowCodexOptions codexOptions,
+        ConcurrentQueue<string> startupDiagnostics)
+    {
+        await SendAsync(
+                session,
+                new
+                {
+                    id = requestId,
+                    method = "turn/start",
+                    @params = new
+                    {
+                        threadId,
+                        input = new object[]
+                        {
+                            new
+                            {
+                                type = "text",
+                                text = prompt
+                            }
+                        },
+                        cwd = workspacePath,
+                        title,
+                        approvalPolicy = codexOptions.ApprovalPolicy,
+                        sandboxPolicy = codexOptions.TurnSandboxPolicy
+                    }
+                },
+                context.CancellationToken)
+            .ConfigureAwait(false);
+        var turnStartResponse = await ReadResponseAsync(
+                session,
+                requestId,
+                codexOptions.ReadTimeoutMs,
+                context,
+                startupDiagnostics,
+                context.CancellationToken)
+            .ConfigureAwait(false);
+        var turnId = ExtractRequiredNestedId(turnStartResponse, "turn");
+
+        context.UpdateSession(
+            new LiveSessionMetadata(
+                threadId,
+                turnId,
+                codexAppServerPid: session.ProcessId?.ToString(CultureInfo.InvariantCulture),
+                lastCodexEvent: turnNumber == 1 ? "session_started" : "turn_started",
+                lastCodexTimestamp: timeProvider.GetUtcNow(),
+                lastCodexMessage: "turn_started",
+                turnCount: turnNumber));
+        context.UpdateStatus(RunAttemptStatus.StreamingTurn);
+
+        await ReadTurnStreamAsync(session, context, codexOptions.TurnTimeoutMs).ConfigureAwait(false);
     }
 
     private async Task<JsonElement> ReadResponseAsync(

--- a/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.Logging;
 using Symphony.Abstractions.Processes;
+using Symphony.Abstractions.Trackers;
 using Symphony.Abstractions.Workspaces;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
+using Symphony.Domain.Issues;
 using Symphony.Domain.Runs;
 using Symphony.Domain.Workspaces;
 using Symphony.Infrastructure.Codex;
@@ -14,6 +16,7 @@ namespace Symphony.Infrastructure.Orchestration;
 internal sealed class CodexQueuedIssueWorker(
     IWorkflowOptionsProvider workflowOptionsProvider,
     IWorkflowDefinitionProvider workflowDefinitionProvider,
+    IIssueTrackerClient issueTrackerClient,
     IWorkspaceManager workspaceManager,
     IProcessRunner processRunner,
     WorkflowPromptRenderer workflowPromptRenderer,
@@ -34,6 +37,8 @@ internal sealed class CodexQueuedIssueWorker(
         {
             workspace = await workspaceManager.CreateForIssueAsync(context.Issue.Identifier, context.CancellationToken).ConfigureAwait(false);
             var issueWorkspace = workspace ?? throw new InvalidOperationException("Workspace manager returned null.");
+            var currentIssue = context.Issue;
+            var activeStates = CreateStateSet(workflowOptions.Tracker.ActiveStates);
 
             if (workflowOptions.Hooks.BeforeRun is not null)
             {
@@ -51,10 +56,41 @@ internal sealed class CodexQueuedIssueWorker(
 
             context.UpdateStatus(RunAttemptStatus.BuildingPrompt);
             var workflowDefinition = await workflowDefinitionProvider.GetCurrentDefinitionAsync(context.CancellationToken).ConfigureAwait(false);
-            var prompt = workflowPromptRenderer.Render(workflowDefinition, context.Issue, context.Attempt);
+            var prompt = workflowPromptRenderer.RenderTurn(
+                workflowDefinition,
+                currentIssue,
+                context.Attempt,
+                turnNumber: 1,
+                workflowOptions.Agent.MaxTurns);
 
             context.UpdateStatus(RunAttemptStatus.LaunchingAgentProcess);
-            await codexAppServerClient.RunAsync(context, issueWorkspace.Path, prompt, workflowOptions.Codex).ConfigureAwait(false);
+            await codexAppServerClient.RunAsync(
+                    context,
+                    issueWorkspace.Path,
+                    prompt,
+                    workflowOptions.Codex,
+                    async (completedTurnCount, cancellationToken) =>
+                    {
+                        currentIssue = await RefreshIssueAsync(currentIssue, context, cancellationToken).ConfigureAwait(false);
+                        if (!activeStates.Contains(currentIssue.NormalizedState))
+                        {
+                            return null;
+                        }
+
+                        if (completedTurnCount >= workflowOptions.Agent.MaxTurns)
+                        {
+                            return null;
+                        }
+
+                        context.UpdateStatus(RunAttemptStatus.BuildingPrompt);
+                        return workflowPromptRenderer.RenderTurn(
+                            workflowDefinition,
+                            currentIssue,
+                            context.Attempt,
+                            completedTurnCount + 1,
+                            workflowOptions.Agent.MaxTurns);
+                    })
+                .ConfigureAwait(false);
             context.UpdateStatus(RunAttemptStatus.Finishing);
         }
         catch (ProcessRunTimedOutException exception)
@@ -179,5 +215,30 @@ internal sealed class CodexQueuedIssueWorker(
     private static bool IsTimeout(CodexAgentException exception)
     {
         return exception.Code is "response_timeout" or "turn_timeout";
+    }
+
+    private async Task<Issue> RefreshIssueAsync(
+        Issue currentIssue,
+        QueuedIssueExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        var refreshedIssues = await issueTrackerClient.FetchIssueStatesByIdsAsync([currentIssue.Id], cancellationToken).ConfigureAwait(false);
+        var refreshedIssue = refreshedIssues.FirstOrDefault(issue => string.Equals(issue.Id, currentIssue.Id, StringComparison.Ordinal))
+            ?? currentIssue;
+
+        if (!ReferenceEquals(refreshedIssue, currentIssue))
+        {
+            context.UpdateIssue(refreshedIssue);
+        }
+
+        return refreshedIssue;
+    }
+
+    private static HashSet<string> CreateStateSet(IEnumerable<string> states)
+    {
+        return states
+            .Where(state => !string.IsNullOrWhiteSpace(state))
+            .Select(state => state.Trim().ToLowerInvariant())
+            .ToHashSet(StringComparer.Ordinal);
     }
 }

--- a/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowPromptRenderer.cs
+++ b/dotnet/src/Symphony.Infrastructure/Workflows/WorkflowPromptRenderer.cs
@@ -9,19 +9,41 @@ namespace Symphony.Infrastructure.Workflows;
 internal sealed class WorkflowPromptRenderer
 {
     private const string DefaultPrompt = "You are working on an issue from Linear.";
+    private const string DefaultContinuationPrompt = """
+        Continue working in the existing Codex thread for issue {{ issue.identifier }}.
+        Do not repeat the original task prompt; use the existing thread history and current workspace state.
+        This is continuation turn {{ turn_number }} of {{ max_turns }} in the current worker session.
+        Inspect what changed, continue from the next best step, and stop only when you are blocked or the issue is no longer active.
+        """;
 
     public string Render(WorkflowDefinition workflowDefinition, Issue issue, int? attempt)
     {
+        return RenderTurn(workflowDefinition, issue, attempt, turnNumber: 1, maxTurns: 1);
+    }
+
+    public string RenderTurn(
+        WorkflowDefinition workflowDefinition,
+        Issue issue,
+        int? attempt,
+        int turnNumber,
+        int maxTurns)
+    {
         ArgumentNullException.ThrowIfNull(workflowDefinition);
         ArgumentNullException.ThrowIfNull(issue);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(turnNumber);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTurns);
 
-        var template = string.IsNullOrWhiteSpace(workflowDefinition.PromptTemplate)
-            ? DefaultPrompt
-            : workflowDefinition.PromptTemplate;
+        var template = turnNumber == 1
+            ? string.IsNullOrWhiteSpace(workflowDefinition.PromptTemplate)
+                ? DefaultPrompt
+                : workflowDefinition.PromptTemplate
+            : DefaultContinuationPrompt;
         var variables = new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["issue"] = BuildIssueModel(issue),
-            ["attempt"] = attempt
+            ["attempt"] = attempt,
+            ["turn_number"] = turnNumber,
+            ["max_turns"] = maxTurns
         };
 
         var tokens = Tokenize(template);

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/ActiveSessionRegistryTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/ActiveSessionRegistryTests.cs
@@ -73,6 +73,27 @@ public sealed class ActiveSessionRegistryTests
     }
 
     [Fact]
+    public void ExecutionContext_updates_issue_snapshot_when_tracker_state_changes()
+    {
+        var registry = CreateRegistry();
+        using var trackedSession = registry.BeginSession(CreateIssue("ABC-9", "ABC-9"), attempt: 1, CancellationToken.None);
+        var context = trackedSession.CreateExecutionContext();
+
+        context.UpdateIssue(
+            new Issue(
+                "ABC-9",
+                "ABC-9",
+                "Issue ABC-9",
+                description: "Active session registry test",
+                state: "Done",
+                createdAt: DateTimeOffset.UtcNow));
+
+        var snapshot = Assert.Single(registry.GetActiveSessions());
+
+        Assert.Equal("Done", snapshot.IssueState);
+    }
+
+    [Fact]
     public void ExecutionContext_logs_issue_and_session_fields_with_spec_names()
     {
         var logger = new TestLogger<ActiveSessionRegistry>();

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
@@ -136,6 +136,78 @@ public sealed class CodexAppServerClientTests
     }
 
     [Fact]
+    public async Task RunAsync_reuses_same_thread_for_continuation_turns_and_updates_turn_count()
+    {
+        var turnCounter = 0;
+        var sessionFactory = new TestCodexProcessSessionFactory(
+            async (line, session) =>
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                var method = root.TryGetProperty("method", out var methodElement)
+                    ? methodElement.GetString()
+                    : null;
+
+                if (method == "initialize")
+                {
+                    session.EnqueueStdout(new { id = 1, result = new { } });
+                    return;
+                }
+
+                if (method == "thread/start")
+                {
+                    session.EnqueueStdout(new { id = 2, result = new { thread = new { id = "thread-123" } } });
+                    return;
+                }
+
+                if (method == "turn/start")
+                {
+                    turnCounter++;
+                    session.EnqueueStdout(new { id = turnCounter + 2, result = new { turn = new { id = $"turn-{turnCounter}" } } });
+                    session.EnqueueStdout(new { method = "turn/completed", @params = new { message = $"done-{turnCounter}" } });
+                }
+
+                await Task.CompletedTask;
+            });
+        var client = new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance);
+        using var testContext = CreateContext();
+
+        await client.RunAsync(
+            testContext.Context,
+            Path.GetTempPath(),
+            "Prompt body",
+            CreateCodexOptions(),
+            (completedTurnCount, cancellationToken) => Task.FromResult<string?>(
+                completedTurnCount == 1 ? "Continuation prompt" : null));
+
+        Assert.NotNull(sessionFactory.Session);
+        var turnStartLines = sessionFactory.Session!.SentLines
+            .Where(line => line.Contains("\"method\":\"turn/start\"", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(2, turnStartLines.Length);
+
+        using var firstTurnDocument = JsonDocument.Parse(turnStartLines[0]);
+        using var secondTurnDocument = JsonDocument.Parse(turnStartLines[1]);
+        var firstTurnRoot = firstTurnDocument.RootElement;
+        var secondTurnRoot = secondTurnDocument.RootElement;
+        var firstTurnParams = firstTurnRoot.GetProperty("params");
+        var secondTurnParams = secondTurnRoot.GetProperty("params");
+
+        Assert.Equal(3, firstTurnRoot.GetProperty("id").GetInt32());
+        Assert.Equal(4, secondTurnRoot.GetProperty("id").GetInt32());
+        Assert.Equal("thread-123", firstTurnParams.GetProperty("threadId").GetString());
+        Assert.Equal("thread-123", secondTurnParams.GetProperty("threadId").GetString());
+        Assert.Equal("Prompt body", firstTurnParams.GetProperty("input")[0].GetProperty("text").GetString());
+        Assert.Equal("Continuation prompt", secondTurnParams.GetProperty("input")[0].GetProperty("text").GetString());
+
+        var latestSession = Assert.IsType<LiveSessionMetadata>(testContext.Context.Session);
+        Assert.Equal("thread-123-turn-2", latestSession.SessionId);
+        Assert.Equal(2, latestSession.TurnCount);
+        Assert.Equal("turn_completed", latestSession.LastCodexEvent);
+        Assert.Equal("done-2", latestSession.LastCodexMessage);
+    }
+
+    [Fact]
     public async Task RunAsync_includes_stderr_when_process_exits_during_startup_handshake()
     {
         var sessionFactory = new TestCodexProcessSessionFactory(

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Orchestration/CodexQueuedIssueWorkerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Symphony.Abstractions.Trackers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Symphony.Abstractions.Processes;
@@ -65,6 +66,7 @@ public sealed class CodexQueuedIssueWorkerTests
             var worker = new CodexQueuedIssueWorker(
                 new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
                 new StaticWorkflowDefinitionProvider(workflowDefinition),
+                new RecordingIssueTrackerClient(),
                 new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
                 processRunner,
                 new WorkflowPromptRenderer(),
@@ -126,6 +128,7 @@ public sealed class CodexQueuedIssueWorkerTests
             var worker = new CodexQueuedIssueWorker(
                 new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
                 new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
+                new RecordingIssueTrackerClient(),
                 new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
                 new RecordingProcessRunner(exitCodes: [1]),
                 new WorkflowPromptRenderer(),
@@ -154,6 +157,7 @@ public sealed class CodexQueuedIssueWorkerTests
             var worker = new CodexQueuedIssueWorker(
                 new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
                 new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
+                new RecordingIssueTrackerClient(),
                 new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
                 new RecordingProcessRunner(
                     exceptionFactory: request => new ProcessRunTimedOutException(
@@ -185,6 +189,7 @@ public sealed class CodexQueuedIssueWorkerTests
             var worker = new CodexQueuedIssueWorker(
                 new StaticWorkflowOptionsProvider(CreateWorkflowOptions(beforeRun: null, afterRun: null, readTimeoutMs: 50)),
                 new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
+                new RecordingIssueTrackerClient(),
                 new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
                 new RecordingProcessRunner(),
                 new WorkflowPromptRenderer(),
@@ -201,10 +206,163 @@ public sealed class CodexQueuedIssueWorkerTests
         }
     }
 
+    [Fact]
+    public async Task ExecuteAsync_reuses_same_thread_for_multiple_turns_until_max_turns()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "symphony-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspacePath);
+
+        try
+        {
+            var workflowDefinition = new WorkflowDefinition(
+                config: null,
+                promptTemplate: """
+                    Issue {{ issue.identifier }}
+                    {% if attempt %}
+                    Attempt {{ attempt }}
+                    {% endif %}
+                    """);
+            var turnCounter = 0;
+            var sessionFactory = new TestCodexProcessSessionFactory(
+                async (line, session) =>
+                {
+                    using var document = JsonDocument.Parse(line);
+                    var root = document.RootElement;
+                    var method = root.TryGetProperty("method", out var methodElement)
+                        ? methodElement.GetString()
+                        : null;
+
+                    if (method == "initialize")
+                    {
+                        session.EnqueueStdout(new { id = 1, result = new { } });
+                    }
+                    else if (method == "thread/start")
+                    {
+                        session.EnqueueStdout(new { id = 2, result = new { thread = new { id = "thread-abc" } } });
+                    }
+                    else if (method == "turn/start")
+                    {
+                        turnCounter++;
+                        session.EnqueueStdout(new { id = turnCounter + 2, result = new { turn = new { id = $"turn-{turnCounter}" } } });
+                        session.EnqueueStdout(new { method = "turn/completed", @params = new { message = $"done-{turnCounter}" } });
+                    }
+
+                    await Task.CompletedTask;
+                });
+            var client = new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance);
+            var processRunner = new RecordingProcessRunner();
+            var issueTrackerClient = new RecordingIssueTrackerClient(
+            [
+                CreateIssue(state: "Open"),
+                CreateIssue(state: "Open")
+            ]);
+            var worker = new CodexQueuedIssueWorker(
+                new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxTurns: 2)),
+                new StaticWorkflowDefinitionProvider(workflowDefinition),
+                issueTrackerClient,
+                new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
+                processRunner,
+                new WorkflowPromptRenderer(),
+                client,
+                NullLogger<CodexQueuedIssueWorker>.Instance);
+            using var testContext = CreateContext(attempt: 3);
+
+            await worker.ExecuteAsync(testContext.Context);
+
+            Assert.Equal(2, issueTrackerClient.Requests.Count);
+            Assert.All(issueTrackerClient.Requests, request => Assert.Equal(new[] { "21" }, request));
+
+            Assert.NotNull(sessionFactory.Session);
+            var turnStartLines = sessionFactory.Session!.SentLines
+                .Where(line => line.Contains("\"method\":\"turn/start\"", StringComparison.Ordinal))
+                .ToArray();
+            Assert.Equal(2, turnStartLines.Length);
+
+            using var firstTurnDocument = JsonDocument.Parse(turnStartLines[0]);
+            using var secondTurnDocument = JsonDocument.Parse(turnStartLines[1]);
+            var firstTurnParams = firstTurnDocument.RootElement.GetProperty("params");
+            var secondTurnParams = secondTurnDocument.RootElement.GetProperty("params");
+
+            Assert.Equal("thread-abc", firstTurnParams.GetProperty("threadId").GetString());
+            Assert.Equal("thread-abc", secondTurnParams.GetProperty("threadId").GetString());
+            Assert.Contains("Issue #21", firstTurnParams.GetProperty("input")[0].GetProperty("text").GetString(), StringComparison.Ordinal);
+            Assert.Contains("Attempt 3", firstTurnParams.GetProperty("input")[0].GetProperty("text").GetString(), StringComparison.Ordinal);
+            Assert.Contains("continuation turn 2 of 2", secondTurnParams.GetProperty("input")[0].GetProperty("text").GetString(), StringComparison.OrdinalIgnoreCase);
+
+            var latestSession = Assert.IsType<LiveSessionMetadata>(testContext.Context.Session);
+            Assert.Equal("thread-abc-turn-2", latestSession.SessionId);
+            Assert.Equal(2, latestSession.TurnCount);
+            Assert.Equal("turn_completed", latestSession.LastCodexEvent);
+        }
+        finally
+        {
+            Directory.Delete(workspacePath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_stops_after_tracker_marks_issue_inactive()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "symphony-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspacePath);
+
+        try
+        {
+            var sessionFactory = new TestCodexProcessSessionFactory(
+                async (line, session) =>
+                {
+                    using var document = JsonDocument.Parse(line);
+                    var root = document.RootElement;
+                    var method = root.TryGetProperty("method", out var methodElement)
+                        ? methodElement.GetString()
+                        : null;
+
+                    if (method == "initialize")
+                    {
+                        session.EnqueueStdout(new { id = 1, result = new { } });
+                    }
+                    else if (method == "thread/start")
+                    {
+                        session.EnqueueStdout(new { id = 2, result = new { thread = new { id = "thread-abc" } } });
+                    }
+                    else if (method == "turn/start")
+                    {
+                        session.EnqueueStdout(new { id = 3, result = new { turn = new { id = "turn-1" } } });
+                        session.EnqueueStdout(new { method = "turn/completed", @params = new { message = "done-1" } });
+                    }
+
+                    await Task.CompletedTask;
+                });
+            var worker = new CodexQueuedIssueWorker(
+                new StaticWorkflowOptionsProvider(CreateWorkflowOptions(beforeRun: null, afterRun: null, maxTurns: 3)),
+                new StaticWorkflowDefinitionProvider(new WorkflowDefinition(null, "Prompt")),
+                new RecordingIssueTrackerClient([CreateIssue(state: "Done")]),
+                new StaticWorkspaceManager(new Workspace(workspacePath, "GH-21", createdNow: true)),
+                new RecordingProcessRunner(),
+                new WorkflowPromptRenderer(),
+                new CodexAppServerClient(sessionFactory, TimeProvider.System, NullLogger<CodexAppServerClient>.Instance),
+                NullLogger<CodexQueuedIssueWorker>.Instance);
+            using var testContext = CreateContext(attempt: null);
+
+            await worker.ExecuteAsync(testContext.Context);
+
+            Assert.NotNull(sessionFactory.Session);
+            Assert.Single(
+                sessionFactory.Session!.SentLines,
+                line => line.Contains("\"method\":\"turn/start\"", StringComparison.Ordinal));
+            Assert.Equal("Done", testContext.Context.Issue.State);
+        }
+        finally
+        {
+            Directory.Delete(workspacePath, recursive: true);
+        }
+    }
+
     private static WorkflowServiceOptions CreateWorkflowOptions(
         string? beforeRun = "Write-Host before",
         string? afterRun = "Write-Host after",
-        int readTimeoutMs = 5_000)
+        int readTimeoutMs = 5_000,
+        int maxTurns = 1)
     {
         return new WorkflowServiceOptions(
             new WorkflowTrackerOptions(
@@ -225,7 +383,7 @@ public sealed class CodexQueuedIssueWorkerTests
                 afterRun,
                 null,
                 5_000),
-            new WorkflowAgentOptions(1, 20, 300_000, new Dictionary<string, int>(StringComparer.Ordinal)),
+            new WorkflowAgentOptions(1, maxTurns, 300_000, new Dictionary<string, int>(StringComparer.Ordinal)),
             new WorkflowCodexOptions(
                 "codex app-server",
                 "never",
@@ -241,12 +399,7 @@ public sealed class CodexQueuedIssueWorkerTests
 
     private static TestExecutionContext CreateContext(int? attempt)
     {
-        var issue = new Issue(
-            id: "21",
-            identifier: "#21",
-            title: "Implement Codex agent runner",
-            description: "Implement the runner",
-            state: "Todo");
+        var issue = CreateIssue();
         var logger = new RecordingLogger<ActiveSessionRegistry>();
         var registry = new ActiveSessionRegistry(TimeProvider.System, logger);
         var trackedSession = registry.BeginSession(issue, attempt, CancellationToken.None);
@@ -255,6 +408,16 @@ public sealed class CodexQueuedIssueWorkerTests
             trackedSession,
             trackedSession.CreateExecutionContext(),
             logger);
+    }
+
+    private static Issue CreateIssue(string state = "Todo")
+    {
+        return new Issue(
+            id: "21",
+            identifier: "#21",
+            title: "Implement Codex agent runner",
+            description: "Implement the runner",
+            state: state);
     }
 
     private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions options) : IWorkflowOptionsProvider
@@ -283,6 +446,41 @@ public sealed class CodexQueuedIssueWorkerTests
         public Task DeleteForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingIssueTrackerClient(IEnumerable<Issue>? refreshedIssues = null) : IIssueTrackerClient
+    {
+        private readonly Queue<IReadOnlyList<Issue>> _refreshedIssues = new(
+            (refreshedIssues ?? [])
+            .Select(issue => (IReadOnlyList<Issue>)new[] { issue }));
+
+        public List<IReadOnlyList<string>> Requests { get; } = [];
+
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(issueIds.ToArray());
+
+            if (_refreshedIssues.Count == 0)
+            {
+                return Task.FromResult<IReadOnlyList<Issue>>([]);
+            }
+
+            return Task.FromResult(_refreshedIssues.Dequeue());
         }
     }
 

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowPromptRendererTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Workflows/WorkflowPromptRendererTests.cs
@@ -44,6 +44,26 @@ public sealed class WorkflowPromptRendererTests
     }
 
     [Fact]
+    public void RenderTurn_uses_continuation_guidance_after_first_turn()
+    {
+        var definition = new WorkflowDefinition(
+            config: null,
+            promptTemplate: "Original prompt for {{ issue.identifier }}");
+
+        var result = _renderer.RenderTurn(
+            definition,
+            CreateIssue(),
+            attempt: 2,
+            turnNumber: 2,
+            maxTurns: 5);
+
+        Assert.Contains("existing Codex thread", result, StringComparison.Ordinal);
+        Assert.Contains("#1", result, StringComparison.Ordinal);
+        Assert.Contains("continuation turn 2 of 5", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Original prompt", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Render_throws_for_unknown_variables()
     {
         var definition = new WorkflowDefinition(


### PR DESCRIPTION
#### Context

Issue #53 tracks a SPEC conformance gap: successful worker continuations were leaving the live Codex session and returning only through the outer retry path.

#### TL;DR

Keep one Codex thread/process alive for multiple turns per worker run, up to `agent.max_turns`.

#### Summary

- keep the Codex app-server process and thread alive across continuation turns
- refresh tracker state after each successful turn and stop when the issue is no longer active
- render continuation-only guidance after the first turn and update turn-count/session coverage
- document the multi-turn runtime behavior in `dotnet/README.md`

#### Alternatives

- keep continuation only as an outer retry: rejected because it still violates `SPEC.md` section 7.1
- move tracker refresh into the dispatch loop: rejected because the worker owns live-session turn decisions

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] Focused checks:
  - `dotnet test .\dotnet\tests\Symphony.Infrastructure.Tests\Symphony.Infrastructure.Tests.csproj -c Release -m:1 -v minimal`
  - `dotnet test .\dotnet\tests\Symphony.Application.Tests\Symphony.Application.Tests.csproj -c Release -m:1 -v minimal`

Closes #53