### PR TITLE
Redesign session detail timeline and sticky control deck

### DIFF
--- a/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
@@ -12,16 +12,6 @@
 @inject ISnackbar Snackbar
 
 <main class="page-shell page-stack">
-    <div data-testid="session-detail-breadcrumb">
-        <nav class="page-breadcrumb">
-            <a href="@DashboardPageDataService.BuildLink("/", _mode)" class="page-breadcrumb__link">Home</a>
-            <span>/</span>
-            <a href="@DashboardPageDataService.BuildLink("/sessions", _mode)" class="page-breadcrumb__link">Sessions</a>
-            <span>/</span>
-            <span class="page-breadcrumb__current">@_requestedIdentifier</span>
-        </nav>
-    </div>
-
     @if (_isLoading)
     {
         <MudPaper Class="@ShellCardClass" Outlined="true" Elevation="0" data-testid="session-detail-skeleton">

--- a/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
+++ b/dotnet/src/Symphony.Host/Components/Pages/SessionDetailPage.razor
@@ -47,30 +47,24 @@
             </MudAlert>
         }
 
-        <SessionHeaderCard Session="_header" />
-        <MudButton Variant="Variant.Outlined"
-                   Href="@DashboardPageDataService.BuildExportSessionLink(_requestedIdentifier)"
-                   Class="detail-header__link"
-                   data-testid="session-detail-export-link">
-            Export JSON
-        </MudButton>
-
-        @if (_blockedIssue is not null && _pendingFollowUpAction is not null)
-        {
-            <SessionFollowUpActionPanel BlockedIssue="_blockedIssue"
-                                       PendingAction="_pendingFollowUpAction"
-                                       IsResolving="_isResolvingFollowUpAction"
-                                       ResolveRequested="ResolveFollowUpActionAsync" />
-        }
-
         <div class="session-detail-flow">
-            <div class="session-detail-metadata-row" data-testid="session-detail-metadata-panel">
-                <SessionMetadataPanel Metadata="_metadata" />
-            </div>
             <div data-testid="session-detail-activity-panel">
-                <SessionActivityTimeline Timeline="_timeline"
+                <SessionActivityTimeline Header="_header"
+                                         Metadata="_metadata"
+                                         Timeline="_timeline"
+                                         ExportHref="@DashboardPageDataService.BuildExportSessionLink(_requestedIdentifier)"
                                          DebugModeEnabled="@DashboardUiOptions.Value.DebugMode"
