### PR TITLE
feat: stop and notify on unresolved unattended blockers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1543,7 +1543,8 @@ Minimum endpoints:
 
 - `GET /api/v1/state`
   - Returns a summary view of the current system state (running sessions, retry queue/delays,
-    aggregate token/runtime totals, latest rate limits, and any additional tracked summary fields).
+    blocked sessions that need operator resolution, aggregate token/runtime totals, latest rate
+    limits, and any additional tracked summary fields).
   - Suggested response shape:
 
     ```json
@@ -1551,7 +1552,8 @@ Minimum endpoints:
       "generated_at": "2026-02-24T20:15:30Z",
       "counts": {
         "running": 2,
-        "retrying": 1
+        "retrying": 1,
+        "blocked": 1
       },
       "running": [
         {
@@ -1580,6 +1582,19 @@ Minimum endpoints:
           "error": "no available orchestrator slots"
         }
       ],
+      "blocked": [
+        {
+          "issue_id": "ghi789",
+          "issue_identifier": "MT-651",
+          "orchestrator_session_id": "orch-42",
+          "attempt": 2,
+          "blocked_at": "2026-02-24T20:15:15Z",
+          "reason_code": "InputRequired",
+          "error_message": "Codex app-server requested human intervention.",
+          "required_user_action": "Provide the required input or choose an option, then resolve the follow-up action to resume the run.",
+          "follow_up_action_id": "fai-42"
+        }
+      ],
       "codex_totals": {
         "input_tokens": 5000,
         "output_tokens": 2400,
@@ -1592,13 +1607,15 @@ Minimum endpoints:
 
 - `GET /api/v1/<issue_identifier>`
   - Returns issue-specific runtime/debug details for the identified issue, including any information
-    the implementation tracks that is useful for debugging.
+    the implementation tracks that is useful for debugging, including blocked/follow-up-action
+    state when a run cannot continue unattended.
   - Suggested response shape:
 
     ```json
     {
       "issue_identifier": "MT-649",
       "issue_id": "abc123",
+      "orchestrator_session_id": "orch-42",
       "status": "running",
       "workspace": {
         "path": "/tmp/symphony_workspaces/MT-649"
@@ -1622,6 +1639,8 @@ Minimum endpoints:
         }
       },
       "retry": null,
