### PR TITLE
Honor workflow and CLI host port binding

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -305,10 +305,18 @@ Notes:
 
 ## Web dashboard
 
-When enabled via service configuration (for example `server.port`), Symphony exposes:
+When enabled via service configuration, Symphony exposes:
 
 - Dashboard at `/`
 - JSON APIs under `/api/v1/*`
+
+Host binding notes:
+
+- `server.port` in `WORKFLOW.md` enables host binding when the dashboard/API surface is shipped.
+- CLI `--port` overrides `server.port`.
+- `0` requests an ephemeral local port, which is useful for development and tests.
+- The current host binds loopback (`127.0.0.1`) by default when an explicit port is selected.
+- Listener changes are restart-applied; runtime workflow reload does not hot-rebind HTTP ports.
 
 The dashboard shell is implemented as an interactive-server Blazor page. It is an operator-facing
 surface only: if dashboard rendering fails, the orchestrator and JSON API continue running.

--- a/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
+++ b/dotnet/src/Symphony.Host/Composition/SymphonyHostCompositionExtensions.cs
@@ -3,6 +3,7 @@ using Symphony.Application.Orchestration;
 using Symphony.Application.DependencyInjection;
 using Symphony.Host.Api;
 using Symphony.Host.Components;
+using Symphony.Host.Configuration;
 using Symphony.Host.Dashboard;
 using Symphony.Host.Health;
 using Symphony.Host.Theming;
@@ -16,6 +17,7 @@ public static class SymphonyHostCompositionExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        builder.ApplyConfiguredHttpServerPort();
         builder.Logging.AddSymphonyLogging(builder.Configuration);
         builder.Services.Configure<OrchestratorControlOptions>(
             builder.Configuration.GetSection(OrchestratorControlOptions.SectionName));

--- a/dotnet/src/Symphony.Host/Configuration/HttpServerPortBindingExtensions.cs
+++ b/dotnet/src/Symphony.Host/Configuration/HttpServerPortBindingExtensions.cs
@@ -1,0 +1,141 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Symphony.Abstractions.Workflows;
+using Symphony.Domain.Workflows;
+using Symphony.Infrastructure.Workflows;
+
+namespace Symphony.Host.Configuration;
+
+internal static class HttpServerPortBindingExtensions
+{
+    public static void ApplyConfiguredHttpServerPort(this WebApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var configuredPort = TryResolveCliPort(builder.Configuration);
+        if (configuredPort is null)
+        {
+            configuredPort = TryResolveWorkflowPort(Path.Combine(Directory.GetCurrentDirectory(), "WORKFLOW.md"));
+        }
+
+        if (configuredPort is int port)
+        {
+            builder.WebHost.UseUrls($"http://127.0.0.1:{port.ToString(CultureInfo.InvariantCulture)}");
+        }
+    }
+
+    private static int? TryResolveCliPort(IConfiguration configuration)
+    {
+        var rawPort = configuration["port"];
+        if (string.IsNullOrWhiteSpace(rawPort))
+        {
+            return null;
+        }
+
+        return ParsePort(
+            rawPort,
+            "invalid_cli_port",
+            "--port must be an integer greater than or equal to 0.");
+    }
+
+    private static int? TryResolveWorkflowPort(string workflowPath)
+    {
+        if (!File.Exists(workflowPath))
+        {
+            return null;
+        }
+
+        WorkflowDefinition workflowDefinition;
+        try
+        {
+            workflowDefinition = new YamlWorkflowLoader().LoadAsync(workflowPath).GetAwaiter().GetResult();
+        }
+        catch (MissingWorkflowFileException)
+        {
+            return null;
+        }
+        catch (WorkflowLoadException)
+        {
+            return null;
+        }
+
+        if (!workflowDefinition.Config.TryGetValue("server", out var rawServerSection) || rawServerSection is null)
+        {
+            return null;
+        }
+
+        var serverSection = rawServerSection switch
+        {
+            IReadOnlyDictionary<string, object?> readOnlyDictionary => readOnlyDictionary,
+            IDictionary<string, object?> dictionary => new ReadOnlyDictionary<string, object?>(dictionary),
+            _ => throw CreatePortConfigurationException(
+                "invalid_server_port",
+                $"server in '{workflowPath}' must be an object when configuring server.port.")
+        };
+
+        if (!serverSection.TryGetValue("port", out var rawPort) || rawPort is null)
+        {
+            return null;
+        }
+
+        return ParsePort(
+            rawPort,
+            "invalid_server_port",
+            $"server.port in '{workflowPath}' must be an integer greater than or equal to 0.");
+    }
+
+    private static int ParsePort(object rawValue, string errorCode, string errorMessage)
+    {
+        if (TryConvertToInt(rawValue, out var parsedPort) && parsedPort >= 0)
+        {
+            return parsedPort;
+        }
+
+        throw CreatePortConfigurationException(errorCode, errorMessage);
+    }
+
+    private static bool TryConvertToInt(object rawValue, out int parsedValue)
+    {
+        switch (rawValue)
+        {
+            case byte byteValue:
+                parsedValue = byteValue;
+                return true;
+            case sbyte sbyteValue:
+                parsedValue = sbyteValue;
+                return true;
+            case short shortValue:
+                parsedValue = shortValue;
+                return true;
+            case ushort ushortValue:
+                parsedValue = ushortValue;
+                return true;
+            case int intValue:
+                parsedValue = intValue;
+                return true;
+            case uint uintValue when uintValue <= int.MaxValue:
+                parsedValue = (int)uintValue;
+                return true;
+            case long longValue when longValue is >= int.MinValue and <= int.MaxValue:
+                parsedValue = (int)longValue;
+                return true;
+            case ulong ulongValue when ulongValue <= int.MaxValue:
+                parsedValue = (int)ulongValue;
+                return true;
+            case string stringValue when int.TryParse(stringValue.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedString):
+                parsedValue = parsedString;
+                return true;
+            default:
+                parsedValue = default;
+                return false;
+        }
+    }
+
+    private static InvalidOperationException CreatePortConfigurationException(string errorCode, string detail)
+    {
+        return new InvalidOperationException(
+            $"Failed to configure HTTP server port ({errorCode}). {detail}");
+    }
+}

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyHostLifecycleIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyHostLifecycleIntegrationTests.cs
@@ -34,6 +34,92 @@ public sealed class SymphonyHostLifecycleIntegrationTests
     }
 
     [Fact]
