### PR TITLE
Cache Tailwind bootstrap per machine for host assets

### DIFF
--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -36,39 +36,6 @@ jobs:
       - name: Verify formatting
         run: dotnet format --verify-no-changes
 
-      - name: Provision Tailwind CLI
-        shell: pwsh
-        run: |
-          $toolDirectory = Join-Path $PWD "src/Symphony.Host/tools"
-          New-Item -ItemType Directory -Path $toolDirectory -Force | Out-Null
-
-          switch ("${{ runner.os }}") {
-            "Windows" {
-              $assetName = "tailwindcss-windows-x64.exe"
-              $targetName = "tailwindcss.exe"
-            }
-            "Linux" {
-              $assetName = "tailwindcss-linux-x64"
-              $targetName = "tailwindcss"
-            }
-            "macOS" {
-              $assetName = "tailwindcss-macos-arm64"
-              $targetName = "tailwindcss"
-            }
-            default {
-              throw "Unsupported runner.os '${{ runner.os }}'."
-            }
-          }
-
-          $downloadUrl = "https://github.com/tailwindlabs/tailwindcss/releases/latest/download/$assetName"
-          $targetPath = Join-Path $toolDirectory $targetName
-
-          Invoke-WebRequest -Uri $downloadUrl -OutFile $targetPath
-
-          if ("${{ runner.os }}" -ne "Windows") {
-            chmod +x $targetPath
-          }
-
       - name: Build
         run: dotnet build -c Release
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ dump/
 dotnet/.dotnet-home/
 **/Properties/launchSettings.json
 dotnet/src/Symphony.Host/tools/
+dotnet/src/Symphony.Host/wwwroot/app.min.css
 
 # StyleCop
 StyleCopReport.xml

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -198,19 +198,33 @@ dotnet build -c Release
 dotnet test -c Release
 ```
 
-## UI asset prerequisite
+## UI asset bootstrap
 
-The dashboard UI build expects a one-time Tailwind CLI download in
-`dotnet/src/Symphony.Host/tools/`.
+`dotnet build -c Release` now bootstraps the standalone Tailwind CLI automatically into a shared
+per-user cache when no override binary is already available, then uses it to generate
+`dotnet/src/Symphony.Host/wwwroot/app.min.css`.
 
-- Windows x64: download `tailwindcss-windows-x64.exe` and rename it to
-  `tailwindcss.exe`
-- macOS ARM64: download `tailwindcss-macos-arm64` and rename it to `tailwindcss`
-- Linux x64: download `tailwindcss-linux-x64` and rename it to `tailwindcss`
-- Releases: `https://github.com/tailwindlabs/tailwindcss/releases/latest`
+Symphony first checks for a manual local override in `dotnet/src/Symphony.Host/tools/`, then falls
+back to the shared machine cache for the pinned Tailwind version:
 
-After the binary is present, `dotnet build -c Release` runs it automatically to
-generate `dotnet/src/Symphony.Host/wwwroot/app.min.css`.
+- Windows x64: `%LocalAppData%\Symphony\tools\tailwind\v4.2.2\`
+- Linux/macOS: `~/.cache/symphony/tools/tailwind/v4.2.2/`
+
+- Supported automatic bootstrap targets:
+  - Windows x64 -> `tailwindcss-windows-x64.exe` saved as `tailwindcss.exe`
+  - Linux x64 -> `tailwindcss-linux-x64` saved as `tailwindcss`
+  - macOS ARM64 -> `tailwindcss-macos-arm64` saved as `tailwindcss`
+- Pinned Tailwind release: `v4.2.2`
+- Download source: `https://github.com/tailwindlabs/tailwindcss/releases`
+
+This avoids downloading the Tailwind binary once per git worktree on the same machine. New
+worktrees reuse the shared cached binary automatically.
+
+The first bootstrap uses built-in Windows PowerShell on Windows and `curl` with a `wget` fallback
+on Linux/macOS.
+
+On unsupported platforms, the host build fails fast with an explicit message so the CLI can be
+installed manually into `dotnet/src/Symphony.Host/tools/` or prepopulated in the shared cache.
 
 The PR workflow in [`.github/workflows/make-all.yml`](../.github/workflows/make-all.yml) runs the
 same solution-wide `dotnet test` suite, including the host integration checks for startup