-                                         TrackAgentMessageDeltas="@DashboardUiOptions.Value.TrackAgentMessageDeltas" />
+                                         TrackAgentMessageDeltas="@DashboardUiOptions.Value.TrackAgentMessageDeltas">
+                    <StickyDeckFooter>
+                        @if (_blockedIssue is not null && _pendingFollowUpAction is not null)
+                        {
+                            <SessionFollowUpActionPanel BlockedIssue="_blockedIssue"
+                                                       PendingAction="_pendingFollowUpAction"
+                                                       IsResolving="_isResolvingFollowUpAction"
+                                                       ResolveRequested="ResolveFollowUpActionAsync" />
+                        }
+                    </StickyDeckFooter>
+                </SessionActivityTimeline>
             </div>
         </div>
     }

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
@@ -1,49 +1,213 @@
-<div class="@GetTimelineShellClasses()" data-testid="session-detail-timeline">
-    @if (DebugModeEnabled)
-    {
-        <aside class="timeline-filter-panel" data-testid="session-detail-method-filter">
-            <p class="section-kicker">Filter</p>
-            <h3 class="timeline-filter-panel__title">Message methods</h3>
-            <p class="timeline-filter-panel__copy">
-                Toggle individual debug transcript methods without hiding lifecycle or outcome events.
-            </p>
+@using MudBlazor
 
-            @if (AvailableMethodFilters.Count == 0)
-            {
-                <div class="timeline-filter-panel__empty">
-                    <p class="empty-state__title">No method-tagged debug events yet</p>
-                    <p class="empty-state__copy">
-                        Start an agent run to populate method filters from the live transcript.
-                    </p>
-                </div>
-            }
-            else
-            {
-                <div class="timeline-filter-list" role="group" aria-label="Debug transcript method filters">
-                    @foreach (var filter in AvailableMethodFilters)
+<div class="session-detail-surface" data-testid="session-detail-timeline">
+    <div class="session-detail-topdeck" data-testid="session-detail-topdeck">
+        <MudPaper Class="@TopDeckCardClass" Outlined="true" Elevation="0" data-testid="session-detail-header">
+            <details class="session-topdeck-section" open data-testid="session-detail-summary-section">
+                <summary class="session-topdeck-section__summary" data-testid="session-detail-summary-summary">
+                    <div class="session-topdeck-section__heading">
+                        <p class="section-kicker">Session</p>
+                        <h2 class="session-topdeck-section__title">@HeaderModel.Identifier</h2>
+                    </div>
+                    <div class="session-topdeck-strip">
+                        <StatusPill Text="@HeaderModel.StatusText" Color="@(HeaderModel.Status is null ? HeaderModel.StatusColor : Color.Primary)" />
+                        <span class="session-topdeck-chip">@HeaderModel.StartedAt.ToUniversalTime():HH:mm:ss UTC</span>
+                        <span class="session-topdeck-chip">@SessionDetailDisplay.GetAttemptLabel(MetadataModel.Attempt, MetadataModel.IsAttemptKnown)</span>
+                        <span class="session-topdeck-chip">@FormatInt(MetadataModel.TurnCount) turns</span>
+                    </div>
+                </summary>
+                <div class="session-topdeck-section__body">
+                    <div class="detail-metrics-grid detail-metrics-grid--metadata">
+                        <div class="detail-metric-card" data-testid="session-detail-header-started">
+                            <p class="detail-metric-label">Started</p>
+                            <p class="detail-metric-value">@SessionDetailDisplay.FormatTimestamp(HeaderModel.StartedAt)</p>
+                        </div>
+                        <div class="detail-metric-card" data-testid="session-detail-header-ended">
+                            <p class="detail-metric-label">Ended</p>
+                            <p class="detail-metric-value">@(HeaderModel.EndedAt is null ? "Still running" : SessionDetailDisplay.FormatTimestamp(HeaderModel.EndedAt.Value))</p>
+                        </div>
+                    </div>
+                    @if (HeaderModel.IsActive)
                     {
-                        <label class="timeline-filter-option">
-                            <input type="checkbox"
-                                   class="timeline-filter-option__checkbox"
-                                   checked="@filter.IsEnabled"
-                                   data-testid="@($"session-detail-method-filter-{filter.Slug}")"
-                                   @onchange="@((ChangeEventArgs args) => SetMethodVisibility(filter.Method, IsChecked(args.Value)))" />
-                            <span class="timeline-filter-option__content">
-                                <span class="timeline-filter-option__label">@filter.Method</span>
-                                <span class="timeline-filter-option__count">@filter.Count</span>
-                            </span>
-                        </label>
+                        <div class="detail-active-indicator" data-testid="session-header-active-indicator">
+                            <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Info" />
+                            <span>Session is active</span>
+                        </div>
+                    }
+                    <div class="session-topdeck-actions">
+                        @if (!string.IsNullOrWhiteSpace(HeaderModel.IssueUrl))
+                        {
+                            <MudButton Variant="Variant.Outlined"
+                                       Href="@HeaderModel.IssueUrl"
+                                       Class="detail-header__link"
+                                       data-testid="session-header-tracker-link">
+                                Open tracker issue
+                            </MudButton>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(ExportHref))
+                        {
+                            <MudButton Variant="Variant.Outlined"
+                                       Href="@ExportHref"
+                                       Class="detail-header__link"
+                                       data-testid="session-detail-export-link">
+                                Export JSON
+                            </MudButton>
+                        }
+                    </div>
+                </div>
+            </details>
+
+            <div data-testid="session-detail-metadata-panel">
+            <details class="session-topdeck-section" open data-testid="session-detail-metadata-section">
+                <summary class="session-topdeck-section__summary" data-testid="session-detail-metadata-summary">
+                    <div class="session-topdeck-section__heading">
+                        <p class="section-kicker">Details</p>
+                        <h2 class="session-topdeck-section__title">Session metadata</h2>
+                    </div>
+                    <div class="session-topdeck-strip">
+                        <span class="session-topdeck-chip" data-testid="session-detail-metadata-input-tokens">Rep In @FormatLong(GetReportedInputTokens())</span>
+                        <span class="session-topdeck-chip" data-testid="session-detail-metadata-cached-input-strip-tokens">Cached @FormatLong(GetReportedCachedInputTokens())</span>
+                        <span class="session-topdeck-chip" data-testid="session-detail-metadata-output-tokens">Rep Out @FormatLong(GetReportedOutputTokens())</span>
+                        <span class="session-topdeck-chip" data-testid="session-detail-metadata-reasoning-strip-tokens">Reason @FormatLong(GetReportedReasoningTokens())</span>
+                        <span class="session-topdeck-chip" data-testid="session-detail-metadata-total-tokens">Rep Total @FormatLong(GetReportedTotalTokens())</span>
+                    </div>
+                </summary>
+                <div class="session-topdeck-section__body" data-testid="session-detail-metadata">
+                    @if (!string.IsNullOrWhiteSpace(MetadataModel.AvailabilityMessage))
+                    {
+                        <div class="detail-note">
+                            @MetadataModel.AvailabilityMessage
+                        </div>
+                    }
+
+                    <div class="detail-metrics-grid detail-metrics-grid--metadata">
+                        <div class="detail-metric-card" data-testid="session-detail-metadata-session-id">
+                            <p class="detail-metric-label">Session ID</p>
+                            <p class="detail-metric-value detail-metric-value--break">@FormatText(MetadataModel.SessionId)</p>
+                        </div>
+                        <div class="detail-metric-card" data-testid="session-detail-metadata-orchestrator-session-id">
+                            <p class="detail-metric-label">Orchestrator Session ID</p>
+                            <p class="detail-metric-value detail-metric-value--break">@FormatText(MetadataModel.OrchestratorSessionId)</p>
+                        </div>
+                        @if (MetadataModel.TokenUsage is not null)
+                        {
+                            <div class="detail-metric-card" data-testid="session-detail-metadata-reported-input-tokens">
+                                <p class="detail-metric-label">Reported Input Tokens</p>
+                                <p class="detail-metric-value">@FormatLong(MetadataModel.TokenUsage.ReportedInputTokens)</p>
+                            </div>
+                            <div class="detail-metric-card" data-testid="session-detail-metadata-reported-output-tokens">
+                                <p class="detail-metric-label">Reported Output Tokens</p>
+                                <p class="detail-metric-value">@FormatLong(MetadataModel.TokenUsage.ReportedOutputTokens)</p>
+                            </div>
+                            <div class="detail-metric-card" data-testid="session-detail-metadata-cached-input-tokens">
+                                <p class="detail-metric-label">Cached Input Tokens</p>
+                                <p class="detail-metric-value">@FormatLong(MetadataModel.TokenUsage.ReportedCachedInputTokens)</p>
+                            </div>
+                            <div class="detail-metric-card" data-testid="session-detail-metadata-reasoning-tokens">
+                                <p class="detail-metric-label">Reasoning Tokens</p>
+                                <p class="detail-metric-value">@FormatLong(MetadataModel.TokenUsage.ReportedReasoningTokens)</p>
+                            </div>
+                            <div class="detail-metric-card" data-testid="session-detail-metadata-reported-total-tokens">
+                                <p class="detail-metric-label">Reported Total Tokens</p>
+                                <p class="detail-metric-value">@FormatLong(MetadataModel.TokenUsage.ReportedTotalTokens)</p>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </details>
+            </div>
+
+            <details class="session-topdeck-section" open data-testid="session-detail-filters-section">
+                <summary class="session-topdeck-section__summary" data-testid="session-detail-filters-summary">
+                    <div class="session-topdeck-section__heading">
+                        <p class="section-kicker">Filter</p>
+                        <h2 class="session-topdeck-section__title">Timeline filters</h2>
+                    </div>
+                    <div class="session-topdeck-strip">
+                        <span class="session-topdeck-chip">@EnabledKindCount/@KindFilters.Count kinds</span>
+                        <span class="session-topdeck-chip">@EnabledMethodCount/@MethodFilters.Count methods</span>
+                        <span class="session-topdeck-chip">Empty agent msgs @(HideEmptyAgentMessages ? "hidden" : "shown")</span>
+                    </div>
+                </summary>
+                <div class="session-topdeck-section__body" data-testid="session-detail-filter-panel">
+                    <div class="session-topdeck-actions">
+                        <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="SelectAllFilters" data-testid="session-detail-filter-select-all">
+                            Select all
+                        </MudButton>
+                        <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="ClearAllFilters" data-testid="session-detail-filter-clear-all">
+                            Clear all
+                        </MudButton>
+                    </div>
+
+                    <label class="timeline-filter-option timeline-filter-option--compact">
+                        <input type="checkbox"
+                               class="timeline-filter-option__checkbox"
+                               checked="@HideEmptyAgentMessages"
+                               data-testid="session-detail-hide-empty-agent-messages"
+                               @onchange="@((ChangeEventArgs args) => HideEmptyAgentMessages = IsChecked(args.Value))" />
+                        <span class="timeline-filter-option__content">
+                            <span class="timeline-filter-option__label">Hide empty agent messages</span>
+                        </span>
+                    </label>
+
+                    <div class="timeline-filter-group">
+                        <p class="detail-metric-label">Event kinds</p>
+                        <div class="timeline-filter-grid">
+                            @foreach (var filter in KindFilters)
+                            {
+                                <label class="timeline-filter-option timeline-filter-option--compact">
+                                    <input type="checkbox"
+                                           class="timeline-filter-option__checkbox"
+                                           checked="@filter.IsEnabled"
+                                           data-testid="@($"session-detail-kind-filter-{GetKindSlug(filter.Kind)}")"
+                                           @onchange="@((ChangeEventArgs args) => SetKindVisibility(filter.Kind, IsChecked(args.Value)))" />
+                                    <span class="timeline-filter-option__content">
+                                        <span class="timeline-filter-option__label">@filter.Label</span>
+                                        <span class="timeline-filter-option__count">@filter.Count</span>
+                                    </span>
+                                </label>
+                            }
+                        </div>
+                    </div>
+
+                    @if (DebugModeEnabled && MethodFilters.Count > 0)
+                    {
+                        <div class="timeline-filter-group" data-testid="session-detail-method-filter">
+                            <p class="detail-metric-label">Message methods</p>
+                            <div class="timeline-filter-grid">
+                                @foreach (var filter in MethodFilters)
+                                {
+                                    <label class="timeline-filter-option timeline-filter-option--compact">
+                                        <input type="checkbox"
+                                               class="timeline-filter-option__checkbox"
+                                               checked="@filter.IsEnabled"
+                                               data-testid="@($"session-detail-method-filter-{filter.Slug}")"
+                                               @onchange="@((ChangeEventArgs args) => SetMethodVisibility(filter.Method, IsChecked(args.Value)))" />
+                                        <span class="timeline-filter-option__content">
+                                            <span class="timeline-filter-option__label">@filter.Method</span>
+                                            <span class="timeline-filter-option__count">@filter.Count</span>
+                                        </span>
+                                    </label>
+                                }
+                            </div>
+                            @if (!TrackAgentMessageDeltas)
+                            {
+                                <p class="timeline-filter-panel__note">
+                                    Delta transcript capture is disabled, so <code>item/agentMessage/delta</code> may be absent from this list.
+                                </p>
+                            }
+                        </div>
                     }
                 </div>
-            }
+            </details>
+        </MudPaper>
+    </div>
 
-            @if (!TrackAgentMessageDeltas)
-            {
-                <p class="timeline-filter-panel__note">
-                    Delta transcript capture is disabled, so <code>item/agentMessage/delta</code> may be absent from this list.
-                </p>
-            }
-        </aside>
+    @if (StickyDeckFooter is not null)
+    {
+        <div class="session-detail-deck-footer">
+            @StickyDeckFooter
+        </div>
     }
 
     <MudPaper Class="@TimelineCardClass" Outlined="true" Elevation="0">
@@ -51,7 +215,7 @@
             <p class="section-kicker">Timeline</p>
             <h2 class="section-title section-title--panel">Session activity</h2>
             <p class="section-copy">
-                Lifecycle milestones, agent messages, warnings, outcomes, and debug transcript events in chronological order.
+                Compact, filterable session history with full details available on demand.
             </p>
         </div>
 
@@ -86,129 +250,35 @@
         {
             <div class="empty-state">
                 <p class="empty-state__title">@GetEmptyStateTitle()</p>
-                <p class="empty-state__copy">
-                    @GetEmptyStateCopy()
-                </p>
+                <p class="empty-state__copy">@GetEmptyStateCopy()</p>
             </div>
         }
         else
         {
-            <ol class="timeline-list">
+            <ol class="timeline-list timeline-list--compact">
                 @foreach (var entry in VisibleEntries)
                 {
                     <li class="timeline-item">
                         <span class="@GetTimelineDotClasses(entry)"></span>
-                        <div class="@GetEntryContainerClasses(entry)" data-testid="session-detail-timeline-entry">
-                            <div class="timeline-entry__head">
-                                <div class="timeline-entry__meta">
-                                    <StatusPill Text="@entry.KindLabel" Color="@entry.KindBadgeColor" />
-                                    @if (entry.HasTokenUsage)
-                                    {
-                                        <div data-testid="session-detail-timeline-entry-token-indicator">
-                                            <StatusPill Text="@($"Tokens: {entry.TokenSourceLabel}")" Color="Color.Info" />
-                                        </div>
-                                    }
-                                    @if (entry.Facts.Count > 0)
-                                    {
-                                        <div class="fact-list">
-                                            @foreach (var fact in entry.Facts)
-                                            {
-                                                <span class="fact-pill">
-                                                    <span class="fact-pill__label">@fact.Label:</span>
-                                                    <span>@fact.Value</span>
-                                                </span>
-                                            }
-                                        </div>
-                                    }
+                        @if (ShouldRenderExpandableDetail(entry))
+                        {
+                            <details class="@GetEntryContainerClasses(entry)" data-testid="session-detail-timeline-detail">
+                                <summary class="timeline-entry__row" title="@GetDetailToggleLabel(entry)">
+                                    @RenderCompactRow(entry)
+                                </summary>
+                                <div class="timeline-entry__body" data-testid="session-detail-timeline-entry">
+                                    @RenderExpandedBody(entry)
                                 </div>
-
-                                <div class="timeline-entry__time">
-                                    @entry.TimestampLabel
+                            </details>
+                        }
+                        else
+                        {
+                            <div class="@GetEntryContainerClasses(entry)" data-testid="session-detail-timeline-entry">
+                                <div class="timeline-entry__row">
+                                    @RenderCompactRow(entry)
                                 </div>
                             </div>
-
-                            <div class="timeline-entry__body">
-                                <h3 class="timeline-entry__title">@entry.Title</h3>
-
-                                @if (!string.IsNullOrWhiteSpace(entry.Summary))
-                                {
-                                    <p class="timeline-entry__summary">
-                                        @entry.Summary
-                                    </p>
-                                }
-
-                                @if (!string.IsNullOrWhiteSpace(entry.Detail))
-                                {
-                                    @if (ShouldRenderExpandableDetail(entry))
-                                    {
-                                        <details class="@GetDetailClasses(entry)"
-                                                 data-testid="session-detail-timeline-detail">
-                                            <summary class="timeline-entry__toggle">
-                                                @GetDetailToggleLabel(entry)
-                                            </summary>
-
-                                            @if (ShouldRenderDebugMetadata(entry))
-                                            {
-                                                <div class="timeline-entry__detail-body">
-                                                    <p class="detail-metric-label">Debug metadata</p>
-                                                    <div class="fact-list">
-                                                        <span class="fact-pill">
-                                                            <span class="fact-pill__label">Source:</span>
-                                                            <span>@entry.KindLabel</span>
-                                                        </span>
-                                                        <span class="fact-pill">
-                                                            <span class="fact-pill__label">Timestamp:</span>
-                                                            <span>@entry.TimestampLabel</span>
-                                                        </span>
-                                                        <span class="fact-pill">
-                                                            <span class="fact-pill__label">Event:</span>
-                                                            <span>@entry.Title</span>
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            }
-
-                                            @if (entry.IsStructuredDetail)
-                                            {
-                                                @if (entry.Facts.Count > 0)
-                                                {
-                                                    <div class="timeline-entry__detail-body">
-                                                        <p class="detail-metric-label">Highlights</p>
-                                                        <div class="fact-list">
-                                                            @foreach (var fact in entry.Facts)
-                                                            {
-                                                                <span class="fact-pill">
-                                                                    <span class="fact-pill__label">@fact.Label:</span>
-                                                                    <span>@fact.Value</span>
-                                                                </span>
-                                                            }
-                                                        </div>
-                                                    </div>
-                                                }
-
-                                                <p class="detail-metric-label">@(ShouldRenderDebugMetadata(entry) ? "Raw payload" : "Detail")</p>
-                                                <pre class="timeline-pre">@entry.Detail</pre>
-                                            }
-                                            else
-                                            {
-                                                <p class="detail-metric-label">@(ShouldRenderDebugMetadata(entry) ? "Debug detail" : "Detail")</p>
-                                                <p class="timeline-text">@entry.Detail</p>
-                                            }
-                                        </details>
-                                    }
-                                    else if (ShouldRenderInlineDetail(entry))
-                                    {
-                                        <p class="timeline-text">@entry.Detail</p>
-                                    }
-                                    else
-                                    {
-                                        <p class="timeline-entry__summary timeline-entry__summary--muted">
-                                            Enable dashboard debug mode to inspect the raw agent payload for this event.
-                                        </p>
-                                    }
-                                }
-                            </div>
-                        </div>
+                        }
                     </li>
                 }
             </ol>
@@ -217,7 +287,10 @@
 </div>
 
 @code {
+    private const string TopDeckCardClass = "page-card page-card--tight session-topdeck-card";
     private const string TimelineCardClass = "page-card page-card--tight";
+    private readonly Dictionary<SessionActivityKind, bool> _kindVisibility = Enum.GetValues<SessionActivityKind>()
+        .ToDictionary(kind => kind, _ => true);
     private readonly Dictionary<string, bool> _methodVisibility = new(StringComparer.OrdinalIgnoreCase);
 
     [Parameter]
@@ -225,15 +298,89 @@
     public required SessionActivityTimelineModel Timeline { get; set; }
 
     [Parameter]
+    public SessionHeaderDisplayModel? Header { get; set; }
+
+    [Parameter]
+    public SessionMetadataPanelModel? Metadata { get; set; }
+
+    [Parameter]
+    public string? ExportHref { get; set; }
+
+    [Parameter]
     public bool DebugModeEnabled { get; set; }
 
     [Parameter]
     public bool TrackAgentMessageDeltas { get; set; }
 
+    [Parameter]
+    public RenderFragment? StickyDeckFooter { get; set; }
+
+    private bool HideEmptyAgentMessages { get; set; } = true;
+
+    private SessionHeaderDisplayModel HeaderModel =>
+        Header ?? new SessionHeaderDisplayModel(
+            "Session",
+            IssueUrl: null,
+            IsActive: false,
+            StatusText: "Unavailable",
+            Status: null,
+            StatusColor: Color.Default,
+            StartedAt: DateTimeOffset.UnixEpoch,
+            EndedAt: null);
+
+    private SessionMetadataPanelModel MetadataModel =>
+        Metadata ?? new SessionMetadataPanelModel(
+            InputTokens: null,
+            OutputTokens: null,
+            TotalTokens: null,
+            TurnCount: null,
+            SessionId: null,
+            OrchestratorSessionId: null,
+            Attempt: null,
+            IsAttemptKnown: false,
+            AvailabilityMessage: null,
+            TokenUsage: null);
+
     protected override void OnParametersSet()
     {
+        SyncKindVisibility();
         SyncMethodVisibility();
     }
+
+    private IReadOnlyList<SessionActivityTimelineEntryModel> VisibleEntries =>
+        Timeline.Entries.Where(entry => !ShouldHideEntry(entry)).ToArray();
+
+    private IReadOnlyList<KindFilterOption> KindFilters =>
+        Enum.GetValues<SessionActivityKind>()
+            .Select(
+                kind => new KindFilterOption(
+                    kind,
+                    SessionDetailDisplay.GetKindLabel(kind),
+                    Timeline.Entries.Count(entry => entry.Kind == kind),
+                    _kindVisibility.TryGetValue(kind, out var isEnabled) && isEnabled))
+            .ToArray();
+
+    private IReadOnlyList<MessageMethodFilterOption> MethodFilters => GetAvailableMethodFilters();
+
+    private int EnabledKindCount => KindFilters.Count(filter => filter.IsEnabled);
+
+    private int EnabledMethodCount => MethodFilters.Count(filter => filter.IsEnabled);
+
+    private static string FormatLong(long? value) => value?.ToString("N0") ?? "Unavailable";
+
+    private static string FormatInt(int? value) => value?.ToString() ?? "Unavailable";
+
+    private static string FormatText(string? value) => string.IsNullOrWhiteSpace(value) ? "Unavailable" : value;
+
+    private long? GetReportedInputTokens() => MetadataModel.TokenUsage?.ReportedInputTokens ?? MetadataModel.InputTokens;
+
+    private long? GetReportedCachedInputTokens() => MetadataModel.TokenUsage?.ReportedCachedInputTokens;
+
+    private long? GetReportedOutputTokens() => MetadataModel.TokenUsage?.ReportedOutputTokens ?? MetadataModel.OutputTokens;
+
+    private long? GetReportedReasoningTokens() => MetadataModel.TokenUsage?.ReportedReasoningTokens;
+
+    private long? GetReportedTotalTokens() => MetadataModel.TokenUsage?.ReportedTotalTokens ?? MetadataModel.TotalTokens;
 
     private static string GetEntryContainerClasses(SessionActivityTimelineEntryModel entry)
     {
@@ -263,13 +410,28 @@
         };
     }
 
-    private IReadOnlyList<SessionActivityTimelineEntryModel> VisibleEntries =>
-        DebugModeEnabled
-            ? Timeline.Entries.Where(entry => !ShouldHideEntry(entry)).ToArray()
-            : Timeline.Entries.Where(entry => !IsDebugOnlyEntry(entry)).ToArray();
+    private bool ShouldHideEntry(SessionActivityTimelineEntryModel entry)
+    {
+        if (!DebugModeEnabled && IsDebugOnlyEntry(entry))
+        {
+            return true;
+        }
 
-    private IReadOnlyList<MessageMethodFilterOption> AvailableMethodFilters =>
-        GetAvailableMethodFilters();
+        if (_kindVisibility.TryGetValue(entry.Kind, out var kindEnabled) && !kindEnabled)
+        {
+            return true;
+        }
+
+        if (HideEmptyAgentMessages && entry.IsEmptyAgentMessage)
+        {
+            return true;
+        }
+
+        var methodTag = GetEntryMethodTag(entry);
+        return !string.IsNullOrWhiteSpace(methodTag)
+            && _methodVisibility.TryGetValue(methodTag, out var isEnabled)
+            && !isEnabled;
+    }
 
     private bool ShouldRenderExpandableDetail(SessionActivityTimelineEntryModel entry)
     {
@@ -307,13 +469,6 @@
             && (entry.Kind == SessionActivityKind.AgentMessage || entry.Kind == SessionActivityKind.DebugMessage);
     }
 
-    private string GetDetailClasses(SessionActivityTimelineEntryModel entry)
-    {
-        return ShouldRenderDebugMetadata(entry)
-            ? "timeline-entry__detail timeline-entry__detail--debug"
-            : "timeline-entry__detail";
-    }
-
     private string? GetDetailToggleLabel(SessionActivityTimelineEntryModel entry)
     {
         if (!ShouldRenderDebugMetadata(entry))
@@ -331,72 +486,34 @@
         return entry.Kind == SessionActivityKind.DebugMessage;
     }
 
-    private bool ShouldHideEntry(SessionActivityTimelineEntryModel entry)
-    {
-        return TryGetMethod(entry, out var method)
-            && _methodVisibility.TryGetValue(method, out var isEnabled)
-            && !isEnabled;
-    }
-
-    private static bool TryGetMethod(SessionActivityTimelineEntryModel entry, out string method)
-    {
-        method = string.Empty;
-
-        if (entry.Kind != SessionActivityKind.DebugMessage)
-        {
-            return false;
-        }
-
-        var fact = entry.Facts.FirstOrDefault(candidate => string.Equals(candidate.Label, "Method", StringComparison.Ordinal));
-        if (fact is null || string.IsNullOrWhiteSpace(fact.Value))
-        {
-            return false;
-        }
-
-        method = fact.Value.Trim();
-        return true;
-    }
-
     private IReadOnlyList<MessageMethodFilterOption> GetAvailableMethodFilters()
     {
-        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        var displayNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var orderedMethods = new List<string>();
-
-        foreach (var entry in Timeline.Entries)
-        {
-            if (!TryGetMethod(entry, out var method))
-            {
-                continue;
-            }
-
-            if (!counts.TryAdd(method, 1))
-            {
-                counts[method]++;
-                continue;
-            }
-
-            orderedMethods.Add(method);
-            displayNames[method] = method;
-        }
-
-        return orderedMethods
+        return Timeline.Entries
+            .Select(entry => GetEntryMethodTag(entry))
+            .OfType<string>()
+            .GroupBy(method => method, StringComparer.OrdinalIgnoreCase)
             .Select(
-                method => new MessageMethodFilterOption(
-                    displayNames[method],
-                    GetMethodSlug(method),
-                    counts[method],
-                    _methodVisibility.TryGetValue(method, out var isEnabled) ? isEnabled : true))
+                group => new MessageMethodFilterOption(
+                    group.Key,
+                    GetMethodSlug(group.Key),
+                    group.Count(),
+                    _methodVisibility.TryGetValue(group.Key, out var isEnabled) ? isEnabled : true))
+            .OrderBy(option => option.Method, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private void SyncKindVisibility()
+    {
+        foreach (var kind in Enum.GetValues<SessionActivityKind>())
+        {
+            _kindVisibility.TryAdd(kind, true);
+        }
     }
 
     private void SyncMethodVisibility()
     {
         var availableMethods = Timeline.Entries
-            .Select(
-                entry => TryGetMethod(entry, out var method)
-                    ? method
-                    : null)
+            .Select(entry => GetEntryMethodTag(entry))
             .OfType<string>()
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -418,6 +535,37 @@
         _methodVisibility[method] = isEnabled;
     }
 
+    private void SetKindVisibility(SessionActivityKind kind, bool isEnabled)
+    {
+        _kindVisibility[kind] = isEnabled;
+    }
+
+    private void SelectAllFilters()
+    {
+        foreach (var kind in Enum.GetValues<SessionActivityKind>())
+        {
+            _kindVisibility[kind] = true;
+        }
+
+        foreach (var method in _methodVisibility.Keys.ToArray())
+        {
+            _methodVisibility[method] = true;
+        }
+    }
+
+    private void ClearAllFilters()
+    {
+        foreach (var kind in Enum.GetValues<SessionActivityKind>())
+        {
+            _kindVisibility[kind] = false;
+        }
+
+        foreach (var method in _methodVisibility.Keys.ToArray())
+        {
+            _methodVisibility[method] = false;
+        }
+    }
+
     private static bool IsChecked(object? value)
     {
         return value switch
@@ -428,25 +576,25 @@
         };
     }
 
-    private string GetTimelineShellClasses()
-    {
-        return DebugModeEnabled
-            ? "session-detail-timeline-shell session-detail-timeline-shell--with-filters"
-            : "session-detail-timeline-shell";
-    }
-
     private string GetEmptyStateTitle()
     {
-        return DebugModeEnabled && AvailableMethodFilters.Count > 0
+        return HasActiveFilters()
             ? "No session activity matches the active filters"
             : "No session activity recorded";
     }
 
     private string GetEmptyStateCopy()
     {
-        return DebugModeEnabled && AvailableMethodFilters.Count > 0
-            ? "Adjust the method filter checkboxes to bring hidden transcript events back into view."
+        return HasActiveFilters()
+            ? "Adjust the sticky filter deck to bring hidden session events back into view."
             : "The session exists, but no visible timeline entries are available yet.";
+    }
+
+    private bool HasActiveFilters()
+    {
+        return EnabledKindCount != KindFilters.Count
+            || EnabledMethodCount != MethodFilters.Count
+            || HideEmptyAgentMessages;
     }
 
     private static string GetMethodSlug(string method)
@@ -471,9 +619,113 @@
         return builder.ToString().Trim('-');
     }
 
+    private static string GetKindSlug(SessionActivityKind kind)
+    {
+        return kind.ToString().Replace('_', '-').ToLowerInvariant();
+    }
+
+    private static string? GetEntryMethodTag(SessionActivityTimelineEntryModel entry)
+    {
+        return !string.IsNullOrWhiteSpace(entry.MethodTag)
+            ? entry.MethodTag
+            : entry.Facts.FirstOrDefault(fact => string.Equals(fact.Label, "Method", StringComparison.Ordinal))?.Value;
+    }
+
+    private RenderFragment RenderCompactRow(SessionActivityTimelineEntryModel entry) => @<div class="timeline-entry__row-content">
+        <div class="timeline-entry__row-start">
+            <StatusPill Text="@entry.KindLabel" Color="@entry.KindBadgeColor" />
+            <span class="timeline-entry__row-title">@entry.Title</span>
+            <span class="timeline-entry__row-time">@entry.CompactTimestampLabel</span>
+            @if (!string.IsNullOrWhiteSpace(GetEntryMethodTag(entry)))
+            {
+                <span class="timeline-entry__inline-pill">@GetEntryMethodTag(entry)</span>
+            }
+            @if (entry.HasTokenUsage)
+            {
+                <span data-testid="session-detail-timeline-entry-token-indicator" class="timeline-entry__inline-pill timeline-entry__inline-pill--token">
+                    Tokens: @entry.TokenSourceLabel
+                </span>
+            }
+        </div>
+        @if (!string.IsNullOrWhiteSpace(entry.CompactPreview))
+        {
+            <span class="timeline-entry__row-preview">@entry.CompactPreview</span>
+        }
+    </div>;
+
+    private RenderFragment RenderExpandedBody(SessionActivityTimelineEntryModel entry) => @<div>
+        @if (!string.IsNullOrWhiteSpace(entry.Summary))
+        {
+            <p class="timeline-entry__summary">@entry.Summary</p>
+        }
+
+        @if (ShouldRenderDebugMetadata(entry))
+        {
+            <div class="timeline-entry__detail-body">
+                <p class="detail-metric-label">Debug metadata</p>
+                <div class="fact-list">
+                    <span class="fact-pill">
+                        <span class="fact-pill__label">Source:</span>
+                        <span>@entry.KindLabel</span>
+                    </span>
+                    <span class="fact-pill">
+                        <span class="fact-pill__label">Timestamp:</span>
+                        <span>@entry.TimestampLabel</span>
+                    </span>
+                    <span class="fact-pill">
+                        <span class="fact-pill__label">Event:</span>
+                        <span>@entry.Title</span>
+                    </span>
+                </div>
+            </div>
+        }
+
+        @if (entry.Facts.Count > 0)
+        {
+            <div class="timeline-entry__detail-body">
+                <p class="detail-metric-label">Highlights</p>
+                <div class="fact-list">
+                    @foreach (var fact in entry.Facts)
+                    {
+                        <span class="fact-pill">
+                            <span class="fact-pill__label">@fact.Label:</span>
+                            <span>@fact.Value</span>
+                        </span>
+                    }
+                </div>
+            </div>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(entry.Detail))
+        {
+            @if (entry.IsStructuredDetail)
+            {
+                <p class="detail-metric-label">Raw payload</p>
+                <pre class="timeline-pre">@entry.Detail</pre>
+            }
+            else if (ShouldRenderInlineDetail(entry))
+            {
+                <p class="detail-metric-label">Detail</p>
+                <p class="timeline-text">@entry.Detail</p>
+            }
+            else
+            {
+                <p class="timeline-entry__summary timeline-entry__summary--muted">
+                    Enable dashboard debug mode to inspect the raw agent payload for this event.
+                </p>
+            }
+        }
+    </div>;
+
     private sealed record MessageMethodFilterOption(
         string Method,
         string Slug,
+        int Count,
+        bool IsEnabled);
+
+    private sealed record KindFilterOption(
+        SessionActivityKind Kind,
+        string Label,
         int Count,
         bool IsEnabled);
 }

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
@@ -15,6 +15,11 @@
                         <span class="session-topdeck-chip">@SessionDetailDisplay.GetAttemptLabel(MetadataModel.Attempt, MetadataModel.IsAttemptKnown)</span>
                         <span class="session-topdeck-chip">@FormatInt(MetadataModel.TurnCount) turns</span>
                     </div>
+                    <span class="session-topdeck-toggle" data-testid="session-detail-summary-toggle" aria-hidden="true">
+                        <span class="session-topdeck-toggle__text session-topdeck-toggle__text--collapsed">Expand</span>
+                        <span class="session-topdeck-toggle__text session-topdeck-toggle__text--expanded">Collapse</span>
+                        <span class="session-topdeck-toggle__chevron"></span>
+                    </span>
                 </summary>
                 <div class="session-topdeck-section__body">
                     <div class="detail-metrics-grid detail-metrics-grid--metadata">
@@ -58,7 +63,7 @@
             </details>
 
             <div data-testid="session-detail-metadata-panel">
-            <details class="session-topdeck-section" open data-testid="session-detail-metadata-section">
+            <details class="session-topdeck-section" data-testid="session-detail-metadata-section">
                 <summary class="session-topdeck-section__summary" data-testid="session-detail-metadata-summary">
                     <div class="session-topdeck-section__heading">
                         <p class="section-kicker">Details</p>
@@ -71,6 +76,11 @@
                         <span class="session-topdeck-chip" data-testid="session-detail-metadata-reasoning-strip-tokens">Reason @FormatLong(GetReportedReasoningTokens())</span>
                         <span class="session-topdeck-chip" data-testid="session-detail-metadata-total-tokens">Rep Total @FormatLong(GetReportedTotalTokens())</span>
                     </div>
+                    <span class="session-topdeck-toggle" data-testid="session-detail-metadata-toggle" aria-hidden="true">
+                        <span class="session-topdeck-toggle__text session-topdeck-toggle__text--collapsed">Expand</span>
+                        <span class="session-topdeck-toggle__text session-topdeck-toggle__text--expanded">Collapse</span>
+                        <span class="session-topdeck-toggle__chevron"></span>
+                    </span>
                 </summary>
                 <div class="session-topdeck-section__body" data-testid="session-detail-metadata">
                     @if (!string.IsNullOrWhiteSpace(MetadataModel.AvailabilityMessage))
@@ -117,7 +127,7 @@
             </details>
             </div>
 
-            <details class="session-topdeck-section" open data-testid="session-detail-filters-section">
+            <details class="session-topdeck-section" data-testid="session-detail-filters-section">
                 <summary class="session-topdeck-section__summary" data-testid="session-detail-filters-summary">
                     <div class="session-topdeck-section__heading">
                         <p class="section-kicker">Filter</p>
@@ -128,6 +138,11 @@
                         <span class="session-topdeck-chip">@EnabledMethodCount/@MethodFilters.Count methods</span>
                         <span class="session-topdeck-chip">Empty agent msgs @(HideEmptyAgentMessages ? "hidden" : "shown")</span>
                     </div>
+                    <span class="session-topdeck-toggle" data-testid="session-detail-filters-toggle" aria-hidden="true">
+                        <span class="session-topdeck-toggle__text session-topdeck-toggle__text--collapsed">Expand</span>
+                        <span class="session-topdeck-toggle__text session-topdeck-toggle__text--expanded">Collapse</span>
+                        <span class="session-topdeck-toggle__chevron"></span>
+                    </span>
                 </summary>
                 <div class="session-topdeck-section__body" data-testid="session-detail-filter-panel">
                     <div class="session-topdeck-actions">

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
@@ -3,7 +3,7 @@
 <div class="session-detail-surface" data-testid="session-detail-timeline">
     <div class="session-detail-topdeck" data-testid="session-detail-topdeck">
         <MudPaper Class="@TopDeckCardClass" Outlined="true" Elevation="0" data-testid="session-detail-header">
-            <details class="session-topdeck-section" open data-testid="session-detail-summary-section">
+            <details class="session-topdeck-section" data-testid="session-detail-summary-section">
                 <summary class="session-topdeck-section__summary" data-testid="session-detail-summary-summary">
                     <div class="session-topdeck-section__heading">
                         <p class="section-kicker">Session</p>

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimeline.razor
@@ -278,8 +278,8 @@
                         @if (ShouldRenderExpandableDetail(entry))
                         {
                             <details class="@GetEntryContainerClasses(entry)" data-testid="session-detail-timeline-detail">
-                                <summary class="timeline-entry__row" title="@GetDetailToggleLabel(entry)">
-                                    @RenderCompactRow(entry)
+                                <summary class="timeline-entry__row">
+                                    @RenderCompactRow(entry, isExpandable: true)
                                 </summary>
                                 <div class="timeline-entry__body" data-testid="session-detail-timeline-entry">
                                     @RenderExpandedBody(entry)
@@ -290,7 +290,7 @@
                         {
                             <div class="@GetEntryContainerClasses(entry)" data-testid="session-detail-timeline-entry">
                                 <div class="timeline-entry__row">
-                                    @RenderCompactRow(entry)
+                                    @RenderCompactRow(entry, isExpandable: false)
                                 </div>
                             </div>
                         }
@@ -484,18 +484,6 @@
             && (entry.Kind == SessionActivityKind.AgentMessage || entry.Kind == SessionActivityKind.DebugMessage);
     }
 
-    private string? GetDetailToggleLabel(SessionActivityTimelineEntryModel entry)
-    {
-        if (!ShouldRenderDebugMetadata(entry))
-        {
-            return entry.DetailToggleLabel;
-        }
-
-        return entry.IsStructuredDetail
-            ? "View raw payload and debug metadata"
-            : "View full debug detail";
-    }
-
     private static bool IsDebugOnlyEntry(SessionActivityTimelineEntryModel entry)
     {
         return entry.Kind == SessionActivityKind.DebugMessage;
@@ -646,7 +634,7 @@
             : entry.Facts.FirstOrDefault(fact => string.Equals(fact.Label, "Method", StringComparison.Ordinal))?.Value;
     }
 
-    private RenderFragment RenderCompactRow(SessionActivityTimelineEntryModel entry) => @<div class="timeline-entry__row-content">
+    private RenderFragment RenderCompactRow(SessionActivityTimelineEntryModel entry, bool isExpandable) => @<div class="timeline-entry__row-content">
         <div class="timeline-entry__row-start">
             <StatusPill Text="@entry.KindLabel" Color="@entry.KindBadgeColor" />
             <span class="timeline-entry__row-title">@entry.Title</span>
@@ -665,6 +653,14 @@
         @if (!string.IsNullOrWhiteSpace(entry.CompactPreview))
         {
             <span class="timeline-entry__row-preview">@entry.CompactPreview</span>
+        }
+        @if (isExpandable)
+        {
+            <span class="timeline-entry__toggle-affordance" data-testid="session-detail-timeline-entry-toggle" aria-hidden="true">
+                <span class="timeline-entry__toggle-text timeline-entry__toggle-text--collapsed">Expand</span>
+                <span class="timeline-entry__toggle-text timeline-entry__toggle-text--expanded">Collapse</span>
+                <span class="timeline-entry__toggle-chevron"></span>
+            </span>
         }
     </div>;
 

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineEntryModel.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionActivityTimelineEntryModel.cs
@@ -18,8 +18,12 @@ public sealed record SessionActivityTimelineEntryModel(
     bool HasExpandableDetail,
     bool IsStructuredDetail,
     Color Color,
+    bool IsEmptyAgentMessage = false,
     bool HasTokenUsage = false,
-    string? TokenSourceLabel = null);
+    string? TokenSourceLabel = null,
+    string CompactTimestampLabel = "",
+    string? CompactPreview = null,
+    string? MethodTag = null);
 
 public sealed record SessionActivityFactModel(
     string Label,

--- a/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
+++ b/dotnet/src/Symphony.Host/Components/SessionDetail/SessionDetailDisplay.cs
@@ -14,6 +14,11 @@ internal static class SessionDetailDisplay
         return timestamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
     }
 
