### PR TITLE
Add startup terminal workspace cleanup

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -250,10 +250,14 @@ Notes:
 
 - If a value is missing, defaults are used where defined by the implementation/spec.
 - `polling.interval_ms` controls the delay between poll ticks. After startup validation succeeds,
-  Symphony runs an immediate tick and then continues on the configured interval.
+  Symphony performs a best-effort terminal workspace cleanup sweep, runs an immediate tick, and
+  then continues on the configured interval.
 - `Orchestration:InitialState` in `appsettings*.json` controls whether the host boots in
   `Started` or `Stopped` mode. `Stopped` blocks new poll ticks and new issue assignment until an
   operator resumes orchestration.
+- Startup cleanup queries the tracker for issues already in terminal states and deletes their
+  matching workspaces before polling starts. Fetch or deletion failures are logged as warnings and
+  do not block host startup.
 - Each poll tick reconciles currently running issues before fetching new candidates. Terminal
   tracker transitions cancel the active worker and trigger workspace cleanup; non-active,
   non-terminal transitions cancel the worker without deleting the workspace.

--- a/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Codex;
 using Symphony.Infrastructure.Orchestration;
 using Symphony.Infrastructure.Processes;
+using Symphony.Infrastructure.Startup;
 using Symphony.Infrastructure.Workflows;
 using Symphony.Infrastructure.Workspaces;
 
@@ -31,6 +32,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<ITrackerClientOptionsProvider, TrackerClientOptionsProvider>();
         services.AddSingleton<IWorkflowLoader, YamlWorkflowLoader>();
         services.AddHostedService<WorkflowStartupValidationHostedService>();
+        services.AddHostedService<StartupTerminalWorkspaceCleanupHostedService>();
         services.AddHostedService<PollingBackgroundService>();
         services.AddSingleton<IProcessRunner, ProcessRunner>();
         services.AddSingleton<IWorkspaceManager, WorkspaceManager>();