--- a/dotnet/src/Symphony.Host/Symphony.Host.csproj
+++ b/dotnet/src/Symphony.Host/Symphony.Host.csproj
@@ -12,10 +12,21 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TailwindExecutablePath Condition="'$(OS)' == 'Windows_NT'">$(MSBuildProjectDirectory)\tools\tailwindcss.exe</TailwindExecutablePath>
-    <TailwindExecutablePath Condition="'$(OS)' != 'Windows_NT'">$(MSBuildProjectDirectory)/tools/tailwindcss</TailwindExecutablePath>
-    <TailwindCommand Condition="'$(OS)' == 'Windows_NT'">tools\\tailwindcss.exe -i ./wwwroot/app.css -o ./wwwroot/app.min.css --minify</TailwindCommand>
-    <TailwindCommand Condition="'$(OS)' != 'Windows_NT'">./tools/tailwindcss -i ./wwwroot/app.css -o ./wwwroot/app.min.css --minify</TailwindCommand>
+    <TailwindVersion>v4.2.2</TailwindVersion>
+    <TailwindLocalToolDirectory>$(MSBuildProjectDirectory)\tools</TailwindLocalToolDirectory>
+    <TailwindLocalExecutablePath Condition="'$(OS)' == 'Windows_NT'">$(TailwindLocalToolDirectory)\tailwindcss.exe</TailwindLocalExecutablePath>
+    <TailwindLocalExecutablePath Condition="'$(OS)' != 'Windows_NT'">$(MSBuildProjectDirectory)/tools/tailwindcss</TailwindLocalExecutablePath>
+    <TailwindCacheDirectory Condition="'$(OS)' == 'Windows_NT'">$([System.Environment]::GetFolderPath(System.Environment+SpecialFolder.LocalApplicationData))\Symphony\tools\tailwind\$(TailwindVersion)</TailwindCacheDirectory>
+    <TailwindCacheDirectory Condition="'$(OS)' != 'Windows_NT'">$([System.Environment]::GetFolderPath(System.Environment+SpecialFolder.UserProfile))/.cache/symphony/tools/tailwind/$(TailwindVersion)</TailwindCacheDirectory>
+    <TailwindCachedExecutablePath Condition="'$(OS)' == 'Windows_NT'">$(TailwindCacheDirectory)\tailwindcss.exe</TailwindCachedExecutablePath>
+    <TailwindCachedExecutablePath Condition="'$(OS)' != 'Windows_NT'">$(TailwindCacheDirectory)/tailwindcss</TailwindCachedExecutablePath>
+    <TailwindExecutablePath Condition="Exists('$(TailwindLocalExecutablePath)')">$(TailwindLocalExecutablePath)</TailwindExecutablePath>
+    <TailwindExecutablePath Condition="'$(TailwindExecutablePath)' == ''">$(TailwindCachedExecutablePath)</TailwindExecutablePath>
+    <TailwindAssetName Condition="$([System.OperatingSystem]::IsWindows()) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">tailwindcss-windows-x64.exe</TailwindAssetName>
+    <TailwindAssetName Condition="$([System.OperatingSystem]::IsLinux()) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">tailwindcss-linux-x64</TailwindAssetName>
+    <TailwindAssetName Condition="$([System.OperatingSystem]::IsMacOS()) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">tailwindcss-macos-arm64</TailwindAssetName>
+    <TailwindDownloadUrl Condition="'$(TailwindAssetName)' != ''">https://github.com/tailwindlabs/tailwindcss/releases/download/$(TailwindVersion)/$(TailwindAssetName)</TailwindDownloadUrl>
+    <TailwindCommand>&quot;$(TailwindExecutablePath)&quot; -i ./wwwroot/app.css -o ./wwwroot/app.min.css --minify</TailwindCommand>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,11 +42,24 @@
     </None>
   </ItemGroup>
 
-  <Target Name="WarnMissingTailwindBinary"
+  <Target Name="EnsureSupportedTailwindBootstrapPlatform"
           BeforeTargets="Build"
-          Condition="!Exists('$(TailwindExecutablePath)')">
+          Condition="!Exists('$(TailwindLocalExecutablePath)') and !Exists('$(TailwindCachedExecutablePath)') and '$(TailwindAssetName)' == ''">
+    <Error Text="Automatic Tailwind bootstrap is only configured for Windows x64, Linux x64, and macOS ARM64. Install the CLI manually into dotnet/src/Symphony.Host/tools/ or prepopulate the shared cache for this platform." />
+  </Target>
+
+  <Target Name="BootstrapTailwind"
+          BeforeTargets="Build"
+          Condition="!Exists('$(TailwindLocalExecutablePath)') and !Exists('$(TailwindCachedExecutablePath)') and '$(TailwindAssetName)' != ''">
+    <MakeDir Directories="$(TailwindCacheDirectory)" />
     <Message Importance="high"