+      "blocked": null,
+      "follow_up_actions": [],
       "logs": {
         "codex_session_logs": [
           {
@@ -1645,6 +1664,13 @@ Minimum endpoints:
 
   - If the issue is unknown to the current in-memory state, return `404` with an error response (for
     example `{\"error\":{\"code\":\"issue_not_found\",\"message\":\"...\"}}`).
+
+- `POST /api/v1/<issue_identifier>/follow-up-actions/<fai_id>/resolve`
+  - Resolves a pending follow-up action created for a blocked session.
+  - The implementation should record who resolved the action, any selected option or notes, clear
+    the blocked state, and immediately requeue the same issue when it is still dispatchable.
+  - If the follow-up action or blocked issue no longer exists, return an appropriate error envelope
+    (for example `blocked_issue_not_found`).
 
 - `POST /api/v1/refresh`
   - Queues an immediate tracker poll + reconciliation cycle (best-effort trigger; implementations

--- a/SPEC_UI.md
+++ b/SPEC_UI.md
@@ -108,6 +108,7 @@ The dashboard should make it easy to notice:
 - sessions that have ended successfully
 - sessions that have ended with failure
 - sessions that may require attention
+- sessions that are blocked pending explicit operator resolution
 
 The dashboard theme preference should persist for the current browser via local storage so the
 selected palette is restored after refresh.
@@ -123,6 +124,7 @@ The session detail page must allow the operator to:
 - browse the session activity in order
 - read messages and updates emitted by the agent
 - inspect warnings, errors, and terminal outcomes
+- inspect and resolve pending follow-up actions for blocked sessions
 
 The session detail page should answer these questions clearly:
 
@@ -131,6 +133,7 @@ The session detail page should answer these questions clearly:
 - What did the agent report during the run?
 - Did the session complete successfully?
 - If not, what went wrong?
+- If the run is blocked, what action is required to resume it?
 
 ### 6.3 Session activity timeline
 
@@ -188,6 +191,7 @@ At a minimum, the dashboard should provide an operational summary section that s
 - workflow configuration status
 - running session count
 - retry queue count
+- blocked session count
 - token totals
 - runtime totals
 
@@ -201,6 +205,7 @@ At a minimum, each visible session entry should help the operator identify:
 - when it ended, if applicable
 - the latest meaningful activity
 - whether the session ended with an error
+- whether the session currently needs attention because it is blocked
 
 The dashboard should prioritize clarity over density.
 
@@ -221,6 +226,7 @@ The detail view should include:
 - a separate details view for live session metadata such as tokens, turn count, session ID, and attempt number
 - visible messages and updates from the agent
 - warnings and errors when present
+- a dedicated follow-up-action panel when the session is blocked, including the reason, required operator action, and a clear resolve control
 
 The detail view should feel like an inspection page, not a raw protocol dump.
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -322,10 +322,13 @@ The dashboard shell is implemented as an interactive-server Blazor page. It is a
 surface only: if dashboard rendering fails, the orchestrator and JSON API continue running.
 - The dashboard now includes active-session, retry-queue, and recent-attempt panels so operators
   can see live execution, next retry ETA, and concise outcome/error summaries without reading raw logs.
+- The dashboard also surfaces blocked sessions that need attention, including the orchestrator-owned
+  session/run identifier and the follow-up action that must be resolved before the issue can resume.
 - The session explorer is now available at `/sessions`, with All / Active / Ended filters and deep
   links into `/sessions/{identifier}` for individual run inspection, breadcrumb navigation, a
   chronological activity timeline, richer structured payload highlights, and an Activity / Details
-  tab split for live metadata. Raw agent payloads on the session detail page are gated behind
+  tab split for live metadata. Blocked sessions render a dedicated follow-up-action panel with the
+  required operator action and a resolve CTA. Raw agent payloads on the session detail page are gated behind
   `Dashboard:DebugMode` and are visually marked as debug-only when enabled. In debug mode, the
   timeline also includes the full outbound Codex request transcript, full inbound replies/events,
   and stderr/diagnostic lines for each session. A persistent left-side filter panel exposes one
@@ -337,9 +340,10 @@ surface only: if dashboard rendering fails, the orchestrator and JSON API contin
   `light-blue` palettes; the current browser choice is restored from `localStorage` on refresh.
 - The sidebar footer also exposes `Start` / `Stop` controls for orchestration. `Stop` pauses new
   polling, queue dispatch, and retry dispatch while allowing already running work to finish.
-- `GET /api/v1/state` for the current running/retrying snapshot, live token totals, runtime counts,
-  and operator health fields such as poll staleness, workflow reload status, and orchestration state
-- `GET /api/v1/{issueIdentifier}` for issue-specific runtime details with a `404` JSON error envelope when the issue is not tracked
+- `GET /api/v1/state` for the current running/retrying/blocked snapshot, live token totals, runtime counts,
+  follow-up-action summaries, and operator health fields such as poll staleness, workflow reload status, and orchestration state
+- `GET /api/v1/{issueIdentifier}` for issue-specific runtime details, including blocked-session and follow-up-action data, with a `404` JSON error envelope when the issue is not tracked
+- `POST /api/v1/{issueIdentifier}/follow-up-actions/{faiId}/resolve` to resolve a blocked follow-up action and requeue the issue when it is still dispatchable
 - `POST /api/v1/refresh` to queue an immediate poll-and-reconcile cycle; repeated requests coalesce while one is already pending
 - `GET /api/v1/orchestration` for the current started/stopped control state
 - `POST /api/v1/orchestration/start` to resume polling and new issue assignment

--- a/dotnet/WORKFLOW.azure-devops.md
+++ b/dotnet/WORKFLOW.azure-devops.md
@@ -70,8 +70,8 @@ No description provided.
 
 Instructions:
 
-1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
-2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+1. This is an unattended orchestration session. Do not ask a human directly to perform follow-up actions. If a required approval, input request, or manual decision cannot be auto-resolved, stop so the host can capture the required operator action.
+2. Only stop early for a true blocker (missing required auth/permissions/secrets, or a required approval/input/decision that could not be auto-resolved). If blocked, record it in the workpad and move the issue according to workflow.
 3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
 Work only in the provided repository copy. Do not touch any other path.

--- a/dotnet/WORKFLOW.github.md
+++ b/dotnet/WORKFLOW.github.md
@@ -63,8 +63,8 @@ No description provided.
 
 Instructions:
 
-1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
-2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+1. This is an unattended orchestration session. Do not ask a human directly to perform follow-up actions. If a required approval, input request, or manual decision cannot be auto-resolved, stop so the host can capture the required operator action.
+2. Only stop early for a true blocker (missing required auth/permissions/secrets, or a required approval/input/decision that could not be auto-resolved). If blocked, record it in the workpad and move the issue according to workflow.
 3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
 Work only in the provided repository copy. Do not touch any other path.

--- a/dotnet/WORKFLOW.linear.md
+++ b/dotnet/WORKFLOW.linear.md
@@ -74,8 +74,8 @@ No description provided.
 
 Instructions:
 
-1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
-2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+1. This is an unattended orchestration session. Do not ask a human directly to perform follow-up actions. If a required approval, input request, or manual decision cannot be auto-resolved, stop so the host can capture the required operator action.
+2. Only stop early for a true blocker (missing required auth/permissions/secrets, or a required approval/input/decision that could not be auto-resolved). If blocked, record it in the workpad and move the issue according to workflow.
 3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
 Work only in the provided repository copy. Do not touch any other path.

--- a/dotnet/src/Symphony.Abstractions/Orchestration/ActiveSessionSnapshot.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/ActiveSessionSnapshot.cs
@@ -6,6 +6,7 @@ namespace Symphony.Abstractions.Orchestration;
 public sealed record ActiveSessionSnapshot(
     string IssueId,
     string IssueIdentifier,
+    string OrchestratorSessionId,
     string IssueState,
     int? Attempt,
     DateTimeOffset StartedAt,

--- a/dotnet/src/Symphony.Abstractions/Orchestration/DispatchQueueSnapshot.cs
+++ b/dotnet/src/Symphony.Abstractions/Orchestration/DispatchQueueSnapshot.cs
@@ -4,6 +4,7 @@ public sealed record DispatchQueueSnapshot(
     IReadOnlyList<QueuedDispatchSnapshot> Queued,
     IReadOnlyList<RunningDispatchSnapshot> Running,
     IReadOnlyList<RetryDispatchSnapshot> Retrying,
+    IReadOnlyList<BlockedDispatchSnapshot> Blocked,
     int MaxConcurrentAgents,
     int AvailableSlots);
 
@@ -27,3 +28,51 @@ public sealed record RetryDispatchSnapshot(
     int Attempt,
     DateTimeOffset DueAt,
     string? Error);
+
+public sealed record BlockedDispatchSnapshot(
+    string IssueId,
+    string IssueIdentifier,
+    string OrchestratorSessionId,
+    int? Attempt,
+    DateTimeOffset BlockedAt,
+    BlockingReasonCode ReasonCode,
+    string ErrorMessage,
+    string RequiredUserAction,
+    string FollowUpActionId);
+
+public sealed record FollowUpActionSnapshot(
+    string FollowUpActionId,
+    string IssueId,
+    string IssueIdentifier,
+    string SessionId,
+    DateTimeOffset CreatedAt,
+    BlockingReasonCode ReasonCode,
+    string ErrorMessage,
+    string RequiredUserAction,
+    IReadOnlyList<FollowUpActionOptionSnapshot> Options,
+    FollowUpActionStatus Status,
+    string? ResolvedBy,
+    DateTimeOffset? ResolvedAt,
+    string? SelectedOptionId,
+    string? Notes);
+
+public sealed record FollowUpActionOptionSnapshot(
+    string OptionId,
+    string Label,
+    string? Description);
+
+public enum BlockingReasonCode
+{
+    InputRequired,
+    ApprovalRequired,
+    ManualDecisionRequired,
+    ToolUnavailable,
+    PreconditionFailed
+}
+
+public enum FollowUpActionStatus
+{
+    Pending,
+    Resolved,
+    Expired
+}

--- a/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/dotnet/src/Symphony.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -20,6 +20,8 @@ public static class ApplicationServiceCollectionExtensions
         services.TryAddSingleton<PollingStatusTracker>();
         services.TryAddSingleton<AttemptHistoryTracker>();
         services.TryAddSingleton<RetryDelayPlanner>();
+        services.TryAddSingleton<FollowUpActionRegistry>();
+        services.TryAddSingleton<FollowUpActionResolutionService>();
         services.TryAddSingleton<OrchestratorControlService>();
         services.TryAddSingleton<IOrchestratorControl>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorControlService>());
         services.TryAddSingleton<IOrchestratorControlStatusReader>(serviceProvider => serviceProvider.GetRequiredService<OrchestratorControlService>());

--- a/dotnet/src/Symphony.Application/Orchestration/ActiveSessionRegistry.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/ActiveSessionRegistry.cs
@@ -99,6 +99,7 @@ public sealed class ActiveSessionRegistry(
         var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken);
         var entry = new ActiveSessionEntry(issue, attempt, startedAt, cancellationTokenSource)
         {
+            OrchestratorSessionId = CreateOrchestratorSessionId(issue.Identifier),
             Status = RunAttemptStatus.InitializingSession
         };
 
@@ -289,6 +290,7 @@ public sealed class ActiveSessionRegistry(
         return new ActiveSessionSnapshot(
             entry.Issue.Id,
             entry.Issue.Identifier,
+            entry.OrchestratorSessionId,
             entry.Issue.State,
             entry.Attempt,
             entry.StartedAt,
@@ -300,6 +302,17 @@ public sealed class ActiveSessionRegistry(
     private static string NormalizeIssueId(string issueId)
     {
         return issueId.Trim().ToUpperInvariant();
+    }
+
+    private static string CreateOrchestratorSessionId(string issueIdentifier)
+    {
+        var normalizedIdentifier = new string(
+            issueIdentifier
+                .Trim()
+                .Select(character => char.IsLetterOrDigit(character) ? char.ToLowerInvariant(character) : '-')
+                .ToArray())
+            .Trim('-');
+        return $"{normalizedIdentifier}-{Guid.NewGuid():N}";
     }
 
     public sealed class TrackedActiveSession : IDisposable
@@ -331,6 +344,7 @@ public sealed class ActiveSessionRegistry(
         {
             return new QueuedIssueExecutionContext(
                 _entry.Issue,
+                _entry.OrchestratorSessionId,
                 _entry.Attempt,
                 CancellationToken,
                 issue => _owner.UpdateIssue(_entry, issue),
@@ -358,6 +372,8 @@ public sealed class ActiveSessionRegistry(
         public Issue Issue { get; set; } = issue;
 
         public int? Attempt { get; } = attempt;
+
+        public required string OrchestratorSessionId { get; init; }
 
         public DateTimeOffset StartedAt { get; } = startedAt;
 

--- a/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/DispatchWorkerBackgroundService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Orchestration;
 using Symphony.Abstractions.Trackers;
 using Symphony.Application.Configuration;
 using Symphony.Application.Runtime;
@@ -17,7 +18,8 @@ public sealed class DispatchWorkerBackgroundService(
     IWorkflowOptionsProvider workflowOptionsProvider,
     TimeProvider timeProvider,
     IQueuedIssueWorker queuedIssueWorker,
-    ILogger<DispatchWorkerBackgroundService> logger) : BackgroundService
+    ILogger<DispatchWorkerBackgroundService> logger,
+    FollowUpActionRegistry? followUpActionRegistry = null) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -88,7 +90,8 @@ public sealed class DispatchWorkerBackgroundService(
                 "Succeeded",
                 attemptStartedAt,
                 timeProvider.GetUtcNow(),
-                sessionId: executionContext.SessionId);
+                sessionId: executionContext.SessionId,
+                orchestratorSessionId: executionContext.OrchestratorSessionId);
             var continuationIssue = await TryResolveContinuationIssueAsync(workItem.Issue, cancellationToken).ConfigureAwait(false);
             if (continuationIssue is not null)
             {
@@ -111,7 +114,8 @@ public sealed class DispatchWorkerBackgroundService(
                 attemptStartedAt,
                 timeProvider.GetUtcNow(),
                 stallError,
-                executionContext.SessionId);
+                executionContext.SessionId,
+                executionContext.OrchestratorSessionId);
             logger.LogWarning(
                 stallException,
                 "dispatch_execution stalled issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=stall outcome=stalled",
@@ -135,7 +139,8 @@ public sealed class DispatchWorkerBackgroundService(
                 attemptStartedAt,
                 timeProvider.GetUtcNow(),
                 cancellationError,
-                executionContext.SessionId);
+                executionContext.SessionId,
+                executionContext.OrchestratorSessionId);
             logger.LogInformation(
                 "dispatch_execution canceled issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=reconciliation outcome=canceled",
                 workItem.Issue.Id,
@@ -161,7 +166,8 @@ public sealed class DispatchWorkerBackgroundService(
                 attemptStartedAt,
                 timeProvider.GetUtcNow(),
                 exception.Message,
-                executionContext.SessionId);
+                executionContext.SessionId,
+                executionContext.OrchestratorSessionId);
             logger.LogWarning(
                 exception,
                 "dispatch_execution failed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=non_transient outcome=failed_no_retry",
@@ -180,7 +186,8 @@ public sealed class DispatchWorkerBackgroundService(
                 attemptStartedAt,
                 timeProvider.GetUtcNow(),
                 exception.Message,
-                executionContext.SessionId);
+                executionContext.SessionId,
+                executionContext.OrchestratorSessionId);
             logger.LogWarning(
                 exception,
                 "dispatch_execution timed_out issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=timeout outcome=timed_out",
@@ -189,6 +196,31 @@ public sealed class DispatchWorkerBackgroundService(
                 executionContext.SessionId);
             await dispatchQueue.ScheduleFailureRetryAsync(workItem, exception, cancellationToken).ConfigureAwait(false);
             executionLease.PreserveClaimForRetry();
+        }
+        catch (IssueBlockingException exception)
+        {
+            await HandleBlockedIssueAsync(
+                    executionContext,
+                    workItem,
+                    executionLease,
+                    exception,
+                    attemptStartedAt,
+                    followUpActionRegistry ?? new FollowUpActionRegistry(timeProvider))
+                .ConfigureAwait(false);
+        }
+        catch (InvalidOperationException exception) when (TryCreateProcessStartBlockingException(exception, out _))
+        {
+            var blockingException = TryCreateProcessStartBlockingException(exception, out var resolvedException)
+                ? resolvedException
+                : throw new InvalidOperationException("Expected blocking exception to be available.");
+            await HandleBlockedIssueAsync(
+                    executionContext,
+                    workItem,
+                    executionLease,
+                    blockingException,
+                    attemptStartedAt,
+                    followUpActionRegistry ?? new FollowUpActionRegistry(timeProvider))
+                .ConfigureAwait(false);
         }
         catch (Exception exception)
         {
@@ -201,7 +233,8 @@ public sealed class DispatchWorkerBackgroundService(
                 attemptStartedAt,
                 timeProvider.GetUtcNow(),
                 exception.Message,
-                executionContext.SessionId);
+                executionContext.SessionId,
+                executionContext.OrchestratorSessionId);
             logger.LogError(
                 exception,
                 "dispatch_execution failed issue_id={issue_id} issue_identifier={issue_identifier} session_id={session_id} reason=worker_exception outcome=failed",
@@ -211,6 +244,76 @@ public sealed class DispatchWorkerBackgroundService(
             await dispatchQueue.ScheduleFailureRetryAsync(workItem, exception, cancellationToken).ConfigureAwait(false);
             executionLease.PreserveClaimForRetry();
         }
+    }
+
+    private async Task HandleBlockedIssueAsync(
+        QueuedIssueExecutionContext executionContext,
+        OrchestratorDispatchQueue.DispatchQueueWorkItem workItem,
+        OrchestratorDispatchQueue.ExecutionLease executionLease,
+        IssueBlockingException exception,
+        DateTimeOffset attemptStartedAt,
+        FollowUpActionRegistry followUpActionRegistry)
+    {
+        executionContext.UpdateStatus(RunAttemptStatus.BlockedError, exception.Message);
+        attemptHistoryTracker.Record(
+            workItem.Issue.Id,
+            workItem.Issue.Identifier,
+            workItem.Attempt,
+            "BlockedError",
+            attemptStartedAt,
+            timeProvider.GetUtcNow(),
+            exception.Message,
+            executionContext.SessionId,
+            executionContext.OrchestratorSessionId);
+
+        var followUpAction = followUpActionRegistry.CreatePending(
+            executionContext.Issue.Id,
+            executionContext.Issue.Identifier,
+            executionContext.OrchestratorSessionId,
+            exception.ReasonCode,
+            exception.Message,
+            exception.RequiredUserAction,
+            exception.Options);
+
+        dispatchQueue.BlockAsync(
+            executionContext.Issue,
+            executionContext.OrchestratorSessionId,
+            workItem.Attempt,
+            exception.ReasonCode,
+            exception.Message,
+            exception.RequiredUserAction,
+            followUpAction.FollowUpActionId);
+        executionLease.MarkBlocked();
+
+        logger.LogWarning(
+            exception,
+            "dispatch_execution blocked issue_id={issue_id} issue_identifier={issue_identifier} orchestrator_session_id={orchestrator_session_id} session_id={session_id} reason_code={reason_code} follow_up_action_id={follow_up_action_id} outcome=blocked_error",
+            workItem.Issue.Id,
+            workItem.Issue.Identifier,
+            executionContext.OrchestratorSessionId,
+            executionContext.SessionId,
+            exception.ReasonCode,
+            followUpAction.FollowUpActionId);
+
+        await Task.CompletedTask;
+    }
+
+    private static bool TryCreateProcessStartBlockingException(
+        InvalidOperationException exception,
+        out IssueBlockingException blockingException)
+    {
+        if (exception.Message.StartsWith("Failed to start process", StringComparison.Ordinal))
+        {
+            blockingException = new IssueBlockingException(
+                BlockingReasonCode.ToolUnavailable,
+                exception.Message,
+                "Install or expose the required process on PATH, then resolve the follow-up action to resume the run.",
+                innerException: exception);
+            return true;
+        }
+
+        blockingException = null!;
+        return false;
     }
 
     private async Task<Issue?> TryResolveContinuationIssueAsync(Issue issue, CancellationToken cancellationToken)

--- a/dotnet/src/Symphony.Application/Orchestration/FollowUpActionRegistry.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/FollowUpActionRegistry.cs
@@ -1,0 +1,112 @@
+using Symphony.Abstractions.Orchestration;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class FollowUpActionRegistry(TimeProvider timeProvider)
+{
+    private readonly Lock _stateLock = new();
+    private readonly Dictionary<string, FollowUpActionSnapshot> _actionsById = new(StringComparer.Ordinal);
+
+    public FollowUpActionSnapshot CreatePending(
+        string issueId,
+        string issueIdentifier,
+        string sessionId,
+        BlockingReasonCode reasonCode,
+        string errorMessage,
+        string requiredUserAction,
+        IReadOnlyList<FollowUpActionOptionSnapshot>? options = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requiredUserAction);
+
+        var action = new FollowUpActionSnapshot(
+            Guid.NewGuid().ToString("N"),
+            issueId.Trim(),
+            issueIdentifier.Trim(),
+            sessionId.Trim(),
+            timeProvider.GetUtcNow(),
+            reasonCode,
+            errorMessage.Trim(),
+            requiredUserAction.Trim(),
+            options ?? Array.Empty<FollowUpActionOptionSnapshot>(),
+            FollowUpActionStatus.Pending,
+            ResolvedBy: null,
+            ResolvedAt: null,
+            SelectedOptionId: null,
+            Notes: null);
+
+        lock (_stateLock)
+        {
+            _actionsById[action.FollowUpActionId] = action;
+        }
+
+        return action;
+    }
+
+    public IReadOnlyList<FollowUpActionSnapshot> GetAll()
+    {
+        lock (_stateLock)
+        {
+            return _actionsById.Values
+                .OrderByDescending(action => action.CreatedAt)
+                .ToArray();
+        }
+    }
+
+    public IReadOnlyList<FollowUpActionSnapshot> GetByIssueIdentifier(string issueIdentifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
+
+        lock (_stateLock)
+        {
+            return _actionsById.Values
+                .Where(action => string.Equals(action.IssueIdentifier, issueIdentifier.Trim(), StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(action => action.CreatedAt)
+                .ToArray();
+        }
+    }
+
+    public FollowUpActionSnapshot? GetById(string followUpActionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(followUpActionId);
+
+        lock (_stateLock)
+        {
+            return _actionsById.GetValueOrDefault(followUpActionId.Trim());
+        }
+    }
+
+    public FollowUpActionSnapshot? Resolve(
+        string followUpActionId,
+        string resolvedBy,
+        string? selectedOptionId,
+        string? notes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(followUpActionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedBy);
+
+        lock (_stateLock)
+        {
+            if (!_actionsById.TryGetValue(followUpActionId.Trim(), out var existing)
+                || existing.Status != FollowUpActionStatus.Pending)
+            {
+                return null;
+            }
+
+            var resolved = existing with
+            {
+                Status = FollowUpActionStatus.Resolved,
+                ResolvedBy = resolvedBy.Trim(),
+                ResolvedAt = timeProvider.GetUtcNow(),
+                SelectedOptionId = string.IsNullOrWhiteSpace(selectedOptionId) ? null : selectedOptionId.Trim(),
+                Notes = string.IsNullOrWhiteSpace(notes) ? null : notes.Trim()
+            };
+
+            _actionsById[resolved.FollowUpActionId] = resolved;
+            return resolved;
+        }
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/FollowUpActionResolutionModels.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/FollowUpActionResolutionModels.cs
@@ -1,0 +1,24 @@
+using Symphony.Abstractions.Orchestration;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed record FollowUpActionResolutionRequest(
+    string IssueIdentifier,
+    string FollowUpActionId,
+    string ResolvedBy,
+    string? SelectedOptionId,
+    string? Notes);
+
+public sealed record FollowUpActionResolutionResult(
+    FollowUpActionResolutionStatus Status,
+    bool Requeued,
+    FollowUpActionSnapshot? Action,
+    string? Message);
+
+public enum FollowUpActionResolutionStatus
+{
+    Resolved,
+    ActionNotFound,
+    BlockedIssueNotFound,
+    IssueNotDispatchable
+}

--- a/dotnet/src/Symphony.Application/Orchestration/FollowUpActionResolutionService.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/FollowUpActionResolutionService.cs
@@ -1,0 +1,71 @@
+using Symphony.Abstractions.Orchestration;
+using Symphony.Abstractions.Trackers;
+using Symphony.Application.Configuration;
+using Symphony.Domain.Issues;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class FollowUpActionResolutionService(
+    FollowUpActionRegistry followUpActionRegistry,
+    OrchestratorDispatchQueue dispatchQueue,
+    IIssueTrackerClient issueTrackerClient,
+    IWorkflowOptionsProvider workflowOptionsProvider)
+{
+    public async Task<FollowUpActionResolutionResult> ResolveAsync(
+        FollowUpActionResolutionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var action = followUpActionRegistry.Resolve(
+            request.FollowUpActionId,
+            request.ResolvedBy,
+            request.SelectedOptionId,
+            request.Notes);
+        if (action is null)
+        {
+            return new FollowUpActionResolutionResult(
+                FollowUpActionResolutionStatus.ActionNotFound,
+                Requeued: false,
+                Action: null,
+                "Follow-up action was not found or is no longer pending.");
+        }
+
+        var blockedIssue = dispatchQueue.GetBlockedIssue(request.IssueIdentifier);
+        if (blockedIssue is null || !string.Equals(blockedIssue.FollowUpActionId, action.FollowUpActionId, StringComparison.Ordinal))
+        {
+            dispatchQueue.ReleaseBlockedClaim(action.IssueId);
+            return new FollowUpActionResolutionResult(
+                FollowUpActionResolutionStatus.BlockedIssueNotFound,
+                Requeued: false,
+                Action: action,
+                "Blocked issue state was not found.");
+        }
+
+        var currentIssue = await RefreshIssueAsync(blockedIssue.Issue, cancellationToken).ConfigureAwait(false);
+        var workflowOptions = await workflowOptionsProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        if (!IssueDispatchEligibility.CanDispatch(currentIssue, workflowOptions, out var skipReason))
+        {
+            dispatchQueue.ReleaseBlockedClaim(currentIssue.Id);
+            return new FollowUpActionResolutionResult(
+                FollowUpActionResolutionStatus.IssueNotDispatchable,
+                Requeued: false,
+                Action: action,
+                $"Issue is not dispatchable after resolution: {skipReason}.");
+        }
+
+        await dispatchQueue.ResumeBlockedAsync(currentIssue, blockedIssue.Attempt, cancellationToken).ConfigureAwait(false);
+        return new FollowUpActionResolutionResult(
+            FollowUpActionResolutionStatus.Resolved,
+            Requeued: true,
+            Action: action,
+            null);
+    }
+
+    private async Task<Issue> RefreshIssueAsync(Issue issue, CancellationToken cancellationToken)
+    {
+        var refreshedIssues = await issueTrackerClient.FetchIssueStatesByIdsAsync([issue.Id], cancellationToken).ConfigureAwait(false);
+        return refreshedIssues.FirstOrDefault(candidate => string.Equals(candidate.Id, issue.Id, StringComparison.Ordinal))
+            ?? issue;
+    }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/IssueBlockingException.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/IssueBlockingException.cs
@@ -1,0 +1,30 @@
+using Symphony.Abstractions.Orchestration;
+
+namespace Symphony.Application.Orchestration;
+
+public sealed class IssueBlockingException : Exception
+{
+    public IssueBlockingException(
+        BlockingReasonCode reasonCode,
+        string message,
+        string requiredUserAction,
+        IReadOnlyList<FollowUpActionOptionSnapshot>? options = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        if (string.IsNullOrWhiteSpace(requiredUserAction))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(requiredUserAction));
+        }
+
+        ReasonCode = reasonCode;
+        RequiredUserAction = requiredUserAction.Trim();
+        Options = options ?? Array.Empty<FollowUpActionOptionSnapshot>();
+    }
+
+    public BlockingReasonCode ReasonCode { get; }
+
+    public string RequiredUserAction { get; }
+
+    public IReadOnlyList<FollowUpActionOptionSnapshot> Options { get; }
+}

--- a/dotnet/src/Symphony.Application/Orchestration/OrchestratorDispatchQueue.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/OrchestratorDispatchQueue.cs
@@ -27,6 +27,7 @@ public sealed class OrchestratorDispatchQueue(
     private readonly Dictionary<string, QueuedDispatchEntry> _queued = new(StringComparer.Ordinal);
     private readonly Dictionary<string, RunningDispatchEntry> _running = new(StringComparer.Ordinal);
     private readonly Dictionary<string, RetryDispatchEntry> _retrying = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, BlockedDispatchEntry> _blocked = new(StringComparer.Ordinal);
     private readonly HashSet<string> _claimed = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _retrySignal = new(0, int.MaxValue);
 
@@ -84,9 +85,116 @@ public sealed class OrchestratorDispatchQueue(
                             entry.DueAt,
                             entry.Error))
                     .ToArray(),
+                _blocked.Values
+                    .OrderByDescending(entry => entry.BlockedAt)
+                    .Select(
+                        entry => new BlockedDispatchSnapshot(
+                            entry.Issue.Id,
+                            entry.Issue.Identifier,
+                            entry.OrchestratorSessionId,
+                            entry.Attempt,
+                            entry.BlockedAt,
+                            entry.ReasonCode,
+                            entry.ErrorMessage,
+                            entry.RequiredUserAction,
+                            entry.FollowUpActionId))
+                    .ToArray(),
                 _configuredConcurrency,
                 Math.Max(_configuredConcurrency - _queued.Count - _running.Count, 0));
         }
+    }
+
+    internal BlockedIssueHandle BlockAsync(
+        Issue issue,
+        string orchestratorSessionId,
+        int? attempt,
+        BlockingReasonCode reasonCode,
+        string errorMessage,
+        string requiredUserAction,
+        string followUpActionId)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+        ArgumentException.ThrowIfNullOrWhiteSpace(orchestratorSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requiredUserAction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(followUpActionId);
+
+        var blockedAt = timeProvider.GetUtcNow();
+
+        lock (_stateLock)
+        {
+            _running.Remove(issue.Id);
+            _blocked[issue.Id] = new BlockedDispatchEntry(
+                issue,
+                orchestratorSessionId.Trim(),
+                attempt,
+                blockedAt,
+                reasonCode,
+                errorMessage.Trim(),
+                requiredUserAction.Trim(),
+                followUpActionId.Trim());
+        }
+
+        ReleaseExecutionSlot();
+
+        logger.LogWarning(
+            "dispatch_blocked completed issue_id={issue_id} issue_identifier={issue_identifier} orchestrator_session_id={orchestrator_session_id} attempt={attempt} reason_code={reason_code} follow_up_action_id={follow_up_action_id} outcome=blocked",
+            issue.Id,
+            issue.Identifier,
+            orchestratorSessionId,
+            attempt,
+            reasonCode,
+            followUpActionId);
+
+        return new BlockedIssueHandle(issue, orchestratorSessionId.Trim(), attempt, blockedAt, reasonCode, errorMessage.Trim(), requiredUserAction.Trim(), followUpActionId.Trim());
+    }
+
+    internal BlockedIssueHandle? GetBlockedIssue(string issueIdentifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
+
+        lock (_stateLock)
+        {
+            var entry = _blocked.Values.FirstOrDefault(candidate =>
+                string.Equals(candidate.Issue.Identifier, issueIdentifier.Trim(), StringComparison.OrdinalIgnoreCase));
+            return entry is null
+                ? null
+                : new BlockedIssueHandle(
+                    entry.Issue,
+                    entry.OrchestratorSessionId,
+                    entry.Attempt,
+                    entry.BlockedAt,
+                    entry.ReasonCode,
+                    entry.ErrorMessage,
+                    entry.RequiredUserAction,
+                    entry.FollowUpActionId);
+        }
+    }
+
+    internal void ReleaseBlockedClaim(string issueId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issueId);
+
+        lock (_stateLock)
+        {
+            _blocked.Remove(issueId.Trim());
+            _claimed.Remove(issueId.Trim());
+        }
+    }
+
+    internal async Task<DispatchEnqueueResult> ResumeBlockedAsync(
+        Issue issue,
+        int? attempt,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        lock (_stateLock)
+        {
+            _blocked.Remove(issue.Id);
+        }
+
+        return await QueueInternalAsync(issue, attempt, claimRequired: false, cancellationToken).ConfigureAwait(false);
     }
 
     internal IAsyncEnumerable<DispatchQueueWorkItem> ReadAllAsync(CancellationToken cancellationToken)
@@ -168,6 +276,7 @@ public sealed class OrchestratorDispatchQueue(
         lock (_stateLock)
         {
             _retrying.Remove(issueId);
+            _blocked.Remove(issueId);
             _claimed.Remove(issueId);
         }
     }
@@ -299,7 +408,7 @@ public sealed class OrchestratorDispatchQueue(
                     return DispatchEnqueueResult.AlreadyClaimed;
                 }
             }
-            else if (_queued.ContainsKey(issue.Id) || _running.ContainsKey(issue.Id) || _retrying.ContainsKey(issue.Id))
+            else if (_queued.ContainsKey(issue.Id) || _running.ContainsKey(issue.Id) || _retrying.ContainsKey(issue.Id) || _blocked.ContainsKey(issue.Id))
             {
                 return DispatchEnqueueResult.AlreadyClaimed;
             }
@@ -512,14 +621,31 @@ public sealed class OrchestratorDispatchQueue(
 
     private sealed record RetryDispatchEntry(Issue Issue, int Attempt, DateTimeOffset DueAt, string? Error);
 
+    private sealed record BlockedDispatchEntry(
+        Issue Issue,
+        string OrchestratorSessionId,
+        int? Attempt,
+        DateTimeOffset BlockedAt,
+        BlockingReasonCode ReasonCode,
+        string ErrorMessage,
+        string RequiredUserAction,
+        string FollowUpActionId);
+
     internal sealed class ExecutionLease(OrchestratorDispatchQueue owner, Issue issue) : IDisposable
     {
         private int _disposed;
         private bool _releaseClaim = true;
+        private bool _queueAlreadyCompleted;
 
         public void PreserveClaimForRetry()
         {
             _releaseClaim = false;
+        }
+
+        public void MarkBlocked()
+        {
+            _releaseClaim = false;
+            _queueAlreadyCompleted = true;
         }
 
         public void Dispose()
@@ -529,7 +655,22 @@ public sealed class OrchestratorDispatchQueue(
                 return;
             }
 
+            if (_queueAlreadyCompleted)
+            {
+                return;
+            }
+
             owner.CompleteExecution(issue, _releaseClaim);
         }
     }
+
+    internal sealed record BlockedIssueHandle(
+        Issue Issue,
+        string OrchestratorSessionId,
+        int? Attempt,
+        DateTimeOffset BlockedAt,
+        BlockingReasonCode ReasonCode,
+        string ErrorMessage,
+        string RequiredUserAction,
+        string FollowUpActionId);
 }

--- a/dotnet/src/Symphony.Application/Orchestration/QueuedIssueExecutionContext.cs
+++ b/dotnet/src/Symphony.Application/Orchestration/QueuedIssueExecutionContext.cs
@@ -12,6 +12,7 @@ public sealed class QueuedIssueExecutionContext
 
     internal QueuedIssueExecutionContext(
         Issue issue,
+        string orchestratorSessionId,
         int? attempt,
         CancellationToken cancellationToken,
         Action<Issue> updateIssue,
@@ -19,6 +20,9 @@ public sealed class QueuedIssueExecutionContext
         Action<RunAttemptStatus, string?> updateStatus)
     {
         Issue = issue ?? throw new ArgumentNullException(nameof(issue));
+        OrchestratorSessionId = string.IsNullOrWhiteSpace(orchestratorSessionId)
+            ? throw new ArgumentException("Value cannot be null or whitespace.", nameof(orchestratorSessionId))
+            : orchestratorSessionId.Trim();
         Attempt = attempt;
         CancellationToken = cancellationToken;
         _updateIssue = updateIssue ?? throw new ArgumentNullException(nameof(updateIssue));
@@ -27,6 +31,8 @@ public sealed class QueuedIssueExecutionContext
     }
 
     public Issue Issue { get; private set; }
+
+    public string OrchestratorSessionId { get; }
 
     public int? Attempt { get; }
 

--- a/dotnet/src/Symphony.Application/Runtime/AttemptHistoryTracker.cs
+++ b/dotnet/src/Symphony.Application/Runtime/AttemptHistoryTracker.cs
@@ -15,7 +15,8 @@ public sealed class AttemptHistoryTracker
         DateTimeOffset startedAt,
         DateTimeOffset completedAt,
         string? error = null,
-        string? sessionId = null)
+        string? sessionId = null,
+        string? orchestratorSessionId = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(issueId);
         ArgumentException.ThrowIfNullOrWhiteSpace(issueIdentifier);
@@ -31,7 +32,8 @@ public sealed class AttemptHistoryTracker
             completedAt,
             durationSeconds,
             string.IsNullOrWhiteSpace(error) ? null : error.Trim(),
-            string.IsNullOrWhiteSpace(sessionId) ? null : sessionId.Trim());
+            string.IsNullOrWhiteSpace(sessionId) ? null : sessionId.Trim(),
+            string.IsNullOrWhiteSpace(orchestratorSessionId) ? null : orchestratorSessionId.Trim());
 
         lock (_stateLock)
         {
@@ -62,4 +64,5 @@ public sealed record RecentAttemptSnapshot(
     DateTimeOffset CompletedAt,
     double DurationSeconds,
     string? Error,
-    string? SessionId);
+    string? SessionId,
+    string? OrchestratorSessionId = null);

--- a/dotnet/src/Symphony.Application/Runtime/OrchestratorRuntimeModels.cs
+++ b/dotnet/src/Symphony.Application/Runtime/OrchestratorRuntimeModels.cs
@@ -7,7 +7,9 @@ public sealed record OrchestratorStateSnapshot(
     IReadOnlyList<RunningIssueSnapshot> Running,
     IReadOnlyList<RetryDispatchSnapshot> Retrying,
     CodexTotalsSnapshot CodexTotals,
-    object? RateLimits);
+    object? RateLimits,
+    IReadOnlyList<BlockedDispatchSnapshot>? Blocked = null,
+    IReadOnlyList<FollowUpActionSnapshot>? FollowUpActions = null);
 
 public sealed record RunningIssueSnapshot(
     string IssueId,
@@ -21,7 +23,8 @@ public sealed record RunningIssueSnapshot(
     DateTimeOffset? LastEventAt,
     long InputTokens,
     long OutputTokens,
-    long TotalTokens);
+    long TotalTokens,
+    string? OrchestratorSessionId = null);
 
 public sealed record CodexTotalsSnapshot(
     long InputTokens,
@@ -38,7 +41,10 @@ public sealed record OrchestratorIssueSnapshot(
     RunningIssueSnapshot? Running,
     RetryDispatchSnapshot? Retry,
     string? LastError,
-    IReadOnlyList<RuntimeEventSnapshot> RecentEvents);
+    IReadOnlyList<RuntimeEventSnapshot> RecentEvents,
+    string? OrchestratorSessionId = null,
+    BlockedDispatchSnapshot? Blocked = null,
+    IReadOnlyList<FollowUpActionSnapshot>? FollowUpActions = null);
 
 public sealed record RuntimeEventSnapshot(
     DateTimeOffset At,

--- a/dotnet/src/Symphony.Application/Runtime/OrchestratorRuntimeService.cs
+++ b/dotnet/src/Symphony.Application/Runtime/OrchestratorRuntimeService.cs
@@ -1,5 +1,6 @@
 using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Polling;
+using Symphony.Application.Orchestration;
 
 namespace Symphony.Application.Runtime;
 
@@ -7,11 +8,13 @@ public sealed class OrchestratorRuntimeService(
     IActiveSessionRegistry activeSessionRegistry,
     IOrchestratorDispatchStatusReader dispatchStatusReader,
     PollingRefreshTrigger pollingRefreshTrigger,
-    TimeProvider timeProvider) : IOrchestratorRuntimeService
+    TimeProvider timeProvider,
+    FollowUpActionRegistry? followUpActionRegistry = null) : IOrchestratorRuntimeService
 {
     public Task<OrchestratorStateSnapshot> GetStateSnapshotAsync(CancellationToken cancellationToken = default)
     {
         var generatedAt = timeProvider.GetUtcNow();
+        var dispatchSnapshot = dispatchStatusReader.GetSnapshot();
         var running = activeSessionRegistry.GetActiveSessions()
             .Select(CreateRunningIssueSnapshot)
             .ToArray();
@@ -20,13 +23,15 @@ public sealed class OrchestratorRuntimeService(
             new OrchestratorStateSnapshot(
                 generatedAt,
                 running,
-                dispatchStatusReader.GetSnapshot().Retrying,
+                dispatchSnapshot.Retrying,
                 new CodexTotalsSnapshot(
                     running.Sum(session => session.InputTokens),
                     running.Sum(session => session.OutputTokens),
                     running.Sum(session => session.TotalTokens),
                     running.Sum(session => Math.Max((generatedAt - session.StartedAt).TotalSeconds, 0d))),
-                RateLimits: null));
+                RateLimits: null,
+                Blocked: dispatchSnapshot.Blocked,
+                FollowUpActions: followUpActionRegistry?.GetAll() ?? Array.Empty<FollowUpActionSnapshot>()));
     }
 
     public Task<OrchestratorIssueSnapshot?> GetIssueSnapshotAsync(
@@ -49,7 +54,10 @@ public sealed class OrchestratorRuntimeService(
                     CreateRunningIssueSnapshot(activeSession),
                     retry: null,
                     activeSession.Error,
-                    CreateRecentEvents(activeSession)));
+                    CreateRecentEvents(activeSession),
+                    orchestratorSessionId: activeSession.OrchestratorSessionId,
+                    blocked: null,
+                    followUpActions: followUpActionRegistry?.GetByIssueIdentifier(activeSession.IssueIdentifier) ?? Array.Empty<FollowUpActionSnapshot>()));
         }
 
         var dispatchSnapshot = dispatchStatusReader.GetSnapshot();