--- a/dotnet/src/Symphony.Infrastructure/Startup/StartupTerminalWorkspaceCleanupHostedService.cs
+++ b/dotnet/src/Symphony.Infrastructure/Startup/StartupTerminalWorkspaceCleanupHostedService.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Trackers;
+using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Issues;
+
+namespace Symphony.Infrastructure.Startup;
+
+public sealed class StartupTerminalWorkspaceCleanupHostedService(
+    IWorkflowOptionsProvider workflowOptionsProvider,
+    IIssueTrackerClient issueTrackerClient,
+    IWorkspaceManager workspaceManager,
+    ILogger<StartupTerminalWorkspaceCleanupHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var terminalStates = workflowOptions.Tracker.TerminalStates
+            .Where(state => !string.IsNullOrWhiteSpace(state))
+            .Select(state => state.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        logger.LogInformation(
+            "startup_terminal_cleanup started terminal_state_count={terminal_state_count} outcome=started",
+            terminalStates.Length);
+
+        if (terminalStates.Length == 0)
+        {
+            logger.LogInformation(
+                "startup_terminal_cleanup completed terminal_issue_count={terminal_issue_count} cleaned_count={cleaned_count} failed_count={failed_count} outcome=completed",
+                0,
+                0,
+                0);
+            return;
+        }
+
+        IReadOnlyList<Issue> terminalIssues;
+        try
+        {
+            terminalIssues = await issueTrackerClient.FetchIssuesByStatesAsync(terminalStates, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(
+                exception,
+                "startup_terminal_cleanup failed terminal_state_count={terminal_state_count} reason=terminal_issue_fetch_failed outcome=continued",
+                terminalStates.Length);
+            return;
+        }
+
+        var cleanedCount = 0;
+        var failedCount = 0;
+        var cleanedIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var issue in terminalIssues)
+        {
+            if (!cleanedIdentifiers.Add(issue.Identifier))
+            {
+                continue;
+            }
+
+            try
+            {
+                await workspaceManager.DeleteForIssueAsync(issue.Identifier, cancellationToken).ConfigureAwait(false);
+                cleanedCount++;
+
+                logger.LogInformation(
+                    "startup_terminal_cleanup cleaned issue_id={issue_id} issue_identifier={issue_identifier} outcome=cleaned",
+                    issue.Id,
+                    issue.Identifier);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                failedCount++;
+                logger.LogWarning(
+                    exception,
+                    "startup_terminal_cleanup failed issue_id={issue_id} issue_identifier={issue_identifier} reason=workspace_cleanup_failed outcome=continued",
+                    issue.Id,
+                    issue.Identifier);
+            }
+        }
+
+        logger.LogInformation(
+            "startup_terminal_cleanup completed terminal_issue_count={terminal_issue_count} cleaned_count={cleaned_count} failed_count={failed_count} outcome=completed",
+            cleanedIdentifiers.Count,
+            cleanedCount,
+            failedCount);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyHostLifecycleIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyHostLifecycleIntegrationTests.cs
@@ -83,6 +83,67 @@ public sealed class SymphonyHostLifecycleIntegrationTests
     }
 
     [Fact]
+    public async Task StartAsync_runs_terminal_workspace_cleanup_before_polling_dispatch()
+    {
+        var activeIssue = new Issue(
+            id: "42",
+            identifier: "ABC-42",
+            title: "Smoke flow",
+            description: "Validate the orchestration path",
+            priority: 1,
+            state: "Todo",
+            createdAt: new DateTimeOffset(2026, 3, 18, 9, 0, 0, TimeSpan.Zero));
+        var terminalIssue = new Issue(
+            id: "9",
+            identifier: "DONE-9",
+            title: "Completed",
+            description: "Cleanup target",
+            priority: 1,
+            state: "Done",
+            createdAt: new DateTimeOffset(2026, 3, 17, 9, 0, 0, TimeSpan.Zero));
+        var trackerClient = new StartupCleanupTrackerClient(activeIssue, terminalIssue);
+        var probe = new SmokeRunProbe();
+        var staleWorkspacePath = string.Empty;
+
+        await using var host = await StartedSymphonyHost.StartAsync(
+            tempDirectory =>
+            {
+                staleWorkspacePath = Path.Combine(tempDirectory, "workspaces", terminalIssue.Identifier);
+                Directory.CreateDirectory(staleWorkspacePath);
+                return CreateWorkflowContents(Path.Combine(tempDirectory, "workspaces"));
+            },
+            configureBuilder: builder =>
+            {
+                builder.Configuration.AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["Orchestration:InitialState"] = "Started"
+                    });
+            },
+            configureServices: services =>
+            {
+                services.RemoveAll<IIssueTrackerClient>();
+                services.AddSingleton<IIssueTrackerClient>(trackerClient);
+
+                services.RemoveAll<IQueuedIssueWorker>();
+                services.AddSingleton(probe);
+                services.AddSingleton<IQueuedIssueWorker, SmokeQueuedIssueWorker>();
+
+                RemoveHostedService<RetryDispatchBackgroundService>(services);
+            });
+
+        await probe.AttemptObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(Directory.Exists(staleWorkspacePath));
+        Assert.Equal(["Done"], trackerClient.LastFetchedStates);
+        Assert.Equal("terminal_fetch", trackerClient.CallOrder[0]);
+        Assert.Contains("candidate_fetch", trackerClient.CallOrder);
+        Assert.True(
+            trackerClient.CallOrder.IndexOf("terminal_fetch") < trackerClient.CallOrder.IndexOf("candidate_fetch"),
+            "Startup terminal cleanup should run before polling fetches candidates.");
+    }
+
+    [Fact]
     public async Task StartAsync_exposes_ui_routes_and_ui_services_from_di()
     {
         await using var host = await StartedSymphonyHost.StartAsync(
@@ -322,6 +383,35 @@ public sealed class SymphonyHostLifecycleIntegrationTests
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+    }
+
+    private sealed class StartupCleanupTrackerClient(Issue activeIssue, Issue terminalIssue) : IIssueTrackerClient
+    {
+        public List<string> CallOrder { get; } = [];
+
+        public IReadOnlyList<string> LastFetchedStates { get; private set; } = Array.Empty<string>();
+
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            CallOrder.Add("candidate_fetch");
+            return Task.FromResult<IReadOnlyList<Issue>>([activeIssue]);
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            CallOrder.Add("terminal_fetch");
+            LastFetchedStates = stateNames.ToArray();
+            return Task.FromResult<IReadOnlyList<Issue>>([terminalIssue]);
         }
 
         public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(

--- a/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -12,6 +12,7 @@ using Symphony.Infrastructure.Configuration;
 using Symphony.Infrastructure.Orchestration;
 using Symphony.Infrastructure.DependencyInjection;
 using Symphony.Infrastructure.Processes;
+using Symphony.Infrastructure.Startup;
 using Symphony.Infrastructure.Workflows;
 using Symphony.Infrastructure.Workspaces;
 
@@ -51,7 +52,16 @@ public class InfrastructureServiceCollectionExtensionsTests
         var hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
 
         Assert.Contains(hostedServices, service => service is WorkflowStartupValidationHostedService);
+        Assert.Contains(hostedServices, service => service is StartupTerminalWorkspaceCleanupHostedService);
         Assert.Contains(hostedServices, service => service is PollingBackgroundService);
+
+        var startupValidationIndex = Array.FindIndex(hostedServices, static service => service is WorkflowStartupValidationHostedService);
+        var startupCleanupIndex = Array.FindIndex(hostedServices, static service => service is StartupTerminalWorkspaceCleanupHostedService);
+        var pollingIndex = Array.FindIndex(hostedServices, static service => service is PollingBackgroundService);
+
+        Assert.True(startupValidationIndex >= 0);
+        Assert.True(startupCleanupIndex > startupValidationIndex);
+        Assert.True(pollingIndex > startupCleanupIndex);
     }
 
     private sealed class StubIssueTrackerClient : IIssueTrackerClient

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Startup/StartupTerminalWorkspaceCleanupHostedServiceTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Startup/StartupTerminalWorkspaceCleanupHostedServiceTests.cs
@@ -1,0 +1,267 @@
+using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Trackers;
+using Symphony.Abstractions.Workspaces;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Issues;
+using Symphony.Domain.Workspaces;
+using Symphony.Infrastructure.Startup;
+
+namespace Symphony.Infrastructure.Tests.Startup;
+
+public sealed class StartupTerminalWorkspaceCleanupHostedServiceTests
+{
+    [Fact]
+    public async Task StartAsync_fetches_terminal_issues_and_deletes_matching_workspaces()
+    {
+        var trackerClient = new StubIssueTrackerClient
+        {
+            TerminalIssues =
+            [
+                CreateIssue("1", "ABC-1", "Done"),
+                CreateIssue("2", "ABC-2", "Canceled"),
+                CreateIssue("3", "ABC-1", "Done")
+            ]
+        };
+        var workspaceManager = new StubWorkspaceManager();
+        var logger = new TestLogger<StartupTerminalWorkspaceCleanupHostedService>();
+        var service = CreateService(trackerClient, workspaceManager, logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(["Done", "Canceled"], trackerClient.LastFetchedStates);
+        Assert.Equal(["ABC-1", "ABC-2"], workspaceManager.RequestedIssueIdentifiers);
+
+        var completedEntry = Assert.Single(
+            logger.Entries,
+            entry => entry.Message.Contains("startup_terminal_cleanup completed", StringComparison.Ordinal));
+        Assert.Equal(2d, Convert.ToDouble(completedEntry.State["terminal_issue_count"]));
+        Assert.Equal(2d, Convert.ToDouble(completedEntry.State["cleaned_count"]));
+        Assert.Equal(0d, Convert.ToDouble(completedEntry.State["failed_count"]));
+    }
+
+    [Fact]
+    public async Task StartAsync_logs_warning_and_continues_when_terminal_issue_fetch_fails()
+    {
+        var trackerClient = new StubIssueTrackerClient
+        {
+            FetchByStatesException = new InvalidOperationException("boom")
+        };
+        var workspaceManager = new StubWorkspaceManager();
+        var logger = new TestLogger<StartupTerminalWorkspaceCleanupHostedService>();
+        var service = CreateService(trackerClient, workspaceManager, logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Empty(workspaceManager.RequestedIssueIdentifiers);
+
+        var warningEntry = Assert.Single(logger.Entries, entry => entry.LogLevel == LogLevel.Warning);
+        Assert.Contains("reason=terminal_issue_fetch_failed", warningEntry.Message, StringComparison.Ordinal);
+        Assert.NotNull(warningEntry.Exception);
+    }
+
+    [Fact]
+    public async Task StartAsync_logs_warning_and_continues_when_workspace_cleanup_fails()
+    {
+        var trackerClient = new StubIssueTrackerClient
+        {
+            TerminalIssues =
+            [
+                CreateIssue("1", "ABC-1", "Done"),
+                CreateIssue("2", "ABC-2", "Done")
+            ]
+        };
+        var workspaceManager = new StubWorkspaceManager();
+        workspaceManager.FailingIssueIdentifiers.Add("ABC-1");
+        var logger = new TestLogger<StartupTerminalWorkspaceCleanupHostedService>();
+        var service = CreateService(trackerClient, workspaceManager, logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(["ABC-1", "ABC-2"], workspaceManager.RequestedIssueIdentifiers);
+        Assert.Equal(["ABC-2"], workspaceManager.DeletedIssueIdentifiers);
+
+        var warningEntry = Assert.Single(logger.Entries, entry => entry.LogLevel == LogLevel.Warning);
+        Assert.Contains("reason=workspace_cleanup_failed", warningEntry.Message, StringComparison.Ordinal);
+
+        var completedEntry = Assert.Single(
+            logger.Entries,
+            entry => entry.Message.Contains("startup_terminal_cleanup completed", StringComparison.Ordinal));
+        Assert.Equal(2d, Convert.ToDouble(completedEntry.State["terminal_issue_count"]));
+        Assert.Equal(1d, Convert.ToDouble(completedEntry.State["cleaned_count"]));
+        Assert.Equal(1d, Convert.ToDouble(completedEntry.State["failed_count"]));
+    }
+
+    private static StartupTerminalWorkspaceCleanupHostedService CreateService(
+        IIssueTrackerClient trackerClient,
+        StubWorkspaceManager workspaceManager,
+        ILogger<StartupTerminalWorkspaceCleanupHostedService> logger)
+    {
+        return new StartupTerminalWorkspaceCleanupHostedService(
+            new StaticWorkflowOptionsProvider(CreateWorkflowOptions()),
+            trackerClient,
+            workspaceManager,
+            logger);
+    }
+
+    private static WorkflowServiceOptions CreateWorkflowOptions()
+    {
+        return new WorkflowServiceOptions(
+            new WorkflowTrackerOptions(
+                "github",
+                "https://api.github.com",
+                "token",
+                null,
+                "owner/repo",
+                null,
+                null,
+                ["Todo", "In Progress"],
+                ["Done", "Canceled"]),
+            new WorkflowPollingOptions(1_000),
+            new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+            new WorkflowHookOptions(
+                null,
+                null,
+                null,
+                null,
+                60_000),
+            new WorkflowAgentOptions(
+                4,
+                20,
+                300_000,
+                new Dictionary<string, int>(StringComparer.Ordinal)),
+            new WorkflowCodexOptions(
+                "codex app-server",
+                null,
+                null,
+                null,
+                3_600_000,
+                5_000,
+                300_000));
+    }
+
+    private static Issue CreateIssue(string id, string identifier, string state)
+    {
+        return new Issue(
+            id,
+            identifier,
+            $"Issue {identifier}",
+            description: "Startup cleanup test",
+            priority: 1,
+            state: state,
+            createdAt: new DateTimeOffset(2026, 3, 23, 10, 0, 0, TimeSpan.Zero));
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class StubIssueTrackerClient : IIssueTrackerClient
+    {
+        public IReadOnlyList<Issue> TerminalIssues { get; set; } = Array.Empty<Issue>();
+
+        public Exception? FetchByStatesException { get; set; }
+
+        public IReadOnlyList<string> LastFetchedStates { get; private set; } = Array.Empty<string>();
+
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            if (FetchByStatesException is not null)
+            {
+                throw FetchByStatesException;
+            }
+
+            LastFetchedStates = stateNames.ToArray();
+            return Task.FromResult(TerminalIssues);
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+    }
+
+    private sealed class StubWorkspaceManager : IWorkspaceManager
+    {
+        public List<string> RequestedIssueIdentifiers { get; } = [];
+
+        public List<string> DeletedIssueIdentifiers { get; } = [];
+
+        public HashSet<string> FailingIssueIdentifiers { get; } = new(StringComparer.Ordinal);
+
+        public Task<Workspace> CreateForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new Workspace(Path.Combine(Path.GetTempPath(), issueIdentifier), issueIdentifier, createdNow: true));
+        }
+
+        public Task DeleteForIssueAsync(string issueIdentifier, CancellationToken cancellationToken = default)
+        {
+            RequestedIssueIdentifiers.Add(issueIdentifier);
+
+            if (FailingIssueIdentifiers.Contains(issueIdentifier))
+            {
+                throw new InvalidOperationException($"Failed to delete {issueIdentifier}.");
+            }
+
+            DeletedIssueIdentifiers.Add(issueIdentifier);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<TestLogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var structuredState = state as IEnumerable<KeyValuePair<string, object?>>;
+            var values = structuredState?.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+                ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+
+            Entries.Add(new TestLogEntry(logLevel, formatter(state, exception), values, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private sealed record TestLogEntry(
+        LogLevel LogLevel,
+        string Message,
+        IReadOnlyDictionary<string, object?> State,
+        Exception? Exception);
+}


### PR DESCRIPTION
#### Context

Issue #55 tracks a SPEC conformance gap: Symphony cleaned terminal workspaces during active-run reconciliation, but it did not perform the required startup sweep for terminal issues left behind across restarts.

#### TL;DR

Add a dedicated startup hosted service that fetches terminal issues, deletes their matching workspaces before polling starts, and logs recoverable failures without blocking host startup.

#### Summary

- add `StartupTerminalWorkspaceCleanupHostedService` and register it between workflow validation and polling
- fetch terminal issues through the workflow-selected tracker adapter and delete matching workspaces with the existing safety checks
- continue startup when terminal-issue fetch or per-workspace deletion fails, while emitting structured warning logs
- add infrastructure tests, DI-order coverage, and a host integration test that proves startup cleanup runs before polling dispatch
- document the startup cleanup behavior in `dotnet/README.md`

#### Alternatives

- fold startup cleanup into the first polling tick: rejected because `SPEC.md` requires cleanup before the immediate startup tick
- add cleanup logic directly to `OrchestratorPollingIterationHandler`: rejected because that mixes startup-only behavior into per-tick reconciliation and weakens the startup ordering contract

#### Test Plan

- [x] `dotnet build .\dotnet\Symphony.sln -c Release -m:1 -v minimal`
- [x] `dotnet test .\dotnet\tests\Symphony.Infrastructure.Tests\Symphony.Infrastructure.Tests.csproj -c Release --no-build -m:1 -v minimal`
- [x] `dotnet test .\dotnet\tests\Symphony.Host.IntegrationTests\Symphony.Host.IntegrationTests.csproj -c Release --no-build -m:1 -v minimal`
- [x] `dotnet test .\dotnet\Symphony.sln -c Release --no-build -m:1 -v minimal`
- [x] `dotnet format .\dotnet\Symphony.sln --verify-no-changes --no-restore`

Closes #55