+    public async Task StartAsync_uses_workflow_server_port_when_configured()
+    {
+        await using var host = await StartedSymphonyHost.StartAsync(
+            tempDirectory => CreateWorkflowContents(
+                Path.Combine(tempDirectory, "workspaces"),
+                serverSection:
+                """
+                server:
+                  port: 0
+                """),
+            configureServices: services =>
+            {
+                services.RemoveAll<IIssueTrackerClient>();
+                services.AddSingleton<IIssueTrackerClient>(new EmptyIssueTrackerClient());
+
+                RemoveHostedService<RetryDispatchBackgroundService>(services);
+            },
+            useEphemeralLoopbackUrl: false);
+
+        var address = GetServerAddress(host.App);
+
+        Assert.Equal("127.0.0.1", address.Host);
+        Assert.True(address.Port > 0);
+    }
+
+    [Fact]
+    public async Task StartAsync_cli_port_overrides_workflow_server_port()
+    {
+        await using var host = await StartedSymphonyHost.StartAsync(
+            tempDirectory => CreateWorkflowContents(
+                Path.Combine(tempDirectory, "workspaces"),
+                serverSection:
+                """
+                server:
+                  port: nope
+                """),
+            configureServices: services =>
+            {
+                services.RemoveAll<IIssueTrackerClient>();
+                services.AddSingleton<IIssueTrackerClient>(new EmptyIssueTrackerClient());
+
+                RemoveHostedService<RetryDispatchBackgroundService>(services);
+            },
+            args: ["--port", "0"],
+            useEphemeralLoopbackUrl: false);
+
+        var address = GetServerAddress(host.App);
+
+        Assert.Equal("127.0.0.1", address.Host);
+        Assert.True(address.Port > 0);
+    }
+
+    [Fact]
+    public async Task StartAsync_invalid_workflow_server_port_fails_cleanly()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => StartedSymphonyHost.StartAsync(
+                tempDirectory => CreateWorkflowContents(
+                    Path.Combine(tempDirectory, "workspaces"),
+                    serverSection:
+                    """
+                    server:
+                      port: nope
+                    """),
+                configureServices: null,
+                useEphemeralLoopbackUrl: false));
+
+        Assert.Contains("invalid_server_port", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("server.port", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartAsync_invalid_cli_port_fails_cleanly()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => StartedSymphonyHost.StartAsync(
+                tempDirectory => CreateWorkflowContents(Path.Combine(tempDirectory, "workspaces")),
+                configureServices: null,
+                args: ["--port", "nope"],
+                useEphemeralLoopbackUrl: false));
+
+        Assert.Contains("invalid_cli_port", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("--port", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task StartAsync_runs_smoke_flow_from_workflow_load_to_workspace_create_and_worker_attempt()
     {
         var issue = new Issue(
@@ -170,13 +256,17 @@ public sealed class SymphonyHostLifecycleIntegrationTests
         Assert.Equal(System.Net.HttpStatusCode.OK, unknownSessionResponse.StatusCode);
     }
 
-    private static string CreateWorkflowContents(string workspaceRoot)
+    private static string CreateWorkflowContents(string workspaceRoot, string? serverSection = null)
     {
         var normalizedWorkspaceRoot = workspaceRoot.Replace('\\', '/');
+        var serverBlock = serverSection is null
+            ? string.Empty
+            : serverSection.TrimEnd() + Environment.NewLine;
 
         return
-            $$"""
-            ---
+            "---" + Environment.NewLine
+            + serverBlock
+            + $$"""
             tracker:
               kind: github
               api_key: test-token
@@ -202,15 +292,20 @@ public sealed class SymphonyHostLifecycleIntegrationTests
 
     private static HttpClient CreateHttpClient(WebApplication app)
     {
+        return new HttpClient
+        {
+            BaseAddress = GetServerAddress(app)
+        };
+    }
+
+    private static Uri GetServerAddress(WebApplication app)
+    {
         var server = app.Services.GetRequiredService<IServer>();
         var addresses = server.Features.Get<IServerAddressesFeature>()
             ?? throw new InvalidOperationException("Test server addresses are unavailable.");
         var address = Assert.Single(addresses.Addresses);
 
-        return new HttpClient
-        {
-            BaseAddress = new Uri(address)
-        };
+        return new Uri(address);
     }
 
     private static void RemoveHostedService<TImplementation>(IServiceCollection services)
@@ -253,7 +348,9 @@ public sealed class SymphonyHostLifecycleIntegrationTests
         public static async Task<StartedSymphonyHost> StartAsync(
             Func<string, string?> workflowFactory,
             Action<WebApplicationBuilder>? configureBuilder = null,
-            Action<IServiceCollection>? configureServices = null)
+            Action<IServiceCollection>? configureServices = null,
+            string[]? args = null,
+            bool useEphemeralLoopbackUrl = true)
         {
             ArgumentNullException.ThrowIfNull(workflowFactory);
 
@@ -276,8 +373,12 @@ public sealed class SymphonyHostLifecycleIntegrationTests
             {
                 Directory.SetCurrentDirectory(tempDirectory);
 
-                var builder = WebApplication.CreateBuilder();
-                builder.WebHost.UseUrls("http://127.0.0.1:0");
+                var builder = WebApplication.CreateBuilder(args ?? Array.Empty<string>());
+                if (useEphemeralLoopbackUrl)
+                {
+                    builder.WebHost.UseUrls("http://127.0.0.1:0");
+                }
+
                 configureBuilder?.Invoke(builder);
                 builder.AddSymphonyHost();
                 configureServices?.Invoke(builder.Services);


### PR DESCRIPTION
#### Context

Issue #56 tracks the remaining host-port extension gap from `SPEC.md`: the shipped host never honored workflow `server.port` or CLI `--port`, and invalid port values were not surfaced as clear startup errors.

#### TL;DR

Add host-side port resolution that binds loopback from workflow `server.port` or CLI `--port`, with CLI precedence and clear fail-fast validation for invalid values.

#### Summary

- add a host-only port binding resolver that reads CLI `--port` first and falls back to workflow `server.port`
- bind the shipped host to loopback (`127.0.0.1`) when an explicit port is selected, including `0` for ephemeral local ports
- fail startup cleanly for invalid workflow or CLI port values, while preserving CLI override precedence over workflow `server.port`
- extend host lifecycle integration tests for workflow-configured port, CLI override, and invalid input handling
- document `server.port`, CLI `--port`, precedence, and restart-applied listener behavior in `dotnet/README.md`

#### Alternatives

- move `server.port` into the core typed workflow runtime model: rejected because this is a host-only extension and the rest of the orchestrator does not need to consume it
- disable the HTTP host entirely unless `server.port` or `--port` is provided: rejected for this issue because it would be a broader product-behavior change than the backlog item scopes

#### Test Plan

- [x] `dotnet build .\dotnet\src\Symphony.Host\Symphony.Host.csproj -c Release -m:1 -v minimal`
- [x] `dotnet test .\dotnet\tests\Symphony.Host.IntegrationTests\Symphony.Host.IntegrationTests.csproj -c Release -m:1 -v minimal`
- [x] `dotnet build .\dotnet\Symphony.sln -c Release -m:1 -v minimal`
- [x] `dotnet test .\dotnet\Symphony.sln -c Release --no-build -m:1 -v minimal`
- [x] `dotnet format .\dotnet\Symphony.sln --verify-no-changes --no-restore`

Closes #56