@@ -67,7 +75,29 @@ public sealed class OrchestratorRuntimeService(
                     running: null,
                     retryingIssue,
                     retryingIssue.Error,
-                    []));
+                    [],
+                    orchestratorSessionId: null,
+                    blocked: null,
+                    followUpActions: followUpActionRegistry?.GetByIssueIdentifier(retryingIssue.IssueIdentifier) ?? Array.Empty<FollowUpActionSnapshot>()));
+        }
+
+        var blockedIssue = dispatchSnapshot.Blocked
+            .FirstOrDefault(issue => string.Equals(issue.IssueIdentifier, normalizedIssueIdentifier, StringComparison.OrdinalIgnoreCase));
+        if (blockedIssue is not null)
+        {
+            return Task.FromResult<OrchestratorIssueSnapshot?>(
+                CreateIssueSnapshot(
+                    blockedIssue.IssueIdentifier,
+                    blockedIssue.IssueId,
+                    "blocked_error",
+                    blockedIssue.Attempt,
+                    running: null,
+                    retry: null,
+                    blockedIssue.ErrorMessage,
+                    [],
+                    orchestratorSessionId: blockedIssue.OrchestratorSessionId,
+                    blocked: blockedIssue,
+                    followUpActions: followUpActionRegistry?.GetByIssueIdentifier(blockedIssue.IssueIdentifier) ?? Array.Empty<FollowUpActionSnapshot>()));
         }
 
         var queuedIssue = dispatchSnapshot.Queued
@@ -83,7 +113,10 @@ public sealed class OrchestratorRuntimeService(
                     running: null,
                     retry: null,
                     lastError: null,
-                    []));
+                    [],
+                    orchestratorSessionId: null,
+                    blocked: null,
+                    followUpActions: followUpActionRegistry?.GetByIssueIdentifier(queuedIssue.IssueIdentifier) ?? Array.Empty<FollowUpActionSnapshot>()));
         }
 
         return Task.FromResult<OrchestratorIssueSnapshot?>(null);
@@ -102,7 +135,10 @@ public sealed class OrchestratorRuntimeService(
         RunningIssueSnapshot? running,
         RetryDispatchSnapshot? retry,
         string? lastError,
-        IReadOnlyList<RuntimeEventSnapshot> recentEvents)
+        IReadOnlyList<RuntimeEventSnapshot> recentEvents,
+        string? orchestratorSessionId = null,
+        BlockedDispatchSnapshot? blocked = null,
+        IReadOnlyList<FollowUpActionSnapshot>? followUpActions = null)
     {
         var normalizedAttempt = attempt.GetValueOrDefault();
 
@@ -115,7 +151,10 @@ public sealed class OrchestratorRuntimeService(
             running,
             retry,
             lastError,
-            recentEvents);
+            recentEvents,
+            orchestratorSessionId,
+            blocked,
+            followUpActions ?? Array.Empty<FollowUpActionSnapshot>());
     }
 
     private static RunningIssueSnapshot CreateRunningIssueSnapshot(ActiveSessionSnapshot activeSession)
@@ -132,7 +171,8 @@ public sealed class OrchestratorRuntimeService(
             activeSession.Session?.LastCodexTimestamp,
             activeSession.Session?.CodexInputTokens ?? 0,
             activeSession.Session?.CodexOutputTokens ?? 0,
-            activeSession.Session?.CodexTotalTokens ?? 0);
+            activeSession.Session?.CodexTotalTokens ?? 0,
+            activeSession.OrchestratorSessionId);
     }
 
     private static IReadOnlyList<RuntimeEventSnapshot> CreateRecentEvents(ActiveSessionSnapshot activeSession)

--- a/dotnet/src/Symphony.Domain/Runs/RunAttemptStatus.cs
+++ b/dotnet/src/Symphony.Domain/Runs/RunAttemptStatus.cs
@@ -9,6 +9,7 @@ public enum RunAttemptStatus
     StreamingTurn,
     Finishing,
     Succeeded,
+    BlockedError,
     Failed,
     TimedOut,
     Stalled,