-             Text="Skipping Tailwind CSS build because $(TailwindExecutablePath) was not found. Install the CLI into dotnet/src/Symphony.Host/tools/ as documented in dotnet/README.md." />
+             Text="Bootstrapping Tailwind CLI $(TailwindVersion) into shared cache $(TailwindCacheDirectory) from $(TailwindDownloadUrl)." />
+    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri '$(TailwindDownloadUrl)' -OutFile '$(TailwindCachedExecutablePath)'&quot;"
+          Condition="'$(OS)' == 'Windows_NT'" />
+    <Exec Command="/bin/sh -c &quot;if command -v curl &gt;/dev/null 2&gt;&amp;1; then curl -fsSL '$(TailwindDownloadUrl)' -o '$(TailwindCachedExecutablePath)'; elif command -v wget &gt;/dev/null 2&gt;&amp;1; then wget -qO '$(TailwindCachedExecutablePath)' '$(TailwindDownloadUrl)'; else echo 'Neither curl nor wget is installed.' 1&gt;&amp;2; exit 1; fi&quot;"
+          Condition="'$(OS)' != 'Windows_NT'" />
+    <Exec Command="chmod +x &quot;$(TailwindCachedExecutablePath)&quot;"
+          Condition="'$(OS)' != 'Windows_NT'" />
   </Target>
 
   <Target Name="Tailwind"

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardPageIntegrationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
 using Symphony.Application.Polling;
@@ -19,6 +20,8 @@ namespace Symphony.Host.IntegrationTests;
 
 public sealed class DashboardPageIntegrationTests
 {
+    private static readonly string HostProjectDirectory = ResolveHostProjectDirectory();
+
     [Fact]
     public async Task Root_page_renders_dashboard_shell()
     {
@@ -55,6 +58,22 @@ public sealed class DashboardPageIntegrationTests
         Assert.Contains("ABC-1", html, StringComparison.Ordinal);
         Assert.Contains("ABC-2", html, StringComparison.Ordinal);
         Assert.Contains("ABC-3", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Root_page_static_stylesheet_is_served()
+    {
+        using var app = await StartDashboardApplicationAsync(
+            new StubRuntimeService(),
+            new StaticDashboardStateService(CreateDashboardSnapshot()));
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/app.min.css");
+        var css = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("text/css", response.Content.Headers.ContentType?.MediaType, StringComparison.Ordinal);
+        Assert.Contains(".dashboard-page", css, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -167,7 +186,11 @@ public sealed class DashboardPageIntegrationTests
                         300_000))));
 
         var app = builder.Build();
-        app.UseStaticFiles();
+        app.UseStaticFiles(
+            new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(Path.Combine(HostProjectDirectory, "wwwroot"))
+            });
         app.UseAntiforgery();
         app.MapSymphonyApi();
         app.MapRazorComponents<App>()
@@ -175,6 +198,25 @@ public sealed class DashboardPageIntegrationTests
 
         await app.StartAsync();
         return app;
+    }
+
+    private static string ResolveHostProjectDirectory()
+    {
+        var hostProjectDirectory = Path.GetFullPath(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "src",
+                "Symphony.Host"));
+
+        return Directory.Exists(hostProjectDirectory)
+            ? hostProjectDirectory
+            : throw new DirectoryNotFoundException(
+                $"Unable to locate the Symphony.Host project directory from '{AppContext.BaseDirectory}'.");
     }
 
     private sealed class StubRuntimeService : IOrchestratorRuntimeService


### PR DESCRIPTION
#### Context

The host dashboard can 404 `app.min.css` when a fresh worktree has not provisioned Tailwind yet. The current build also redownloads the CLI per worktree instead of reusing it per machine.

#### TL;DR

*Bootstrap Tailwind once per machine, keep local override support, and verify the host serves `app.min.css`.*

#### Summary

- Cache the pinned Tailwind CLI in a shared per-user path instead of `dotnet/src/Symphony.Host/tools/`
- Keep `dotnet/src/Symphony.Host/tools/` as a manual override and ignore generated `wwwroot/app.min.css`
- Remove the separate GitHub Actions provisioning step and rely on the host build bootstrap
- Add a dashboard integration test that verifies `/app.min.css` is served from the host `wwwroot`
- Document the shared-cache behavior and platform-specific bootstrap details in the README

#### Alternatives

- Keep the worktree-local binary download: simple, but it repeats the same download for every worktree
- Switch to a Node-based Tailwind toolchain: workable, but it would add a new runtime/tooling dependency to the repo
- Commit the generated CSS: simpler runtime behavior, but higher drift risk for generated assets

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] `dotnet build .\dotnet\src\Symphony.Host\Symphony.Host.csproj -c Release -m:1 -v minimal`
- [x] `dotnet build .\dotnet\Symphony.sln -c Release -m:1 -v minimal`
- [x] `dotnet test .\dotnet\tests\Symphony.Host.IntegrationTests\Symphony.Host.IntegrationTests.csproj -c Release --no-build -m:1 -v minimal`
- [x] `dotnet test .\dotnet\Symphony.sln -c Release --no-build -m:1 -v minimal`
- [x] `dotnet format .\dotnet\Symphony.sln --verify-no-changes --no-restore`