+    internal static string FormatCompactTimestamp(DateTimeOffset timestamp)
+    {
+        return timestamp.ToUniversalTime().ToString("HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+    }
+
     internal static Color GetFallbackStatusColor(string statusText, bool isActive)
     {
         if (isActive)
@@ -119,6 +124,12 @@ internal static class SessionDetailDisplay
         var displayTitle = HumanizeTitle(entry.Title);
         var hasVisibleTokenUsage = HasVisibleEntryTokenUsage(entry.TokenUsage);
         var facts = MergeFacts(detailPresentation.Facts, entry.TokenUsage);
+        var methodTag = TryGetMethodTag(facts);
+        var compactPreview = BuildCompactPreview(detailPresentation.Summary, detailPresentation.DetailPreview, entry.Detail);
+        var isEmptyAgentMessage = entry.Kind == SessionActivityKind.AgentMessage
+            && string.IsNullOrWhiteSpace(compactPreview)
+            && string.IsNullOrWhiteSpace(detailPresentation.Detail)
+            && facts.Count == 0;
 
         return new SessionActivityTimelineEntryModel(
             entry.Kind,
@@ -135,8 +146,12 @@ internal static class SessionDetailDisplay
             detailPresentation.HasExpandableDetail,
             detailPresentation.IsStructuredDetail,
             GetTimelineColor(entry),
+            isEmptyAgentMessage,
             hasVisibleTokenUsage,
-            GetTokenSourceLabel(entry.TokenUsage));
+            GetTokenSourceLabel(entry.TokenUsage),
+            FormatCompactTimestamp(entry.Timestamp),
+            compactPreview,
+            methodTag);
     }
 
     internal static int? TryParseTurnCount(string? sessionId)
@@ -196,6 +211,27 @@ internal static class SessionDetailDisplay
         }
 
         return string.Join(' ', parts);