--- a/dotnet/src/Symphony.Host/Api/SymphonyApiContracts.cs
+++ b/dotnet/src/Symphony.Host/Api/SymphonyApiContracts.cs
@@ -10,12 +10,14 @@ public sealed record StateResponseDto(
     [property: JsonPropertyName("orchestration")] OrchestrationStatusDto Orchestration,
     [property: JsonPropertyName("running")] IReadOnlyList<RunningIssueDto> Running,
     [property: JsonPropertyName("retrying")] IReadOnlyList<RetryingIssueDto> Retrying,
+    [property: JsonPropertyName("blocked")] IReadOnlyList<BlockedIssueDto> Blocked,
     [property: JsonPropertyName("codex_totals")] CodexTotalsDto CodexTotals,
     [property: JsonPropertyName("rate_limits")] object? RateLimits);
 
 public sealed record StateCountsDto(
     [property: JsonPropertyName("running")] int Running,
-    [property: JsonPropertyName("retrying")] int Retrying);
+    [property: JsonPropertyName("retrying")] int Retrying,
+    [property: JsonPropertyName("blocked")] int Blocked);
 
 public sealed record HealthStatusDto(
     [property: JsonPropertyName("status")] string Status,
@@ -34,6 +36,7 @@ public sealed record HealthStatusDto(
 public sealed record RunningIssueDto(
     [property: JsonPropertyName("issue_id")] string IssueId,
     [property: JsonPropertyName("issue_identifier")] string IssueIdentifier,
+    [property: JsonPropertyName("orchestrator_session_id")] string? OrchestratorSessionId,
     [property: JsonPropertyName("state")] string State,
     [property: JsonPropertyName("session_id")] string? SessionId,
     [property: JsonPropertyName("turn_count")] int TurnCount,
@@ -50,6 +53,17 @@ public sealed record RetryingIssueDto(
     [property: JsonPropertyName("due_at")] DateTimeOffset DueAt,
     [property: JsonPropertyName("error")] string? Error);
 
+public sealed record BlockedIssueDto(
+    [property: JsonPropertyName("issue_id")] string IssueId,
+    [property: JsonPropertyName("issue_identifier")] string IssueIdentifier,
+    [property: JsonPropertyName("orchestrator_session_id")] string OrchestratorSessionId,
+    [property: JsonPropertyName("attempt")] int? Attempt,
+    [property: JsonPropertyName("blocked_at")] DateTimeOffset BlockedAt,
+    [property: JsonPropertyName("reason_code")] string ReasonCode,
+    [property: JsonPropertyName("error_message")] string ErrorMessage,
+    [property: JsonPropertyName("required_user_action")] string RequiredUserAction,
+    [property: JsonPropertyName("follow_up_action_id")] string FollowUpActionId);
+
 public sealed record TokenTotalsDto(
     [property: JsonPropertyName("input_tokens")] long InputTokens,
     [property: JsonPropertyName("output_tokens")] long OutputTokens,
@@ -64,11 +78,14 @@ public sealed record CodexTotalsDto(
 public sealed record IssueResponseDto(
     [property: JsonPropertyName("issue_identifier")] string IssueIdentifier,
     [property: JsonPropertyName("issue_id")] string IssueId,
+    [property: JsonPropertyName("orchestrator_session_id")] string? OrchestratorSessionId,
     [property: JsonPropertyName("status")] string Status,
     [property: JsonPropertyName("workspace")] WorkspaceDto Workspace,
     [property: JsonPropertyName("attempts")] IssueAttemptsDto Attempts,
     [property: JsonPropertyName("running")] RunningIssueDto? Running,
     [property: JsonPropertyName("retry")] RetryingIssueDto? Retry,
+    [property: JsonPropertyName("blocked")] BlockedIssueDto? Blocked,
+    [property: JsonPropertyName("follow_up_actions")] IReadOnlyList<FollowUpActionDto> FollowUpActions,
     [property: JsonPropertyName("logs")] IssueLogsDto Logs,
     [property: JsonPropertyName("recent_events")] IReadOnlyList<RuntimeEventDto> RecentEvents,
     [property: JsonPropertyName("last_error")] string? LastError,
@@ -93,6 +110,30 @@ public sealed record RuntimeEventDto(
     [property: JsonPropertyName("at")] DateTimeOffset At,
     [property: JsonPropertyName("event")] string? Event,
     [property: JsonPropertyName("message")] string? Message);
+
+public sealed record FollowUpActionDto(
+    [property: JsonPropertyName("fai_id")] string FollowUpActionId,
+    [property: JsonPropertyName("issue_identifier")] string IssueIdentifier,
+    [property: JsonPropertyName("session_id")] string SessionId,
+    [property: JsonPropertyName("created_at")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("reason_code")] string ReasonCode,
+    [property: JsonPropertyName("error_message")] string ErrorMessage,
+    [property: JsonPropertyName("required_user_action")] string RequiredUserAction,
+    [property: JsonPropertyName("options")] IReadOnlyList<FollowUpActionOptionDto> Options,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("resolved_by")] string? ResolvedBy,
+    [property: JsonPropertyName("resolved_at")] DateTimeOffset? ResolvedAt,
+    [property: JsonPropertyName("selected_option_id")] string? SelectedOptionId,
+    [property: JsonPropertyName("notes")] string? Notes);
+
+public sealed record FollowUpActionOptionDto(
+    [property: JsonPropertyName("option_id")] string OptionId,
+    [property: JsonPropertyName("label")] string Label,
+    [property: JsonPropertyName("description")] string? Description);
+
+public sealed record ResolveFollowUpActionRequestDto(
+    [property: JsonPropertyName("selected_option_id")] string? SelectedOptionId,
+    [property: JsonPropertyName("notes")] string? Notes);
 
 public sealed record RefreshResponseDto(
     [property: JsonPropertyName("queued")] bool Queued,

--- a/dotnet/src/Symphony.Host/Api/SymphonyApiEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Symphony.Host/Api/SymphonyApiEndpointRouteBuilderExtensions.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
 using Symphony.Application.Runtime;
 using Symphony.Host.Health;
 
@@ -50,6 +51,55 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
                         workflowOptionsProvider,
                         cancellationToken)
                     .ConfigureAwait(false);
+                return Results.Ok(ToIssueResponse(snapshot, workspacePath));
+            });
+
+        group.MapPost(
+            "/{issueIdentifier}/follow-up-actions/{faiId}/resolve",
+            async Task<IResult> (
+                string issueIdentifier,
+                string faiId,
+                [FromBody] ResolveFollowUpActionRequestDto request,
+                [FromServices] FollowUpActionResolutionService resolutionService,
+                [FromServices] IOrchestratorRuntimeService runtimeService,
+                [FromServices] IWorkflowOptionsProvider workflowOptionsProvider,
+                CancellationToken cancellationToken) =>
+            {
+                var result = await resolutionService.ResolveAsync(
+                        new FollowUpActionResolutionRequest(
+                            issueIdentifier,
+                            faiId,
+                            "operator",
+                            request.SelectedOptionId ?? "resume",
+                            request.Notes),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (result.Status == FollowUpActionResolutionStatus.ActionNotFound)
+                {
+                    return Results.NotFound(
+                        new ErrorEnvelopeDto(
+                            new ErrorDetailsDto(
+                                "follow_up_action_not_found",
+                                result.Message ?? "Follow-up action was not found.")));
+                }
+
+                if (result.Status == FollowUpActionResolutionStatus.BlockedIssueNotFound)
+                {
+                    return Results.Conflict(
+                        new ErrorEnvelopeDto(
+                            new ErrorDetailsDto(
+                                "blocked_issue_not_found",
+                                result.Message ?? "Blocked issue state was not found.")));
+                }
+
+                var snapshot = await runtimeService.GetIssueSnapshotAsync(issueIdentifier, cancellationToken).ConfigureAwait(false);
+                if (snapshot is null)
+                {
+                    return Results.Accepted(value: result);
+                }
+
+                var workspacePath = await ResolveWorkspacePathAsync(issueIdentifier, workflowOptionsProvider, cancellationToken).ConfigureAwait(false);
                 return Results.Ok(ToIssueResponse(snapshot, workspacePath));
             });
 
@@ -109,6 +159,7 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
                 session => new RunningIssueDto(
                     session.IssueId,
                     session.IssueIdentifier,
+                    session.OrchestratorSessionId,
                     session.State,
                     session.SessionId,
                     session.TurnCount,
@@ -130,10 +181,23 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
                     issue.DueAt,
                     issue.Error))
             .ToArray();
+        var blocked = (snapshot.Blocked ?? [])
+            .Select(
+                issue => new BlockedIssueDto(
+                    issue.IssueId,
+                    issue.IssueIdentifier,
+                    issue.OrchestratorSessionId,
+                    issue.Attempt,
+                    issue.BlockedAt,
+                    issue.ReasonCode.ToString(),
+                    issue.ErrorMessage,
+                    issue.RequiredUserAction,
+                    issue.FollowUpActionId))
+            .ToArray();
 
         return new StateResponseDto(
             snapshot.GeneratedAt,
-            new StateCountsDto(running.Length, retrying.Length),
+            new StateCountsDto(running.Length, retrying.Length, blocked.Length),
             new HealthStatusDto(
                 healthSnapshot.Status,
                 healthSnapshot.OrchestratorState,
@@ -150,6 +214,7 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
             ToOrchestrationResponse(orchestratorSnapshot),
             running,
             retrying,
+            blocked,
             new CodexTotalsDto(
                 snapshot.CodexTotals.InputTokens,
                 snapshot.CodexTotals.OutputTokens,
@@ -168,6 +233,7 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
         return new IssueResponseDto(
             snapshot.IssueIdentifier,
             snapshot.IssueId,
+            snapshot.OrchestratorSessionId,
             snapshot.Status,
             new WorkspaceDto(workspacePath),
             new IssueAttemptsDto(snapshot.RestartCount, snapshot.CurrentRetryAttempt),
@@ -176,6 +242,7 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
                 : new RunningIssueDto(
                     snapshot.Running.IssueId,
                     snapshot.Running.IssueIdentifier,
+                    snapshot.Running.OrchestratorSessionId,
                     snapshot.Running.State,
                     snapshot.Running.SessionId,
                     snapshot.Running.TurnCount,
@@ -195,6 +262,37 @@ public static class SymphonyApiEndpointRouteBuilderExtensions
                     snapshot.Retry.Attempt,
                     snapshot.Retry.DueAt,
                     snapshot.Retry.Error),
+            snapshot.Blocked is null
+                ? null
+                : new BlockedIssueDto(
+                    snapshot.Blocked.IssueId,
+                    snapshot.Blocked.IssueIdentifier,
+                    snapshot.Blocked.OrchestratorSessionId,
+                    snapshot.Blocked.Attempt,
+                    snapshot.Blocked.BlockedAt,
+                    snapshot.Blocked.ReasonCode.ToString(),
+                    snapshot.Blocked.ErrorMessage,
+                    snapshot.Blocked.RequiredUserAction,
+                    snapshot.Blocked.FollowUpActionId),
+            (snapshot.FollowUpActions ?? Array.Empty<Symphony.Abstractions.Orchestration.FollowUpActionSnapshot>())
+                .Select(
+                    action => new FollowUpActionDto(
+                        action.FollowUpActionId,
+                        action.IssueIdentifier,
+                        action.SessionId,
+                        action.CreatedAt,
+                        action.ReasonCode.ToString(),
+                        action.ErrorMessage,
+                        action.RequiredUserAction,
+                        action.Options
+                            .Select(option => new FollowUpActionOptionDto(option.OptionId, option.Label, option.Description))
+                            .ToArray(),
+                        action.Status.ToString(),
+                        action.ResolvedBy,
+                        action.ResolvedAt,
+                        action.SelectedOptionId,
+                        action.Notes))
+                .ToArray(),
             new IssueLogsDto(Array.Empty<SessionLogDto>()),
             snapshot.RecentEvents
                 .Select(runtimeEvent => new RuntimeEventDto(runtimeEvent.At, runtimeEvent.Event, runtimeEvent.Message))

--- a/dotnet/src/Symphony.Host/Components/Dashboard/BlockedSessionsPanel.razor
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/BlockedSessionsPanel.razor
@@ -1,0 +1,54 @@
+@using Symphony.Host.Dashboard
+
+<MudPaper Class="@PanelClass" Outlined="true" Elevation="0" data-testid="dashboard-blocked-sessions">
+    <div class="panel-header">
+        <div class="panel-header__content">
+            <p class="section-kicker">Needs Attention</p>
+            <h2 class="section-title section-title--panel">Blocked sessions</h2>
+            <p class="section-copy">
+                Sessions stopped by unresolved intervention or precondition blockers.
+            </p>
+        </div>
+        <StatusPill Text="@Entries.Count.ToString()" Color="Color.Warning" />
+    </div>
+
+    @if (Entries.Count == 0)
+    {
+        <div class="empty-state">
+            <p class="empty-state__title">No blocked sessions</p>
+            <p class="empty-state__copy">
+                Sessions that need explicit operator resolution will appear here.
+            </p>
+        </div>
+    }
+    else
+    {
+        <ul class="panel-list">
+            @foreach (var entry in Entries)
+            {
+                <li class="panel-item">
+                    <div class="panel-item__header">
+                        <a class="accent-link"
+                           href="/sessions/@Uri.EscapeDataString(entry.IssueIdentifier)">
+                            @entry.IssueIdentifier
+                        </a>
+                        <StatusPill Text="Needs attention" Color="Color.Warning" />
+                    </div>
+                    <div class="panel-item__meta">
+                        <p>Blocked @DashboardDisplay.FormatTimestamp(entry.BlockedAt) · session @entry.OrchestratorSessionId</p>
+                        <p>@entry.ErrorMessage</p>
+                        <p>Action: @entry.RequiredUserAction</p>
+                    </div>
+                </li>
+            }
+        </ul>
+    }
+</MudPaper>
+
+@code {
+    private const string PanelClass = "panel-card";
+
+    [Parameter]
+    [EditorRequired]
+    public required IReadOnlyList<DashboardBlockedSessionSnapshot> Entries { get; set; }
+}

--- a/dotnet/src/Symphony.Host/Components/Dashboard/DashboardDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/DashboardDisplay.cs
@@ -67,6 +67,8 @@ internal static class DashboardDisplay
             "streaming" => Color.Info,
             "finishing" => Color.Info,
             "retrying" => Color.Warning,
+            "needs attention" => Color.Warning,
+            "blocked_error" => Color.Warning,
             "succeeded" => Color.Success,
             "failed" => Color.Error,
             "timedout" => Color.Error,
@@ -82,6 +84,7 @@ internal static class DashboardDisplay
         {
             "succeeded" => Color.Success,
             "retrying" => Color.Warning,
+            "blockederror" => Color.Warning,
             "failed" => Color.Error,
             "timedout" => Color.Error,
             "stalled" => Color.Error,
@@ -176,6 +179,13 @@ internal static class DashboardDisplay
                 Severity.Warning,
                 "Workflow reload warning:",
                 snapshot.WorkflowLastError));
+        }
+        else if (snapshot.BlockedCount > 0)
+        {
+            alerts.Add(new DashboardAlertMessage(
+                Severity.Warning,
+                "Needs attention:",
+                $"{snapshot.BlockedCount} blocked session(s) require explicit operator resolution."));
         }
         else if (string.Equals(snapshot.ServiceHealth, "Degraded", StringComparison.Ordinal))
         {

--- a/dotnet/src/Symphony.Host/Components/Dashboard/HealthSummaryCards.razor
+++ b/dotnet/src/Symphony.Host/Components/Dashboard/HealthSummaryCards.razor
@@ -31,7 +31,7 @@
             State is tracked in-process and served live for the operator shell.
         </p>
         <p class="body-copy body-copy--muted">
-            Retry queue: @Snapshot.RetryingCount queued
+            Retry queue: @Snapshot.RetryingCount queued · Needs attention: @Snapshot.BlockedCount
         </p>
     </MudPaper>
 

--- a/dotnet/src/Symphony.Host/Components/Pages/DashboardPageContent.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/DashboardPageContent.razor
@@ -17,7 +17,7 @@
         </section>
 
         <section class="operations-grid">
-            @for (var index = 0; index < 3; index++)
+            @for (var index = 0; index < 4; index++)
             {
                 <MudPaper Class="@SkeletonCardClass" Outlined="true" Elevation="0">
                     <MudSkeleton SkeletonType="SkeletonType.Text" Width="55%" />
@@ -76,6 +76,21 @@
                         <h2 class="section-title section-title--card">Panel failed</h2>
                         <p class="section-copy">
                             Retry details are temporarily unavailable.
+                        </p>
+                    </MudPaper>
+                </ErrorContent>
+            </ErrorBoundary>
+
+            <ErrorBoundary>
+                <ChildContent>
+                    <BlockedSessionsPanel Entries="@(_snapshot.BlockedSessions ?? [])" />
+                </ChildContent>
+                <ErrorContent>
+                    <MudPaper Class="@FallbackCardClass" Outlined="true" Elevation="0" data-testid="dashboard-blocked-sessions-fallback">
+                        <p class="section-kicker">Needs Attention</p>
+                        <h2 class="section-title section-title--card">Panel failed</h2>
+                        <p class="section-copy">
+                            Blocked session details are temporarily unavailable.
                         </p>
                     </MudPaper>
                 </ErrorContent>

--- a/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
@@ -1,6 +1,9 @@
 @page "/sessions/{Identifier}"
 @implements IAsyncDisposable
 @using Microsoft.Extensions.Options
+@using MudBlazor
+@using Symphony.Abstractions.Orchestration
+@using Symphony.Application.Orchestration
 @using Symphony.Application.Runtime
 @using Symphony.Host.Components.SessionDetail
 @using Symphony.Host.Configuration
@@ -8,6 +11,8 @@
 @inject IOrchestratorRuntimeService OrchestratorRuntimeService
 @inject ISessionActivityStore SessionActivityStore
 @inject IOptions<DashboardUiOptions> DashboardUiOptions
+@inject FollowUpActionResolutionService FollowUpActionResolutionService
+@inject ISnackbar Snackbar
 
 <main class="page-shell page-stack">
     <div data-testid="session-detail-breadcrumb">
@@ -47,6 +52,14 @@
 
         <SessionHeaderCard Session="_header" />
 
+        @if (_blockedIssue is not null && _pendingFollowUpAction is not null)
+        {
+            <SessionFollowUpActionPanel BlockedIssue="_blockedIssue"
+                                       PendingAction="_pendingFollowUpAction"
+                                       IsResolving="_isResolvingFollowUpAction"
+                                       ResolveRequested="ResolveFollowUpActionAsync" />
+        }
+
         <div class="session-detail-flow">
             <div class="session-detail-metadata-row" data-testid="session-detail-metadata-panel">
                 <SessionMetadataPanel Metadata="_metadata" />
@@ -71,11 +84,14 @@
     private Task? _refreshLoopTask;
     private bool _isLoading = true;
     private bool _isSessionActive;
+    private bool _isResolvingFollowUpAction;
     private string _requestedIdentifier = string.Empty;
     private string? _refreshErrorMessage;
     private SessionHeaderDisplayModel? _header;
     private SessionActivityTimelineModel? _timeline;
     private SessionMetadataPanelModel? _metadata;
+    private BlockedDispatchSnapshot? _blockedIssue;
+    private FollowUpActionSnapshot? _pendingFollowUpAction;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -182,8 +198,11 @@
         var activeSession = snapshot.ActiveSessions
             .FirstOrDefault(candidate => string.Equals(candidate.IssueIdentifier, session.IssueIdentifier, StringComparison.OrdinalIgnoreCase));
         var issueSnapshot = await OrchestratorRuntimeService.GetIssueSnapshotAsync(session.IssueIdentifier, cancellationToken);
+        _pendingFollowUpAction = (issueSnapshot?.FollowUpActions ?? Array.Empty<FollowUpActionSnapshot>())
+            .FirstOrDefault(action => action.Status == FollowUpActionStatus.Pending);
+        _blockedIssue = issueSnapshot?.Blocked;
 
-        _header = BuildHeader(session);
+        _header = BuildHeader(session, issueSnapshot, _pendingFollowUpAction);
         _timeline = BuildTimeline(session, SessionActivityStore.GetActivities(session.IssueIdentifier));
         _metadata = BuildMetadata(session, activeSession, issueSnapshot, snapshot);
         _isSessionActive = session.IsActive;
@@ -191,9 +210,14 @@
         _isLoading = false;
     }
 
-    private static SessionHeaderDisplayModel BuildHeader(SessionRecord session)
+    private static SessionHeaderDisplayModel BuildHeader(
+        SessionRecord session,
+        OrchestratorIssueSnapshot? issueSnapshot,
+        FollowUpActionSnapshot? pendingFollowUpAction)
     {
-        var statusText = session.IsActive ? "Active" : session.FinalOutcome ?? "Ended";
+        var statusText = pendingFollowUpAction is null
+            ? (session.IsActive ? "Active" : session.FinalOutcome ?? "Ended")
+            : "Needs attention";
         var parsedStatus = SessionDetailDisplay.TryParseStatus(statusText);
         var statusColor = parsedStatus is null
             ? SessionDetailDisplay.GetFallbackStatusColor(statusText, session.IsActive)
@@ -220,7 +244,7 @@
             .ToArray();
 
         var latestWarning = activities
-            .Where(activity => activity.Kind == SessionActivityKind.Warning)
+            .Where(activity => activity.Kind == SessionActivityKind.Warning || activity.Kind == SessionActivityKind.AttentionRequired)
             .OrderByDescending(activity => activity.Timestamp)
             .FirstOrDefault();
         var latestError = activities
@@ -267,6 +291,7 @@
             .FirstOrDefault();
         var runningSession = issueSnapshot?.Running;
         var sessionId = runningSession?.SessionId ?? activeSession?.SessionId ?? recentAttempt?.SessionId;
+        var orchestratorSessionId = issueSnapshot?.OrchestratorSessionId ?? recentAttempt?.OrchestratorSessionId;
         var turnCount = runningSession?.TurnCount ?? activeSession?.TurnCount ?? SessionDetailDisplay.TryParseTurnCount(sessionId);
         var attempt = issueSnapshot is null ? recentAttempt?.Attempt : issueSnapshot.CurrentRetryAttempt;
         var isAttemptKnown = issueSnapshot is not null || recentAttempt is not null;
@@ -277,6 +302,7 @@
             runningSession?.TotalTokens ?? activeSession?.TotalTokens,
             turnCount,
             sessionId,
+            orchestratorSessionId,
             attempt,
             isAttemptKnown,
             GetMetadataAvailabilityMessage(session, runningSession is not null));
@@ -299,5 +325,42 @@
         return string.IsNullOrWhiteSpace(entry.Detail)
             ? entry.Title
             : $"{entry.Title} - {entry.Detail}";
+    }
+
+    private async Task ResolveFollowUpActionAsync()
+    {
+        if (_pendingFollowUpAction is null || _isResolvingFollowUpAction)
+        {
+            return;
+        }
+
+        _isResolvingFollowUpAction = true;
+
+        try
+        {
+            var selectedOptionId = _pendingFollowUpAction.Options.FirstOrDefault()?.OptionId ?? "resume";
+            var result = await FollowUpActionResolutionService.ResolveAsync(
+                new FollowUpActionResolutionRequest(
+                    _requestedIdentifier,
+                    _pendingFollowUpAction.FollowUpActionId,
+                    "operator",
+                    selectedOptionId,
+                    Notes: null));
+
+            if (result.Status == FollowUpActionResolutionStatus.Resolved)
+            {
+                Snackbar.Add("Follow-up action resolved. The issue was queued to resume.", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add(result.Message ?? "Follow-up action could not be resolved.", Severity.Warning);
+            }
+
+            await LoadAsync();
+        }
+        finally
+        {
+            _isResolvingFollowUpAction = false;
+        }
     }
 }

--- a/dotnet/src/Symphony.Host/Components/Pages/SessionListPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionListPage.razor
@@ -146,9 +146,11 @@
         var snapshot = await DashboardStateService.GetSnapshotAsync(cancellationToken);
         var activeSessionsByIssue = snapshot.ActiveSessions
             .ToDictionary(session => session.IssueIdentifier, StringComparer.OrdinalIgnoreCase);
+        var blockedSessionsByIssue = (snapshot.BlockedSessions ?? [])
+            .ToDictionary(session => session.IssueIdentifier, StringComparer.OrdinalIgnoreCase);
 
         var allSessions = SessionActivityStore.GetAllSessions()
-            .Select(session => BuildRow(session, activeSessionsByIssue, snapshot.GeneratedAt))
+            .Select(session => BuildRow(session, activeSessionsByIssue, blockedSessionsByIssue, snapshot.GeneratedAt))
             .ToArray();
 
         _generatedAt = snapshot.GeneratedAt;
@@ -162,6 +164,7 @@
     private static SessionListRowViewModel BuildRow(
         SessionRecord session,
         IReadOnlyDictionary<string, DashboardActiveSessionSnapshot> activeSessionsByIssue,
+        IReadOnlyDictionary<string, DashboardBlockedSessionSnapshot> blockedSessionsByIssue,
         DateTimeOffset generatedAt)
     {
         if (activeSessionsByIssue.TryGetValue(session.IssueIdentifier, out var activeSession))
@@ -170,6 +173,7 @@
                 session.IssueIdentifier,
                 session.IssueUrl,
                 true,
+                false,
                 activeSession.State,
                 session.StartedAt,
                 null,
@@ -182,10 +186,27 @@
                     : activeSession.LastMessage);
         }
 
+        if (blockedSessionsByIssue.TryGetValue(session.IssueIdentifier, out var blockedSession))
+        {
+            var blockedEndedAt = session.EndedAt ?? blockedSession.BlockedAt;
+            return new SessionListRowViewModel(
+                session.IssueIdentifier,
+                session.IssueUrl,
+                false,
+                true,
+                "Needs attention",
+                session.StartedAt,
+                blockedEndedAt,
+                Math.Max((blockedEndedAt - session.StartedAt).TotalSeconds, 0d),
+                blockedSession.ErrorMessage,
+                $"Action: {blockedSession.RequiredUserAction}");
+        }
+
         var endedAt = session.EndedAt ?? generatedAt;
         return new SessionListRowViewModel(
             session.IssueIdentifier,
             session.IssueUrl,
+            false,
             false,
             session.FinalOutcome ?? "Ended",
             session.StartedAt,

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
@@ -236,6 +236,7 @@
         return entry.Kind switch
         {
             SessionActivityKind.DebugMessage => $"{baseClasses} timeline-entry--debug",
+            SessionActivityKind.AttentionRequired => $"{baseClasses} timeline-entry--warning",
             SessionActivityKind.Warning => $"{baseClasses} timeline-entry--warning",
             SessionActivityKind.Error => $"{baseClasses} timeline-entry--error",
             SessionActivityKind.Outcome when entry.Color == Color.Error => $"{baseClasses} timeline-entry--error",

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
@@ -23,6 +23,9 @@ internal static class SessionDetailDisplay
         return statusText.Trim().ToLowerInvariant() switch
         {
             "succeeded" => Color.Success,
+            "needs attention" => Color.Warning,
+            "blocked_error" => Color.Warning,
+            "blockederror" => Color.Warning,
             "retrying" => Color.Warning,
             "failed" => Color.Error,
             "timedout" => Color.Error,
@@ -70,6 +73,7 @@ internal static class SessionDetailDisplay
             SessionActivityKind.AgentMessage => "Agent message",
             SessionActivityKind.DebugMessage => "Debug transcript",
             SessionActivityKind.ProgressUpdate => "Progress",
+            SessionActivityKind.AttentionRequired => "Attention",
             SessionActivityKind.Warning => "Warning",
             SessionActivityKind.Error => "Error",
             SessionActivityKind.Outcome => "Outcome",
@@ -83,6 +87,7 @@ internal static class SessionDetailDisplay
         {
             SessionActivityKind.AgentMessage => Color.Info,
             SessionActivityKind.DebugMessage => Color.Info,
+            SessionActivityKind.AttentionRequired => Color.Warning,
             SessionActivityKind.Warning => Color.Warning,
             SessionActivityKind.Error => Color.Error,
             SessionActivityKind.Outcome => Color.Success,
@@ -98,6 +103,7 @@ internal static class SessionDetailDisplay
             SessionActivityKind.AgentMessage => Color.Info,
             SessionActivityKind.DebugMessage => Color.Info,
             SessionActivityKind.ProgressUpdate => Color.Default,
+            SessionActivityKind.AttentionRequired => Color.Warning,
             SessionActivityKind.Warning => Color.Warning,
             SessionActivityKind.Error => Color.Error,
             SessionActivityKind.Outcome => IsSuccessfulOutcome(entry) ? Color.Success : Color.Error,

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionFollowUpActionPanel.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionFollowUpActionPanel.razor
@@ -1,0 +1,63 @@
+@using Symphony.Abstractions.Orchestration
+
+<div data-testid="session-detail-follow-up-action-panel">
+    <MudPaper Class="@PanelClass" Outlined="true" Elevation="0">
+        <div class="panel-header">
+            <div class="panel-header__content">
+                <p class="section-kicker">Needs Attention</p>
+                <h2 class="section-title section-title--panel">Follow-up action</h2>
+                <p class="section-copy">
+                    This session is blocked until the pending follow-up action is resolved.
+                </p>
+            </div>
+            <StatusPill Text="@PendingAction.Status.ToString()" Color="Color.Warning" />
+        </div>
+
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true">
+            <strong>@PendingAction.ReasonCode</strong> @PendingAction.ErrorMessage
+        </MudAlert>
+
+        <div class="detail-metrics-grid detail-metrics-grid--metadata">
+            <div class="detail-metric-card">
+                <p class="detail-metric-label">Required action</p>
+                <p class="detail-metric-value">@PendingAction.RequiredUserAction</p>
+            </div>
+            <div class="detail-metric-card">
+                <p class="detail-metric-label">Session linkage</p>
+                <p class="detail-metric-value detail-metric-value--break">@BlockedIssue.OrchestratorSessionId</p>
+            </div>
+        </div>
+
+        @if (PendingAction.Options.Count > 0)
+        {
+            <div class="detail-note">
+                Options: @string.Join(", ", PendingAction.Options.Select(option => option.Label))
+            </div>
+        }
+
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Warning"
+                   Disabled="@IsResolving"
+                   OnClick="@(() => ResolveRequested.InvokeAsync())">
+            Resolve and resume
+        </MudButton>
+    </MudPaper>
+</div>
+
+@code {
+    private const string PanelClass = "page-card page-card--tight";
+
+    [Parameter]
+    [EditorRequired]
+    public required BlockedDispatchSnapshot BlockedIssue { get; set; }
+
+    [Parameter]
+    [EditorRequired]
+    public required FollowUpActionSnapshot PendingAction { get; set; }
+
+    [Parameter]
+    public bool IsResolving { get; set; }
+
+    [Parameter]
+    public EventCallback ResolveRequested { get; set; }
+}

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanel.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanel.razor
@@ -44,6 +44,10 @@
                         <p class="detail-metric-label">Session ID</p>
                         <p class="detail-metric-value detail-metric-value--break">@FormatText(Metadata.SessionId)</p>
                     </div>
+                    <div class="detail-metric-card" data-testid="session-detail-metadata-orchestrator-session-id">
+                        <p class="detail-metric-label">Orchestrator Session ID</p>
+                        <p class="detail-metric-value detail-metric-value--break">@FormatText(Metadata.OrchestratorSessionId)</p>
+                    </div>
                 </div>
             </div>
         </details>

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanelModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionMetadataPanelModel.cs
@@ -6,6 +6,7 @@ public sealed record SessionMetadataPanelModel(
     long? TotalTokens,
     int? TurnCount,
     string? SessionId,
+    string? OrchestratorSessionId,
     int? Attempt,
     bool IsAttemptKnown,
     string? AvailabilityMessage);

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionListDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionListDisplay.cs
@@ -27,10 +27,12 @@ internal static class SessionListDisplay
     {
         return session.Status.ToLowerInvariant() switch
         {
+            _ when session.NeedsAttention => Color.Warning,
             "in progress" => Color.Info,
             "streaming" => Color.Info,
             "finishing" => Color.Info,
             "retrying" => Color.Warning,
+            "blockederror" => Color.Warning,
             "succeeded" => Color.Success,
             "failed" => Color.Error,
             "timedout" => Color.Error,

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionListRowViewModel.cs
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionListRowViewModel.cs
@@ -4,6 +4,7 @@ public sealed record SessionListRowViewModel(
     string IssueIdentifier,
     string? IssueUrl,
     bool IsActive,
+    bool NeedsAttention,
     string Status,
     DateTimeOffset StartedAt,
     DateTimeOffset? EndedAt,

--- a/dotnet/src/Symphony.Host/Components/Sessions/SessionStatusBadge.razor
+++ b/dotnet/src/Symphony.Host/Components/Sessions/SessionStatusBadge.razor
@@ -45,6 +45,7 @@
             RunAttemptStatus.InitializingSession => Color.Info,
             RunAttemptStatus.StreamingTurn => Color.Info,
             RunAttemptStatus.Finishing => Color.Info,
+            RunAttemptStatus.BlockedError => Color.Warning,
             RunAttemptStatus.Failed => Color.Error,
             RunAttemptStatus.TimedOut => Color.Error,
             RunAttemptStatus.Stalled => Color.Error,

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardModels.cs
@@ -23,7 +23,10 @@ public sealed record DashboardSnapshot(
     IReadOnlyList<DashboardRetrySnapshot> RetryQueue,
     IReadOnlyList<DashboardRecentAttemptSnapshot> RecentAttempts,
     string? LastError,
-    string? WorkflowLastError);
+    string? WorkflowLastError,
+    int BlockedCount = 0,
+    IReadOnlyList<DashboardBlockedSessionSnapshot>? BlockedSessions = null,
+    IReadOnlyList<FollowUpActionSnapshot>? FollowUpActions = null);
 
 public sealed record DashboardActiveSessionSnapshot(
     string IssueIdentifier,
@@ -42,6 +45,14 @@ public sealed record DashboardRetrySnapshot(
     DateTimeOffset DueAt,
     string? Error);
 
+public sealed record DashboardBlockedSessionSnapshot(
+    string IssueIdentifier,
+    string OrchestratorSessionId,
+    string FollowUpActionId,
+    DateTimeOffset BlockedAt,
+    string ErrorMessage,
+    string RequiredUserAction);
+
 public sealed record DashboardRecentAttemptSnapshot(
     string IssueIdentifier,
     int? Attempt,
@@ -49,4 +60,5 @@ public sealed record DashboardRecentAttemptSnapshot(
     DateTimeOffset CompletedAt,
     double DurationSeconds,
     string? Error,
-    string? SessionId);
+    string? SessionId,
+    string? OrchestratorSessionId = null);

--- a/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/DashboardStateService.cs
@@ -1,3 +1,4 @@
+using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Health;
@@ -39,6 +40,16 @@ public sealed class DashboardStateService(
                     retry.DueAt,
                     retry.Error))
             .ToArray();
+        var blockedSessions = (runtimeSnapshot.Blocked ?? [])
+            .Select(
+                blocked => new DashboardBlockedSessionSnapshot(
+                    blocked.IssueIdentifier,
+                    blocked.OrchestratorSessionId,
+                    blocked.FollowUpActionId,
+                    blocked.BlockedAt,
+                    blocked.ErrorMessage,
+                    blocked.RequiredUserAction))
+            .ToArray();
         var recentAttempts = attemptHistoryTracker.GetRecentAttempts()
             .Select(
                 attempt => new DashboardRecentAttemptSnapshot(
@@ -48,7 +59,8 @@ public sealed class DashboardStateService(
                     attempt.CompletedAt,
                     attempt.DurationSeconds,
                     attempt.Error,
-                    attempt.SessionId))
+                    attempt.SessionId,
+                    attempt.OrchestratorSessionId))
             .ToArray();
 
         var snapshot = new DashboardSnapshot(
@@ -72,7 +84,10 @@ public sealed class DashboardStateService(
             retryQueue,
             recentAttempts,
             healthSnapshot.PollLastError,
-            healthSnapshot.WorkflowLastError);
+            healthSnapshot.WorkflowLastError,
+            blockedSessions.Length,
+            blockedSessions,
+            runtimeSnapshot.FollowUpActions ?? Array.Empty<FollowUpActionSnapshot>());
 
         lock (_snapshotLock)
         {
@@ -91,6 +106,11 @@ public sealed class DashboardStateService(
             .ToDictionary(session => session.IssueIdentifier, StringComparer.OrdinalIgnoreCase);
         var previousRetry = new HashSet<DashboardRetrySnapshot>(previousSnapshot?.RetryQueue ?? []);
         var previousAttempts = new HashSet<DashboardRecentAttemptSnapshot>(previousSnapshot?.RecentAttempts ?? []);
+        var previousBlocked = new HashSet<string>(
+            (previousSnapshot?.BlockedSessions ?? []).Select(session => session.FollowUpActionId),
+            StringComparer.Ordinal);
+        var previousActions = (previousSnapshot?.FollowUpActions ?? [])
+            .ToDictionary(action => action.FollowUpActionId, StringComparer.Ordinal);
         var latestAttemptsByIssue = currentSnapshot.RecentAttempts
             .GroupBy(attempt => attempt.IssueIdentifier, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
@@ -187,6 +207,55 @@ public sealed class DashboardStateService(
                     retry.DueAt,
                     "Queued for retry",
                     retry.Error));
+        }
+
+        foreach (var blocked in currentSnapshot.BlockedSessions ?? [])
+        {
+            if (previousBlocked.Contains(blocked.FollowUpActionId))
+            {
+                continue;
+            }
+
+            sessionActivityStore.RecordActivity(
+                blocked.IssueIdentifier,
+                new SessionActivityEntry(
+                    SessionActivityKind.AttentionRequired,
+                    blocked.BlockedAt,
+                    "Follow-up action created",
+                    $"{blocked.ErrorMessage} Action: {blocked.RequiredUserAction}"));
+        }
+
+        foreach (var action in currentSnapshot.FollowUpActions ?? [])
+        {
+            if (action.Status != FollowUpActionStatus.Resolved)
+            {
+                continue;
+            }
+
+            if (previousActions.TryGetValue(action.FollowUpActionId, out var previousAction)
+                && previousAction.Status == FollowUpActionStatus.Resolved)
+            {
+                continue;
+            }
+
+            var resolutionDetail = $"Resolved by {action.ResolvedBy ?? "operator"}";
+            if (!string.IsNullOrWhiteSpace(action.SelectedOptionId))
+            {
+                resolutionDetail += $" using {action.SelectedOptionId}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Notes))
+            {
+                resolutionDetail += $". {action.Notes}";
+            }
+
+            sessionActivityStore.RecordActivity(
+                action.IssueIdentifier,
+                new SessionActivityEntry(
+                    SessionActivityKind.AttentionRequired,
+                    action.ResolvedAt ?? action.CreatedAt,
+                    "Follow-up action resolved",
+                    resolutionDetail));
         }
 
         foreach (var attempt in currentSnapshot.RecentAttempts)

--- a/dotnet/src/Symphony.Host/Dashboard/SessionActivityModels.cs
+++ b/dotnet/src/Symphony.Host/Dashboard/SessionActivityModels.cs
@@ -6,6 +6,7 @@ public enum SessionActivityKind
     AgentMessage,
     DebugMessage,
     ProgressUpdate,
+    AttentionRequired,
     Warning,
     Error,
     Outcome

--- a/dotnet/src/Symphony.Host/WORKFLOW.md
+++ b/dotnet/src/Symphony.Host/WORKFLOW.md
@@ -63,8 +63,8 @@ No description provided.
 
 Instructions:
 
-1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
-2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+1. This is an unattended orchestration session. Do not ask a human directly to perform follow-up actions. If a required approval, input request, or manual decision cannot be auto-resolved, stop so the host can capture the required operator action.
+2. Only stop early for a true blocker (missing required auth/permissions/secrets, or a required approval/input/decision that could not be auto-resolved). If blocked, record it in the workpad and move the issue according to workflow.
 3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
 Work only in the provided repository copy. Do not touch any other path.

--- a/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
+++ b/dotnet/src/Symphony.Infrastructure/Codex/CodexAppServerClient.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
 using Symphony.Domain.Runs;
@@ -474,7 +475,7 @@ internal sealed class CodexAppServerClient(
                 || IsMcpServerElicitationRequestMethod(method))
             {
                 UpdateSessionMetadata(context, "turn_input_required", "user_input_required", payload);
-                throw new CodexAgentException("turn_input_required", "Codex app-server requested user input.");
+                throw CreateBlockingException(method, payload);
             }
 
             if (method.Contains("approval", StringComparison.OrdinalIgnoreCase))
@@ -790,6 +791,36 @@ internal sealed class CodexAppServerClient(
         return string.Equals(method, "mcpServer/elicitation/request", StringComparison.Ordinal);
     }
 
+    private static IssueBlockingException CreateBlockingException(string method, JsonElement payload)
+    {
+        var options = ExtractFollowUpOptions(payload);
+        var errorMessage = ExtractMessage(payload) ?? "Codex app-server requested human intervention.";
+
+        if (IsMcpServerElicitationRequestMethod(method))
+        {
+            return new IssueBlockingException(
+                BlockingReasonCode.ManualDecisionRequired,
+                errorMessage,
+                "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+                options);
+        }
+
+        if (IsApprovalRequest(payload))
+        {
+            return new IssueBlockingException(
+                BlockingReasonCode.ApprovalRequired,
+                errorMessage,
+                "Review the requested approval, then resolve the follow-up action to resume the run.",
+                options);
+        }
+
+        return new IssueBlockingException(
+            BlockingReasonCode.InputRequired,
+            errorMessage,
+            "Provide the required input or choose an option, then resolve the follow-up action to resume the run.",
+            options);
+    }
+
     private static bool TryCreateToolRequestUserInputApprovalResponse(JsonElement payload, out object response)
     {
         response = default!;
@@ -1039,6 +1070,73 @@ internal sealed class CodexAppServerClient(
         }
 
         return null;
+    }
+
+    private static bool IsApprovalRequest(JsonElement payload)
+    {
+        if (payload.TryGetProperty("params", out var parameters)
+            && parameters.ValueKind == JsonValueKind.Object
+            && parameters.TryGetProperty("questions", out var questionsElement)
+            && questionsElement.ValueKind == JsonValueKind.Array)
+        {
+            return questionsElement.EnumerateArray().Any(question =>
+                question.ValueKind == JsonValueKind.Object
+                && question.TryGetProperty("options", out var optionsElement)
+                && optionsElement.ValueKind == JsonValueKind.Array
+                && optionsElement.GetArrayLength() > 0);
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<FollowUpActionOptionSnapshot> ExtractFollowUpOptions(JsonElement payload)
+    {
+        if (!payload.TryGetProperty("params", out var parameters) || parameters.ValueKind != JsonValueKind.Object)
+        {
+            return Array.Empty<FollowUpActionOptionSnapshot>();
+        }
+
+        if (parameters.TryGetProperty("questions", out var questionsElement) && questionsElement.ValueKind == JsonValueKind.Array)
+        {
+            var options = new List<FollowUpActionOptionSnapshot>();
+            foreach (var question in questionsElement.EnumerateArray())
+            {
+                if (question.ValueKind != JsonValueKind.Object
+                    || !question.TryGetProperty("options", out var optionsElement)
+                    || optionsElement.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var option in optionsElement.EnumerateArray())
+                {
+                    if (option.ValueKind != JsonValueKind.Object
+                        || !option.TryGetProperty("label", out var labelElement)
+                        || labelElement.ValueKind != JsonValueKind.String)
+                    {
+                        continue;
+                    }
+
+                    var label = labelElement.GetString();
+                    if (string.IsNullOrWhiteSpace(label))
+                    {
+                        continue;
+                    }
+
+                    var id = option.TryGetProperty("id", out var idElement) && idElement.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(idElement.GetString())
+                        ? idElement.GetString()!
+                        : label.Trim().ToLowerInvariant().Replace(' ', '-');
+                    var description = option.TryGetProperty("description", out var descriptionElement) && descriptionElement.ValueKind == JsonValueKind.String
+                        ? descriptionElement.GetString()
+                        : null;
+                    options.Add(new FollowUpActionOptionSnapshot(id, label.Trim(), string.IsNullOrWhiteSpace(description) ? null : description.Trim()));
+                }
+            }
+
+            return options;
+        }
+
+        return Array.Empty<FollowUpActionOptionSnapshot>();
     }
 
     private readonly record struct UsageInfo(int? InputTokens, int? OutputTokens, int? TotalTokens);

--- a/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
+++ b/dotnet/src/Symphony.Infrastructure/Orchestration/CodexQueuedIssueWorker.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Symphony.Abstractions.Orchestration;
 using Symphony.Abstractions.Processes;
 using Symphony.Abstractions.Trackers;
 using Symphony.Abstractions.Workspaces;
@@ -104,6 +105,14 @@ internal sealed class CodexQueuedIssueWorker(
             throw new IssueExecutionTimedOutException(
                 $"Issue '{context.Issue.Identifier}' timed out while waiting for Codex.",
                 exception);
+        }
+        catch (CodexAgentException exception) when (exception.Code == "codex_not_found")
+        {
+            throw new IssueBlockingException(
+                BlockingReasonCode.ToolUnavailable,
+                exception.Message,
+                "Install or make the required Codex command available to Symphony, then resolve the follow-up action to resume the run.",
+                innerException: exception);
         }
         catch (WorkflowPromptRenderer.WorkflowPromptException exception)
         {

--- a/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/ApplicationServiceCollectionExtensionsTests.cs
@@ -71,6 +71,8 @@ public class ApplicationServiceCollectionExtensionsTests
         Assert.NotNull(serviceProvider.GetService<PollingStatusTracker>());
         Assert.NotNull(serviceProvider.GetService<AttemptHistoryTracker>());
         Assert.NotNull(serviceProvider.GetService<RetryDelayPlanner>());
+        Assert.NotNull(serviceProvider.GetService<FollowUpActionRegistry>());
+        Assert.NotNull(serviceProvider.GetService<FollowUpActionResolutionService>());
         Assert.IsType<ActiveSessionRegistry>(serviceProvider.GetRequiredService<IActiveSessionRegistry>());
         Assert.IsType<OrchestratorControlService>(serviceProvider.GetRequiredService<IOrchestratorControl>());
         Assert.IsType<OrchestratorControlService>(serviceProvider.GetRequiredService<IOrchestratorControlStatusReader>());

--- a/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Orchestration/OrchestratorDispatchQueueTests.cs
@@ -489,6 +489,110 @@ public sealed class OrchestratorDispatchQueueTests
         Assert.Equal("Session stalled after 360000 ms of Codex inactivity.", retry.Error);
     }
 
+    [Fact]
+    public async Task DispatchWorker_blocks_issue_and_creates_pending_follow_up_action_for_blocking_exception()
+    {
+        var timeProvider = TimeProvider.System;
+        var queue = CreateQueue(maxConcurrentAgents: 1);
+        var registry = CreateRegistry(timeProvider);
+        var attemptHistoryTracker = new AttemptHistoryTracker();
+        var followUpActionRegistry = new FollowUpActionRegistry(timeProvider);
+        var worker = new ThrowingQueuedIssueWorker(
+            new IssueBlockingException(
+                BlockingReasonCode.InputRequired,
+                "Need human confirmation",
+                "Review the prompt and resume the run.",
+                [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue the run after review.")]));
+        var hostedService = CreateHostedService(
+            queue,
+            registry,
+            attemptHistoryTracker,
+            worker,
+            timeProvider,
+            followUpActionRegistry: followUpActionRegistry);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await queue.QueueAsync(CreateIssue("1", "ABC-1"));
+        await worker.ExecutionAttempted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => queue.GetSnapshot().Blocked.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => followUpActionRegistry.GetAll().Count == 1, TimeSpan.FromSeconds(2));
+        await hostedService.StopAsync(CancellationToken.None);
+
+        var blocked = Assert.Single(queue.GetSnapshot().Blocked);
+        var followUpAction = Assert.Single(followUpActionRegistry.GetAll());
+        var attempt = Assert.Single(attemptHistoryTracker.GetRecentAttempts());
+
+        Assert.Equal("ABC-1", blocked.IssueIdentifier);
+        Assert.Equal(BlockingReasonCode.InputRequired, blocked.ReasonCode);
+        Assert.Equal("Need human confirmation", blocked.ErrorMessage);
+        Assert.Equal(followUpAction.FollowUpActionId, blocked.FollowUpActionId);
+        Assert.False(string.IsNullOrWhiteSpace(blocked.OrchestratorSessionId));
+        Assert.Equal(FollowUpActionStatus.Pending, followUpAction.Status);
+        Assert.Equal("ABC-1", followUpAction.IssueIdentifier);
+        Assert.Equal(blocked.OrchestratorSessionId, followUpAction.SessionId);
+        Assert.Single(followUpAction.Options);
+        Assert.Equal("BlockedError", attempt.Outcome);
+        Assert.Equal("Need human confirmation", attempt.Error);
+        Assert.Equal(blocked.OrchestratorSessionId, attempt.OrchestratorSessionId);
+        Assert.Empty(queue.GetSnapshot().Retrying);
+    }
+
+    [Fact]
+    public async Task FollowUpActionResolutionService_requeues_blocked_issue_when_resolution_succeeds()
+    {
+        var timeProvider = TimeProvider.System;
+        var workflowOptions = CreateWorkflowOptions(maxConcurrentAgents: 1);
+        var workflowOptionsProvider = new StaticWorkflowOptionsProvider(workflowOptions);
+        var queue = CreateQueue(workflowOptionsProvider, timeProvider: timeProvider);
+        var issue = CreateIssue("1", "ABC-1");
+        var trackerClient = CreateTracker(issue);
+        var followUpActionRegistry = new FollowUpActionRegistry(timeProvider);
+        var followUpAction = followUpActionRegistry.CreatePending(
+            issue.Id,
+            issue.Identifier,
+            "orch-123",
+            BlockingReasonCode.InputRequired,
+            "Need human confirmation",
+            "Review the prompt and resume the run.",
+            [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue the run after review.")]);
+
+        queue.BlockAsync(
+            issue,
+            "orch-123",
+            attempt: 2,
+            BlockingReasonCode.InputRequired,
+            "Need human confirmation",
+            "Review the prompt and resume the run.",
+            followUpAction.FollowUpActionId);
+
+        var service = new FollowUpActionResolutionService(
+            followUpActionRegistry,
+            queue,
+            trackerClient,
+            workflowOptionsProvider);
+
+        var result = await service.ResolveAsync(
+            new FollowUpActionResolutionRequest(
+                issue.Identifier,
+                followUpAction.FollowUpActionId,
+                "operator",
+                "resume",
+                "Reviewed and resumed."),
+            CancellationToken.None);
+
+        Assert.Equal(FollowUpActionResolutionStatus.Resolved, result.Status);
+        Assert.True(result.Requeued);
+        Assert.NotNull(result.Action);
+        var resolvedAction = result.Action!;
+        Assert.Equal(FollowUpActionStatus.Resolved, resolvedAction.Status);
+        Assert.Equal("operator", resolvedAction.ResolvedBy);
+        Assert.Equal("resume", resolvedAction.SelectedOptionId);
+        Assert.Equal("Reviewed and resumed.", resolvedAction.Notes);
+        Assert.Null(queue.GetBlockedIssue(issue.Identifier));
+        Assert.Single(queue.GetSnapshot().Queued);
+        Assert.Equal("ABC-1", queue.GetSnapshot().Queued[0].IssueIdentifier);
+    }
+
     private static OrchestratorDispatchQueue CreateQueue(int maxConcurrentAgents)
     {
         return CreateQueue(new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents)));
@@ -543,7 +647,8 @@ public sealed class OrchestratorDispatchQueueTests
         TimeProvider? timeProvider = null,
         IOrchestratorExecutionGate? executionGate = null,
         IIssueTrackerClient? trackerClient = null,
-        IWorkflowOptionsProvider? workflowOptionsProvider = null)
+        IWorkflowOptionsProvider? workflowOptionsProvider = null,
+        FollowUpActionRegistry? followUpActionRegistry = null)
     {
         return new DispatchWorkerBackgroundService(
             queue,
@@ -554,7 +659,8 @@ public sealed class OrchestratorDispatchQueueTests
             workflowOptionsProvider ?? new StaticWorkflowOptionsProvider(CreateWorkflowOptions(maxConcurrentAgents: 1)),
             timeProvider ?? TimeProvider.System,
             queuedIssueWorker,
-            NullLogger<DispatchWorkerBackgroundService>.Instance);
+            NullLogger<DispatchWorkerBackgroundService>.Instance,
+            followUpActionRegistry);
     }
 
     private static RetryDispatchBackgroundService CreateRetryHostedService(

--- a/dotnet/tests/Symphony.Application.Tests/Runtime/OrchestratorRuntimeServiceTests.cs
+++ b/dotnet/tests/Symphony.Application.Tests/Runtime/OrchestratorRuntimeServiceTests.cs
@@ -95,6 +95,57 @@ public sealed class OrchestratorRuntimeServiceTests
         Assert.Equal(["poll", "reconcile"], secondRequest.Operations);
     }
 
+    [Fact]
+    public async Task GetIssueSnapshotAsync_returns_blocked_issue_details_and_follow_up_actions_when_present()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero));
+        var registry = new ActiveSessionRegistry(timeProvider, NullLogger<ActiveSessionRegistry>.Instance);
+        var queue = CreateQueue(timeProvider);
+        var followUpActionRegistry = new FollowUpActionRegistry(timeProvider);
+        var issue = CreateIssue("2", "ABC-2");
+        var followUpAction = followUpActionRegistry.CreatePending(
+            issue.Id,
+            issue.Identifier,
+            "orch-123",
+            BlockingReasonCode.ManualDecisionRequired,
+            "Need a human choice",
+            "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+            [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue after review.")]);
+        queue.BlockAsync(
+            issue,
+            "orch-123",
+            attempt: 2,
+            BlockingReasonCode.ManualDecisionRequired,
+            "Need a human choice",
+            "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+            followUpAction.FollowUpActionId);
+        var service = new OrchestratorRuntimeService(
+            registry,
+            queue,
+            new PollingRefreshTrigger(timeProvider),
+            timeProvider,
+            followUpActionRegistry);
+
+        var stateSnapshot = await service.GetStateSnapshotAsync();
+        var issueSnapshot = await service.GetIssueSnapshotAsync("abc-2");
+
+        var blocked = Assert.Single(stateSnapshot.Blocked ?? []);
+        var action = Assert.Single(stateSnapshot.FollowUpActions ?? []);
+        Assert.Equal("ABC-2", blocked.IssueIdentifier);
+        Assert.Equal("orch-123", blocked.OrchestratorSessionId);
+        Assert.Equal(followUpAction.FollowUpActionId, blocked.FollowUpActionId);
+        Assert.Equal(FollowUpActionStatus.Pending, action.Status);
+
+        Assert.NotNull(issueSnapshot);
+        Assert.Equal("blocked_error", issueSnapshot!.Status);
+        Assert.Equal("orch-123", issueSnapshot.OrchestratorSessionId);
+        Assert.Equal(1, issueSnapshot.RestartCount);
+        Assert.Equal(2, issueSnapshot.CurrentRetryAttempt);
+        Assert.NotNull(issueSnapshot.Blocked);
+        Assert.Single(issueSnapshot.FollowUpActions ?? []);
+        Assert.Equal("Need a human choice", issueSnapshot.LastError);
+    }
+
     private static OrchestratorDispatchQueue CreateQueue(TimeProvider timeProvider)
     {
         return new OrchestratorDispatchQueue(

--- a/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/DashboardStateServiceTests.cs
@@ -283,6 +283,86 @@ public sealed class DashboardStateServiceTests
             activity => activity.Kind == SessionActivityKind.Outcome && activity.Title == "Failed" && activity.Detail == "Tracker request failed");
     }
 
+    [Fact]
+    public async Task GetSnapshotAsync_includes_blocked_sessions_and_records_attention_activity_for_follow_up_actions()
+    {
+        var blockedAt = new DateTimeOffset(2026, 3, 16, 16, 0, 0, TimeSpan.Zero);
+        var runtimeService = new StubRuntimeService
+        {
+            StateSnapshot = new OrchestratorStateSnapshot(
+                blockedAt,
+                Array.Empty<RunningIssueSnapshot>(),
+                Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                new CodexTotalsSnapshot(0, 0, 0, 0d),
+                RateLimits: null,
+                Blocked:
+                [
+                    new BlockedDispatchSnapshot(
+                        "1",
+                        "ABC-1",
+                        "orch-123",
+                        2,
+                        blockedAt,
+                        BlockingReasonCode.ManualDecisionRequired,
+                        "Need a human choice",
+                        "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+                        "fai-1")
+                ],
+                FollowUpActions:
+                [
+                    new FollowUpActionSnapshot(
+                        "fai-1",
+                        "1",
+                        "ABC-1",
+                        "orch-123",
+                        blockedAt,
+                        BlockingReasonCode.ManualDecisionRequired,
+                        "Need a human choice",
+                        "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+                        [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue after review.")],
+                        FollowUpActionStatus.Pending,
+                        ResolvedBy: null,
+                        ResolvedAt: null,
+                        SelectedOptionId: null,
+                        Notes: null)
+                ])
+        };
+        var pollingStatusTracker = new PollingStatusTracker();
+        pollingStatusTracker.RecordCompleted(blockedAt);
+        var sessionActivityStore = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        var service = new DashboardStateService(
+            runtimeService,
+            new AttemptHistoryTracker(),
+            new ServiceHealthSnapshotProvider(
+                pollingStatusTracker,
+                new StaticOrchestratorControlStatusReader(OrchestratorControlState.Started),
+                new StaticWorkflowLoadStatusReader(
+                    new WorkflowLoadStatusSnapshot(
+                        "Loaded",
+                        "C:\\repo\\WORKFLOW.md",
+                        blockedAt.AddMinutes(-5),
+                        null,
+                        null,
+                        null,
+                        30_000)),
+                new FakeTimeProvider(blockedAt.AddSeconds(5))),
+            sessionActivityStore);
+
+        var snapshot = await service.GetSnapshotAsync();
+
+        Assert.Equal(1, snapshot.BlockedCount);
+        var blockedSession = Assert.Single(snapshot.BlockedSessions ?? []);
+        Assert.Equal("ABC-1", blockedSession.IssueIdentifier);
+        Assert.Equal("fai-1", blockedSession.FollowUpActionId);
+
+        var activities = sessionActivityStore.GetActivities("ABC-1");
+        Assert.Contains(
+            activities,
+            activity => activity.Kind == SessionActivityKind.AttentionRequired
+                && activity.Title == "Follow-up action created"
+                && activity.Detail == "Need a human choice Action: Review the requested manual decision, then resolve the follow-up action to resume the run.");
+    }
+
     private sealed class StubRuntimeService : IOrchestratorRuntimeService
     {
         public OrchestratorStateSnapshot StateSnapshot { get; set; } = new(

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -5,12 +5,16 @@ using Microsoft.Extensions.Options;
 using MudBlazor;
 using MudBlazor.Services;
 using Symphony.Abstractions.Orchestration;
+using Symphony.Abstractions.Trackers;
+using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Components.Pages;
 using Symphony.Host.Components.SessionDetail;
 using Symphony.Host.Configuration;
 using Symphony.Host.Dashboard;
+using Symphony.Domain.Issues;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -28,6 +32,7 @@ public sealed class SessionDetailComponentTests : BunitContext
                 options.DebugMode = false;
                 options.TrackAgentMessageDeltas = false;
             });
+        Services.AddSingleton(CreateFollowUpActionResolutionService());
     }
 
     [Fact]
@@ -209,6 +214,7 @@ public sealed class SessionDetailComponentTests : BunitContext
                     165,
                     4,
                     "thread-1-turn-4",
+                    null,
                     2,
                     true,
                     "Finished sessions keep the last known session ID and attempt when available.")));
@@ -384,6 +390,86 @@ public sealed class SessionDetailComponentTests : BunitContext
         public PollingRefreshReceipt RequestRefresh()
         {
             return new PollingRefreshReceipt(true, false, DateTimeOffset.UtcNow, ["poll", "reconcile"]);
+        }
+    }
+
+    private static FollowUpActionResolutionService CreateFollowUpActionResolutionService()
+    {
+        var workflowOptionsProvider = new StaticWorkflowOptionsProvider(
+            new WorkflowServiceOptions(
+                new WorkflowTrackerOptions(
+                    "github",
+                    "https://api.github.com",
+                    "token",
+                    null,
+                    "owner/repo",
+                    null,
+                    null,
+                    ["Todo"],
+                    ["Done"]),
+                new WorkflowPollingOptions(1_000),
+                new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                new WorkflowHookOptions(
+                    null,
+                    null,
+                    null,
+                    null,
+                    60_000),
+                new WorkflowAgentOptions(
+                    1,
+                    20,
+                    300_000,
+                    new Dictionary<string, int>(StringComparer.Ordinal),
+                    false,
+                    "exec:agent"),
+                new WorkflowCodexOptions(
+                    "codex app-server",
+                    null,
+                    null,
+                    null,
+                    3_600_000,
+                    5_000,
+                    300_000)));
+        var queue = new OrchestratorDispatchQueue(
+            workflowOptionsProvider,
+            new RetryDelayPlanner(() => 1d),
+            TimeProvider.System,
+            NullLogger<OrchestratorDispatchQueue>.Instance);
+
+        return new FollowUpActionResolutionService(
+            new FollowUpActionRegistry(TimeProvider.System),
+            queue,
+            new StubIssueTrackerClient(),
+            workflowOptionsProvider);
+    }
+
+    private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
+    {
+        public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class StubIssueTrackerClient : IIssueTrackerClient
+    {
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
         }
     }
 

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
@@ -8,7 +8,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using MudBlazor.Services;
 using Symphony.Abstractions.Orchestration;
+using Symphony.Abstractions.Trackers;
 using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Api;
@@ -16,6 +18,7 @@ using Symphony.Host.Components;
 using Symphony.Host.Configuration;
 using Symphony.Host.Dashboard;
 using Symphony.Host.Theming;
+using Symphony.Domain.Issues;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -183,6 +186,36 @@ public sealed class SessionDetailPageIntegrationTests
 
         Assert.Equal(HttpStatusCode.OK, pageResponse.StatusCode);
         Assert.Equal(HttpStatusCode.Accepted, apiResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_detail_page_renders_follow_up_action_panel_for_blocked_issue()
+    {
+        var store = new SessionActivityStore(NullLogger<SessionActivityStore>.Instance);
+        var startedAt = new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero);
+        store.RecordSessionStart("ABC-9", startedAt, "https://github.com/AGiorgetti/my-symphony/issues/ABC-9");
+        store.RecordActivity(
+            "ABC-9",
+            new SessionActivityEntry(
+                SessionActivityKind.AttentionRequired,
+                startedAt.AddMinutes(2),
+                "Follow-up action created",
+                "Need a human choice Action: Review the requested manual decision, then resolve the follow-up action to resume the run."));
+        using var app = await StartSessionDetailApplicationAsync(
+            store,
+            new StaticDashboardStateService(CreateSnapshot(activeSessions: [])),
+            CreateBlockedRuntimeService());
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/sessions/ABC-9");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("data-testid=\"session-detail-follow-up-action-panel\"", html, StringComparison.Ordinal);
+        Assert.Contains("Needs attention", html, StringComparison.Ordinal);
+        Assert.Contains("Need a human choice", html, StringComparison.Ordinal);
+        Assert.Contains("Review the requested manual decision, then resolve the follow-up action to resume the run.", html, StringComparison.Ordinal);
+        Assert.Contains("orch-999", html, StringComparison.Ordinal);
     }
 
     private static SessionActivityStore CreateStoreWithActiveSession()
@@ -356,41 +389,8 @@ public sealed class SessionDetailPageIntegrationTests
         builder.Services.AddScoped<IThemeService, ThemeService>();
         builder.Services.AddScoped<ThemeService>();
         builder.Services.AddSingleton<IWorkflowOptionsProvider>(
-            new StaticWorkflowOptionsProvider(
-                new WorkflowServiceOptions(
-                    new WorkflowTrackerOptions(
-                        "github",
-                        "https://api.github.com",
-                        "token",
-                        null,
-                        "owner/repo",
-                        null,
-                        null,
-                        ["Todo"],
-                        ["Done"]),
-                    new WorkflowPollingOptions(1_000),
-                    new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
-                    new WorkflowHookOptions(
-                        null,
-                        null,
-                        null,
-                        null,
-                        60_000),
-                    new WorkflowAgentOptions(
-                        1,
-                        20,
-                        300_000,
-                        new Dictionary<string, int>(StringComparer.Ordinal),
-                        false,
-                        "exec:agent"),
-                    new WorkflowCodexOptions(
-                        "codex app-server",
-                        null,
-                        null,
-                        null,
-                        3_600_000,
-                        5_000,
-                        300_000))));
+            CreateWorkflowOptionsProvider());
+        builder.Services.AddSingleton(CreateFollowUpActionResolutionService());
 
         var app = builder.Build();
         app.UseStaticFiles();
@@ -430,6 +430,52 @@ public sealed class SessionDetailPageIntegrationTests
                 RecentEvents: []));
     }
 
+    private static StaticRuntimeService CreateBlockedRuntimeService()
+    {
+        var blockedAt = new DateTimeOffset(2026, 3, 20, 9, 2, 0, TimeSpan.Zero);
+
+        return new StaticRuntimeService(
+            new OrchestratorIssueSnapshot(
+                "ABC-9",
+                "9",
+                "blocked_error",
+                RestartCount: 1,
+                CurrentRetryAttempt: 2,
+                Running: null,
+                Retry: null,
+                LastError: "Need a human choice",
+                RecentEvents: [],
+                OrchestratorSessionId: "orch-999",
+                Blocked: new BlockedDispatchSnapshot(
+                    "9",
+                    "ABC-9",
+                    "orch-999",
+                    2,
+                    blockedAt,
+                    BlockingReasonCode.ManualDecisionRequired,
+                    "Need a human choice",
+                    "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+                    "fai-9"),
+                FollowUpActions:
+                [
+                    new FollowUpActionSnapshot(
+                        "fai-9",
+                        "9",
+                        "ABC-9",
+                        "orch-999",
+                        blockedAt,
+                        BlockingReasonCode.ManualDecisionRequired,
+                        "Need a human choice",
+                        "Review the requested manual decision, then resolve the follow-up action to resume the run.",
+                        [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue after review.")],
+                        FollowUpActionStatus.Pending,
+                        ResolvedBy: null,
+                        ResolvedAt: null,
+                        SelectedOptionId: null,
+                        Notes: null)
+                ]));
+    }
+
     private sealed class StaticDashboardStateService(DashboardSnapshot snapshot) : IDashboardStateService
     {
         public Task<DashboardSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
@@ -438,11 +484,88 @@ public sealed class SessionDetailPageIntegrationTests
         }
     }
 
+    private static StaticWorkflowOptionsProvider CreateWorkflowOptionsProvider()
+    {
+        return new StaticWorkflowOptionsProvider(
+            new WorkflowServiceOptions(
+                new WorkflowTrackerOptions(
+                    "github",
+                    "https://api.github.com",
+                    "token",
+                    null,
+                    "owner/repo",
+                    null,
+                    null,
+                    ["Todo"],
+                    ["Done"]),
+                new WorkflowPollingOptions(1_000),
+                new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                new WorkflowHookOptions(
+                    null,
+                    null,
+                    null,
+                    null,
+                    60_000),
+                new WorkflowAgentOptions(
+                    1,
+                    20,
+                    300_000,
+                    new Dictionary<string, int>(StringComparer.Ordinal),
+                    false,
+                    "exec:agent"),
+                new WorkflowCodexOptions(
+                    "codex app-server",
+                    null,
+                    null,
+                    null,
+                    3_600_000,
+                    5_000,
+                    300_000)));
+    }
+
+    private static FollowUpActionResolutionService CreateFollowUpActionResolutionService()
+    {
+        var workflowOptionsProvider = CreateWorkflowOptionsProvider();
+        var queue = new OrchestratorDispatchQueue(
+            workflowOptionsProvider,
+            new RetryDelayPlanner(() => 1d),
+            TimeProvider.System,
+            NullLogger<OrchestratorDispatchQueue>.Instance);
+
+        return new FollowUpActionResolutionService(
+            new FollowUpActionRegistry(TimeProvider.System),
+            queue,
+            new StubIssueTrackerClient(),
+            workflowOptionsProvider);
+    }
+
     private sealed class StaticWorkflowOptionsProvider(WorkflowServiceOptions workflowOptions) : IWorkflowOptionsProvider
     {
         public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private sealed class StubIssueTrackerClient : IIssueTrackerClient
+    {
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
         }
     }
 

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyApiEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SymphonyApiEndpointRouteBuilderExtensionsTests.cs
@@ -6,11 +6,14 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Symphony.Abstractions.Orchestration;
+using Symphony.Abstractions.Trackers;
 using Symphony.Application.Configuration;
+using Symphony.Application.Orchestration;
 using Symphony.Application.Polling;
 using Symphony.Application.Runtime;
 using Symphony.Host.Api;
 using Symphony.Host.Health;
+using Symphony.Domain.Issues;
 
 namespace Symphony.Host.IntegrationTests;
 
@@ -94,6 +97,125 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
         var payload = await response.Content.ReadFromJsonAsync<ErrorEnvelopeDto>();
         Assert.NotNull(payload);
         Assert.Equal("issue_not_found", payload!.Error.Code);
+    }
+
+    [Fact]
+    public async Task State_endpoint_includes_blocked_counts_and_issue_summaries()
+    {
+        using var app = await StartApiApplicationAsync(
+            new StubRuntimeService
+            {
+                StateSnapshot = new OrchestratorStateSnapshot(
+                    new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                    Array.Empty<RunningIssueSnapshot>(),
+                    Array.Empty<Symphony.Abstractions.Orchestration.RetryDispatchSnapshot>(),
+                    new CodexTotalsSnapshot(0, 0, 0, 0d),
+                    RateLimits: null,
+                    Blocked:
+                    [
+                        new BlockedDispatchSnapshot(
+                            "1",
+                            "ABC-1",
+                            "orch-123",
+                            2,
+                            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                            BlockingReasonCode.InputRequired,
+                            "Need human input",
+                            "Provide the required input or choose an option, then resolve the follow-up action to resume the run.",
+                            "fai-1")
+                    ],
+                    FollowUpActions:
+                    [
+                        new FollowUpActionSnapshot(
+                            "fai-1",
+                            "1",
+                            "ABC-1",
+                            "orch-123",
+                            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                            BlockingReasonCode.InputRequired,
+                            "Need human input",
+                            "Provide the required input or choose an option, then resolve the follow-up action to resume the run.",
+                            [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue after review.")],
+                            FollowUpActionStatus.Pending,
+                            ResolvedBy: null,
+                            ResolvedAt: null,
+                            SelectedOptionId: null,
+                            Notes: null)
+                    ])
+            });
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/api/v1/state");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<StateResponseDto>();
+        Assert.NotNull(payload);
+        Assert.Equal(1, payload!.Counts.Blocked);
+        var blocked = Assert.Single(payload.Blocked);
+        Assert.Equal("ABC-1", blocked.IssueIdentifier);
+        Assert.Equal("orch-123", blocked.OrchestratorSessionId);
+        Assert.Equal("fai-1", blocked.FollowUpActionId);
+    }
+
+    [Fact]
+    public async Task Issue_endpoint_returns_blocked_issue_and_follow_up_actions()
+    {
+        using var app = await StartApiApplicationAsync(
+            new StubRuntimeService
+            {
+                IssueSnapshot = new OrchestratorIssueSnapshot(
+                    "ABC-1",
+                    "1",
+                    "blocked_error",
+                    RestartCount: 1,
+                    CurrentRetryAttempt: 2,
+                    Running: null,
+                    Retry: null,
+                    LastError: "Need human input",
+                    RecentEvents: [],
+                    OrchestratorSessionId: "orch-123",
+                    Blocked: new BlockedDispatchSnapshot(
+                        "1",
+                        "ABC-1",
+                        "orch-123",
+                        2,
+                        new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                        BlockingReasonCode.InputRequired,
+                        "Need human input",
+                        "Provide the required input or choose an option, then resolve the follow-up action to resume the run.",
+                        "fai-1"),
+                    FollowUpActions:
+                    [
+                        new FollowUpActionSnapshot(
+                            "fai-1",
+                            "1",
+                            "ABC-1",
+                            "orch-123",
+                            new DateTimeOffset(2026, 3, 16, 15, 0, 0, TimeSpan.Zero),
+                            BlockingReasonCode.InputRequired,
+                            "Need human input",
+                            "Provide the required input or choose an option, then resolve the follow-up action to resume the run.",
+                            [new FollowUpActionOptionSnapshot("resume", "Resume", "Continue after review.")],
+                            FollowUpActionStatus.Pending,
+                            ResolvedBy: null,
+                            ResolvedAt: null,
+                            SelectedOptionId: null,
+                            Notes: null)
+                    ])
+            });
+        var client = CreateHttpClient(app);
+
+        var response = await client.GetAsync("/api/v1/ABC-1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<IssueResponseDto>();
+        Assert.NotNull(payload);
+        Assert.Equal("orch-123", payload!.OrchestratorSessionId);
+        Assert.NotNull(payload.Blocked);
+        Assert.Equal("fai-1", payload.Blocked!.FollowUpActionId);
+        var action = Assert.Single(payload.FollowUpActions);
+        Assert.Equal("fai-1", action.FollowUpActionId);
+        Assert.Equal("Pending", action.Status);
     }
 
     [Fact]
@@ -208,44 +330,12 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
             workflowLoadStatusReader
             ?? new StaticWorkflowLoadStatusReader(
                 new WorkflowLoadStatusSnapshot("Starting", null, null, null, null, null, null)));
-        builder.Services.AddSingleton(timeProvider ?? TimeProvider.System);
+        var resolvedTimeProvider = timeProvider ?? TimeProvider.System;
+        var workflowOptionsProvider = CreateWorkflowOptionsProvider();
+        builder.Services.AddSingleton(resolvedTimeProvider);
         builder.Services.AddSingleton<ServiceHealthSnapshotProvider>();
-        builder.Services.AddSingleton<IWorkflowOptionsProvider>(
-            new StaticWorkflowOptionsProvider(
-                new WorkflowServiceOptions(
-                    new WorkflowTrackerOptions(
-                        "github",
-                        "https://api.github.com",
-                        "token",
-                        null,
-                        "owner/repo",
-                        null,
-                        null,
-                        ["Todo"],
-                        ["Done"]),
-                    new WorkflowPollingOptions(1_000),
-                    new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
-                    new WorkflowHookOptions(
-                        null,
-                        null,
-                        null,
-                        null,
-                        60_000),
-                    new WorkflowAgentOptions(
-                        1,
-                        20,
-                        300_000,
-                        new Dictionary<string, int>(StringComparer.Ordinal),
-                        false,
-                        "exec:agent"),
-                    new WorkflowCodexOptions(
-                        "codex app-server",
-                        null,
-                        null,
-                        null,
-                        3_600_000,
-                        5_000,
-                        300_000))));
+        builder.Services.AddSingleton<IWorkflowOptionsProvider>(workflowOptionsProvider);
+        builder.Services.AddSingleton(CreateFollowUpActionResolutionService(workflowOptionsProvider, resolvedTimeProvider));
 
         var app = builder.Build();
         app.MapSymphonyApi();
@@ -293,6 +383,84 @@ public sealed class SymphonyApiEndpointRouteBuilderExtensionsTests
         public Task<WorkflowServiceOptions> GetCurrentAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(workflowOptions);
+        }
+    }
+
+    private static StaticWorkflowOptionsProvider CreateWorkflowOptionsProvider()
+    {
+        return new StaticWorkflowOptionsProvider(
+            new WorkflowServiceOptions(
+                new WorkflowTrackerOptions(
+                    "github",
+                    "https://api.github.com",
+                    "token",
+                    null,
+                    "owner/repo",
+                    null,
+                    null,
+                    ["Todo"],
+                    ["Done"]),
+                new WorkflowPollingOptions(1_000),
+                new WorkflowWorkspaceOptions(Path.Combine(Path.GetTempPath(), "symphony-tests")),
+                new WorkflowHookOptions(
+                    null,
+                    null,
+                    null,
+                    null,
+                    60_000),
+                new WorkflowAgentOptions(
+                    1,
+                    20,
+                    300_000,
+                    new Dictionary<string, int>(StringComparer.Ordinal),
+                    false,
+                    "exec:agent"),
+                new WorkflowCodexOptions(
+                    "codex app-server",
+                    null,
+                    null,
+                    null,
+                    3_600_000,
+                    5_000,
+                    300_000)));
+    }
+
+    private static FollowUpActionResolutionService CreateFollowUpActionResolutionService(
+        IWorkflowOptionsProvider workflowOptionsProvider,
+        TimeProvider timeProvider)
+    {
+        var queue = new OrchestratorDispatchQueue(
+            workflowOptionsProvider,
+            new RetryDelayPlanner(() => 1d),
+            timeProvider,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<OrchestratorDispatchQueue>.Instance);
+
+        return new FollowUpActionResolutionService(
+            new FollowUpActionRegistry(timeProvider),
+            queue,
+            new StubIssueTrackerClient(),
+            workflowOptionsProvider);
+    }
+
+    private sealed class StubIssueTrackerClient : IIssueTrackerClient
+    {
+        public Task<IReadOnlyList<Issue>> FetchCandidateIssuesAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssuesByStatesAsync(
+            IReadOnlyCollection<string> stateNames,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
+        }
+
+        public Task<IReadOnlyList<Issue>> FetchIssueStatesByIdsAsync(
+            IReadOnlyCollection<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Issue>>(Array.Empty<Issue>());
         }
     }
 