+    }
+
+    private static string? TryGetMethodTag(IReadOnlyList<SessionActivityFactModel> facts)
+    {
+        return facts.FirstOrDefault(candidate => string.Equals(candidate.Label, "Method", StringComparison.Ordinal))?.Value;
+    }
+
+    private static string? BuildCompactPreview(string? summary, string? detailPreview, string? rawDetail)
+    {
+        var candidate = !string.IsNullOrWhiteSpace(summary)
+            ? summary
+            : !string.IsNullOrWhiteSpace(detailPreview)
+                ? detailPreview
+                : NormalizeDetail(rawDetail);
+
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return null;
+        }
+
+        return TruncateText(FirstMeaningfulLine(candidate), 84);
     }
 
     private static ActivityDetailPresentation BuildDetailPresentation(string? detail)

--- a/dotnet/src/Symphony.Host/wwwroot/app.css
+++ b/dotnet/src/Symphony.Host/wwwroot/app.css
@@ -1157,6 +1157,7 @@ code {
 
 .timeline-entry__row-content {
     justify-content: space-between;
+    gap: 0.75rem;
 }
 
 .timeline-entry__row-start {
@@ -1204,6 +1205,40 @@ code {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.timeline-entry__toggle-affordance {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--color-on-surface-secondary);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.timeline-entry__toggle-text--expanded,
+.timeline-entry details[open] .timeline-entry__toggle-text--collapsed {
+    display: none;
+}
+
+.timeline-entry details[open] .timeline-entry__toggle-text--expanded {
+    display: inline;
+}
+
+.timeline-entry__toggle-chevron {
+    width: 0.68rem;
+    height: 0.68rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg) translateY(-0.08rem);
+    transition: transform 0.18s ease;
+}
+
+.timeline-entry details[open] .timeline-entry__toggle-chevron {
+    transform: rotate(-135deg) translateY(-0.02rem);
 }
 
 .timeline-entry__body {

--- a/dotnet/src/Symphony.Host/wwwroot/app.css
+++ b/dotnet/src/Symphony.Host/wwwroot/app.css
@@ -791,22 +791,24 @@ code {
     gap: 1rem;
 }
 
-.session-detail-metadata-row {
+.session-detail-topdeck {
     position: sticky;
     top: 5.75rem;
     z-index: 15;
 }
 
-.session-metadata-panel {
+.session-topdeck-card {
     padding: 1rem 1.25rem;
     backdrop-filter: blur(20px);
 }
 
-.session-metadata-panel__details[open] .session-metadata-panel__summary {
-    padding-bottom: 0.85rem;
+.session-topdeck-section + .session-topdeck-section {
+    border-top: 1px solid color-mix(in oklab, var(--shell-border) 82%, transparent);
+    margin-top: 0.85rem;
+    padding-top: 0.85rem;
 }
 
-.session-metadata-panel__summary {
+.session-topdeck-section__summary {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
@@ -816,22 +818,22 @@ code {
     list-style: none;
 }
 
-.session-metadata-panel__summary::-webkit-details-marker {
+.session-topdeck-section__summary::-webkit-details-marker {
     display: none;
 }
 
-.session-metadata-panel__heading {
+.session-topdeck-section__heading {
     min-width: 0;
 }
 
-.session-metadata-panel__title {
+.session-topdeck-section__title {
     margin: 0.35rem 0 0;
     color: var(--color-on-surface-primary);
     font-size: 1rem;
     font-weight: 700;
 }
 
-.session-metadata-strip {
+.session-topdeck-strip {
     display: flex;
     flex: 1 1 32rem;
     flex-wrap: wrap;
@@ -839,7 +841,7 @@ code {
     justify-content: flex-end;
 }
 
-.session-metadata-chip {
+.session-topdeck-chip {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
@@ -850,26 +852,23 @@ code {
     min-width: fit-content;
 }
 
-.session-metadata-chip__label {
-    color: var(--color-primary-DEFAULT);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-}
-
-.session-metadata-chip__value {
-    color: var(--color-on-surface-primary);
-    font-size: 0.86rem;
-    font-weight: 700;
-}
-
-.session-metadata-panel__body {
+.session-topdeck-section__body {
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
-    border-top: 1px solid color-mix(in oklab, var(--shell-border) 82%, transparent);
     padding-top: 0.9rem;
+}
+
+.session-topdeck-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.session-detail-deck-footer {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .detail-header__link.mud-button-root {
@@ -938,32 +937,12 @@ code {
     line-height: 1.7;
 }
 
-.session-detail-timeline-shell {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1rem;
-    min-width: 0;
-}
-
-.timeline-filter-panel {
+.session-detail-surface {
     display: flex;
     flex-direction: column;
-    gap: 0.9rem;
-    border: 1px solid color-mix(in oklab, var(--shell-info) 28%, transparent);
-    border-radius: var(--shell-radius-lg);
-    background: color-mix(in oklab, var(--shell-info) 8%, var(--color-surface-base));
-    padding: 1rem;
-    min-width: 0;
+    gap: 1rem;
 }
 
-.timeline-filter-panel__title {
-    margin: 0;
-    color: var(--color-on-surface-primary);
-    font-size: 1.02rem;
-    font-weight: 700;
-}
-
-.timeline-filter-panel__copy,
 .timeline-filter-panel__note {
     margin: 0;
     color: var(--color-on-surface-secondary);
@@ -971,16 +950,15 @@ code {
     line-height: 1.65;
 }
 
-.timeline-filter-panel__empty {
-    border: 1px dashed color-mix(in oklab, var(--shell-border) 86%, transparent);
-    border-radius: 1rem;
-    background: color-mix(in oklab, var(--color-surface-base) 74%, transparent);
-    padding: 1rem;
-}
-
-.timeline-filter-list {
+.timeline-filter-group {
     display: flex;
     flex-direction: column;
+    gap: 0.65rem;
+}
+
+.timeline-filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
     gap: 0.65rem;
 }
 
@@ -993,6 +971,10 @@ code {
     background: color-mix(in oklab, var(--color-surface-base) 70%, transparent);
     padding: 0.75rem 0.85rem;
     cursor: pointer;
+}
+
+.timeline-filter-option--compact {
+    padding: 0.55rem 0.7rem;
 }
 
 .timeline-filter-option__checkbox {
@@ -1079,14 +1061,23 @@ code {
     background: #94a3b8;
 }
 
+.timeline-list--compact {
+    padding-left: 1.2rem;
+}
+
+.timeline-item + .timeline-item {
+    margin-top: 0.7rem;
+}
+
+.timeline-dot {
+    top: 0.95rem;
+}
+
 .timeline-entry {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
     border: 1px solid var(--shell-border);
     border-radius: var(--shell-radius-lg);
     background: color-mix(in oklab, var(--color-surface-base) 62%, transparent);
-    padding: 1.1rem 1.2rem;
+    padding: 0.85rem 1rem;
 }
 
 .timeline-entry--default {
@@ -1113,32 +1104,79 @@ code {
     background: color-mix(in oklab, var(--shell-success) 6%, var(--color-surface-base));
 }
 
-.timeline-entry__meta {
+.timeline-entry__row {
+    cursor: pointer;
+    list-style: none;
+}
+
+.timeline-entry__row::-webkit-details-marker {
+    display: none;
+}
+
+.timeline-entry__row-content,
+.timeline-entry__row-start {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 0.5rem;
 }
 
-.timeline-entry__time {
+.timeline-entry__row-content {
+    justify-content: space-between;
+}
+
+.timeline-entry__row-start {
+    min-width: 0;
+    flex: 1 1 24rem;
+}
+
+.timeline-entry__row-title {
+    color: var(--color-on-surface-primary);
+    font-size: 0.95rem;
+    font-weight: 700;
+}
+
+.timeline-entry__row-time {
     color: var(--color-on-surface-secondary);
-    font-size: 0.72rem;
+    font-size: 0.74rem;
     font-weight: 700;
     letter-spacing: 0.16em;
     text-transform: uppercase;
+}
+
+.timeline-entry__inline-pill {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid color-mix(in oklab, var(--shell-border) 80%, transparent);
+    border-radius: 999px;
+    padding: 0.25rem 0.55rem;
+    color: var(--color-on-surface-secondary);
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+.timeline-entry__inline-pill--token {
+    border-color: color-mix(in oklab, var(--shell-info) 40%, transparent);
+    color: var(--color-on-surface-primary);
+}
+
+.timeline-entry__row-preview {
+    min-width: 0;
+    flex: 1 1 18rem;
+    color: var(--color-on-surface-secondary);
+    font-size: 0.88rem;
+    font-weight: 600;
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .timeline-entry__body {
     display: flex;
     flex-direction: column;
     gap: 0.55rem;
-}
-
-.timeline-entry__title {
-    margin: 0;
-    color: var(--color-on-surface-primary);
-    font-size: 1.08rem;
-    font-weight: 700;
+    margin-top: 0.8rem;
 }
 
 .timeline-entry__summary {

--- a/dotnet/src/Symphony.Host/wwwroot/app.css
+++ b/dotnet/src/Symphony.Host/wwwroot/app.css
@@ -822,6 +822,40 @@ code {
     display: none;
 }
 
+.session-topdeck-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--color-on-surface-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.session-topdeck-toggle__text--expanded,
+.session-topdeck-section[open] .session-topdeck-toggle__text--collapsed {
+    display: none;
+}
+
+.session-topdeck-section[open] .session-topdeck-toggle__text--expanded {
+    display: inline;
+}
+
+.session-topdeck-toggle__chevron {
+    width: 0.7rem;
+    height: 0.7rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg) translateY(-0.08rem);
+    transition: transform 0.18s ease;
+}
+
+.session-topdeck-section[open] .session-topdeck-toggle__chevron {
+    transform: rotate(-135deg) translateY(-0.02rem);
+}
+
 .session-topdeck-section__heading {
     min-width: 0;
 }

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -165,6 +165,9 @@ public sealed class SessionDetailComponentTests : BunitContext
         Assert.Contains("Received turn/completed", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Received item/agentMessage/delta", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-topdeck\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-summary-toggle\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-metadata-toggle\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-filters-toggle\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Debug metadata", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Raw payload", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Prompt body", cut.Markup, StringComparison.Ordinal);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -168,6 +168,7 @@ public sealed class SessionDetailComponentTests : BunitContext
         Assert.Contains("data-testid=\"session-detail-summary-toggle\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-metadata-toggle\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-filters-toggle\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-timeline-entry-toggle\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Debug metadata", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Raw payload", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Prompt body", cut.Markup, StringComparison.Ordinal);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailComponentTests.cs
@@ -164,7 +164,7 @@ public sealed class SessionDetailComponentTests : BunitContext
         Assert.Contains("Sent turn/start", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Received turn/completed", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Received item/agentMessage/delta", cut.Markup, StringComparison.Ordinal);
-        Assert.Contains("View raw payload and debug metadata", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-topdeck\"", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Debug metadata", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Raw payload", cut.Markup, StringComparison.Ordinal);
         Assert.Contains("Prompt body", cut.Markup, StringComparison.Ordinal);
@@ -418,7 +418,8 @@ public sealed class SessionDetailComponentTests : BunitContext
             Assert.Contains("Deployment target requires a manual approval step.", cut.Markup, StringComparison.Ordinal);
         });
 
-        await cut.InvokeAsync(() => cut.Find("button").Click());
+        var resolveButton = cut.FindAll("button").Single(button => button.TextContent.Contains("Resolve and resume", StringComparison.Ordinal));
+        await cut.InvokeAsync(() => resolveButton.Click());
 
         cut.WaitForAssertion(() =>
         {

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
@@ -26,7 +26,7 @@ namespace Symphony.Host.IntegrationTests;
 public sealed class SessionDetailPageIntegrationTests
 {
     [Fact]
-    public async Task Session_detail_page_renders_breadcrumb_activity_and_compact_metadata()
+    public async Task Session_detail_page_hides_breadcrumb_and_starts_summary_collapsed()
     {
         var store = CreateStoreWithActiveSession();
         using var app = await StartSessionDetailApplicationAsync(
@@ -39,9 +39,10 @@ public sealed class SessionDetailPageIntegrationTests
         var html = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("data-testid=\"session-detail-breadcrumb\"", html, StringComparison.Ordinal);
-        Assert.Contains("href=\"/sessions\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-testid=\"session-detail-breadcrumb\"", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-header\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-summary-section\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-testid=\"session-detail-summary-section\" open", html, StringComparison.Ordinal);
         Assert.Contains("Open tracker issue", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-export-link\"", html, StringComparison.Ordinal);
         Assert.Contains("href=\"/api/v1/export/sessions/ABC-1\"", html, StringComparison.Ordinal);
@@ -226,8 +227,7 @@ public sealed class SessionDetailPageIntegrationTests
         Assert.Contains("item/agentMessage/delta", html, StringComparison.Ordinal);
         Assert.Contains("Trace sample 36", html, StringComparison.Ordinal);
         Assert.Contains("Sent turn/start", html, StringComparison.Ordinal);
-        Assert.Contains("href=\"/?mode=fake\"", html, StringComparison.Ordinal);
-        Assert.Contains("href=\"/sessions?mode=fake\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-testid=\"session-detail-breadcrumb\"", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
@@ -42,7 +42,14 @@ public sealed class SessionDetailPageIntegrationTests
         Assert.DoesNotContain("data-testid=\"session-detail-breadcrumb\"", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-header\"", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-summary-section\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-metadata-section\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-filters-section\"", html, StringComparison.Ordinal);
         Assert.DoesNotContain("data-testid=\"session-detail-summary-section\" open", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-testid=\"session-detail-metadata-section\" open", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-testid=\"session-detail-filters-section\" open", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-summary-toggle\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-metadata-toggle\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-filters-toggle\"", html, StringComparison.Ordinal);
         Assert.Contains("Open tracker issue", html, StringComparison.Ordinal);
         Assert.Contains("data-testid=\"session-detail-export-link\"", html, StringComparison.Ordinal);
         Assert.Contains("href=\"/api/v1/export/sessions/ABC-1\"", html, StringComparison.Ordinal);

--- a/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
+++ b/dotnet/tests/Symphony.Host.IntegrationTests/SessionDetailPageIntegrationTests.cs
@@ -166,7 +166,8 @@ public sealed class SessionDetailPageIntegrationTests
         Assert.Contains("Sent turn/start", html, StringComparison.Ordinal);
         Assert.Contains("Received turn/completed", html, StringComparison.Ordinal);
         Assert.Contains("Received item/agentMessage/delta", html, StringComparison.Ordinal);
-        Assert.Contains("View raw payload and debug metadata", html, StringComparison.Ordinal);
+        Assert.Contains("data-testid=\"session-detail-timeline-entry-toggle\"", html, StringComparison.Ordinal);
+        Assert.Contains("Expand", html, StringComparison.Ordinal);
         Assert.Contains("Debug metadata", html, StringComparison.Ordinal);
         Assert.Contains("Raw payload", html, StringComparison.Ordinal);
         Assert.Contains("Prompt body", html, StringComparison.Ordinal);


### PR DESCRIPTION
#### Context

Issue #148 redesigns the session detail page so long session histories are easier to scan and control during active debugging.

#### TL;DR

Redesign session detail with a sticky control deck, compact timeline rows, and real working filters.

#### Summary

- Replace the old split header, metadata, and side filter layout with a unified sticky top deck
- Make timeline rows compact and one-line-first with expandable detail only when needed
- Apply working kind and method filters plus hide-empty-agent-message behavior across the visible timeline
- Follow up by removing the breadcrumb and default-collapsing all sticky sections with explicit toggles
- Reuse the same explicit expand/collapse affordance on expandable timeline rows

#### Alternatives

- Keep the original header, metadata, and left rail and only tighten spacing, but that would not fix the layout and filtering problems
- Use a two-column inspector layout, but that was a larger interaction change and less suitable for mobile than the approved sticky-deck design

#### Test Plan

- [x] `dotnet format --verify-no-changes && dotnet build -c Release && dotnet test -c Release`
- [x] `dotnet test .\dotnet\tests\Symphony.Host.IntegrationTests\Symphony.Host.IntegrationTests.csproj -c Release --filter "FullyQualifiedName~SessionDetailPageIntegrationTests|FullyQualifiedName~SessionDetailComponentTests"`

Co-authored-by: Codex <codex@openai.com>