--- a/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
+++ b/dotnet/tests/Symphony.Infrastructure.Tests/Codex/CodexAppServerClientTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Abstractions.Orchestration;
 using Symphony.Application.Configuration;
 using Symphony.Application.Orchestration;
 using Symphony.Domain.Issues;
@@ -119,7 +120,7 @@ public sealed class CodexAppServerClientTests
     }
 
     [Fact]
-    public async Task RunAsync_fails_when_codex_requests_user_input()
+    public async Task RunAsync_blocks_when_codex_requests_user_input()
     {
         var transcriptSink = new RecordingTranscriptSink();
         var sessionFactory = new TestCodexProcessSessionFactory(
@@ -154,10 +155,11 @@ public sealed class CodexAppServerClientTests
         var client = CreateClient(sessionFactory, transcriptSink);
         using var testContext = CreateContext();
 
-        var exception = await Assert.ThrowsAsync<CodexAgentException>(
+        var exception = await Assert.ThrowsAsync<IssueBlockingException>(
             () => client.RunAsync(testContext.Context, Path.GetTempPath(), "Prompt body", CreateCodexOptions()));
 
-        Assert.Equal("turn_input_required", exception.Code);
+        Assert.Equal(BlockingReasonCode.InputRequired, exception.ReasonCode);
+        Assert.Equal("Provide the required input or choose an option, then resolve the follow-up action to resume the run.", exception.RequiredUserAction);
         Assert.NotNull(sessionFactory.Session);
         Assert.True(sessionFactory.Session!.WasKilled);
     }
@@ -329,7 +331,7 @@ public sealed class CodexAppServerClientTests
     }
 
     [Fact]
-    public async Task RunAsync_fails_fast_when_non_approvable_mcp_elicitation_requests_user_input()
+    public async Task RunAsync_blocks_when_non_approvable_mcp_elicitation_requests_user_input()
     {
         var transcriptSink = new RecordingTranscriptSink();
         var sessionFactory = new TestCodexProcessSessionFactory(
@@ -384,10 +386,12 @@ public sealed class CodexAppServerClientTests
         var client = CreateClient(sessionFactory, transcriptSink);
         using var testContext = CreateContext();
 
-        var exception = await Assert.ThrowsAsync<CodexAgentException>(
+        var exception = await Assert.ThrowsAsync<IssueBlockingException>(
             () => client.RunAsync(testContext.Context, Path.GetTempPath(), "Prompt body", CreateCodexOptions()));
 
-        Assert.Equal("turn_input_required", exception.Code);
+        Assert.Equal(BlockingReasonCode.ManualDecisionRequired, exception.ReasonCode);
+        Assert.Equal("Need a human choice", exception.Message);
+        Assert.Equal("Review the requested manual decision, then resolve the follow-up action to resume the run.", exception.RequiredUserAction);
         Assert.NotNull(sessionFactory.Session);
         Assert.True(sessionFactory.Session!.WasKilled);
     }


### PR DESCRIPTION
#### Context

Issue #116 adds an explicit blocked-session path when unattended execution cannot auto-resolve a required approval, input request, or manual decision.

#### TL;DR

Add blocked-session and follow-up-action handling without regressing supported unattended auto-approval.

#### Summary

- add blocked-session and follow-up-action models in orchestration, runtime snapshots, and API responses
- keep existing unattended auto-approval paths and block only when a request cannot be auto-resolved
- surface blocked sessions in dashboard, session list, and session detail with explicit resolution support
- add targeted tests and docs for blocked visibility, resolution, and PR/API contracts

#### Alternatives

- keep unresolved blockers on the retry path, but that hides required operator intervention and causes noisy retries
- disable unattended auto-approval entirely, but this broadens behavior beyond issue #116 and regresses current flows

#### Test Plan

- [x] `dotnet test dotnet\Symphony.sln -c Release`
- [x] Targeted coverage for blocked runtime state, API serialization, host UI, and non-auto-approvable Codex requests

Co-authored-by: Codex <codex@openai.com>
